### PR TITLE
adds focus styles to n-myft-ui__button

### DIFF
--- a/myft-common/main.scss
+++ b/myft-common/main.scss
@@ -32,6 +32,12 @@
 
 	.n-myft-ui__button {
 		@include oButtons();
+
+		&:focus {
+			outline: 3px solid getColor('teal-1');
+			outline-offset: 3px;
+		}
+
 	}
 
 	.n-myft-ui__button--inverse {


### PR DESCRIPTION
Adds focus state outline to `n-myft-ui__buttons`s

![buttons-before2](https://cloud.githubusercontent.com/assets/17549437/25669587/e0682ff2-3021-11e7-9ba2-9aa111813ac5.gif)

![buttons-after](https://cloud.githubusercontent.com/assets/17549437/25669416/5c7c989a-3021-11e7-8847-f6d5a4144c15.gif)
