### PR TITLE
Refactor ui a bit

### DIFF
--- a/myft/ui/index.js
+++ b/myft/ui/index.js
@@ -17,33 +17,10 @@ let flags;
 let results = {};
 let initialised;
 
-const types = {
-	saved: 'content',
-	followed: 'concept',
-	preferred: 'preference',
-	contained: 'content'
-};
-
-const actors = {
-	saved: 'user',
-	followed: 'user',
-	preferred: 'user',
-	contained: 'list'
-};
-
-const uiSelectors = {
-	saved: '[data-myft-ui="saved"]',
-	followed: '[data-myft-ui="follow"]',
-	preferred: '[data-myft-ui="prefer"]',
-	contained: '[data-myft-ui="contained"]'
-};
-
-const idProperties = {
-	saved: 'data-content-id',
-	followed: 'data-concept-id',
-	preferred: 'data-preference-name',
-	contained: 'data-content-id'
-};
+const actorsMap = require('./relationship-maps/actors');
+const uiSelectorsMap = require('./relationship-maps/ui-selectors');
+const idPropertiesMap = require('./relationship-maps/id-properties');
+const typesMap = require('./relationship-maps/types');
 
 const nNotificationMsgs = {
 	followAnon: `Please <a href="${subscribeUrl}" data-trackable="Subscribe">subscribe</a> or <a href="${signInLink}" data-trackable="Sign In">sign in</a> to add this topic to myFT.`,
@@ -51,7 +28,7 @@ const nNotificationMsgs = {
 	opted: 'You‘ve opted into our new site. You can return to FT.com at any time.'
 };
 
-function myFtFeatureFromEvent (ev) {
+function getRelationshipFromEvent (ev) {
 	return ev.type.replace('myft.', '').split('.')[1];
 }
 
@@ -64,23 +41,22 @@ function getUuid (item) {
 	return item.UUID || item.uuid;
 }
 
-function toggleButton (buttonEl, state) {
-	const isPressed = buttonEl.getAttribute('aria-pressed') === 'true';
+function toggleButton (buttonEl, pressed) {
+	const alreadyPressed = buttonEl.getAttribute('aria-pressed') === 'true';
 
-	if (state !== isPressed) {
+	if (pressed !== alreadyPressed) {
 		nextButtons.toggleState(buttonEl);
 	}
 	buttonEl.removeAttribute('disabled');
 }
 
-
-function updateUiForFeature (opts) {
-	if (!uiSelectors[opts.myftFeature]) {
+function updateUiForRelationship (opts) {
+	if (!uiSelectorsMap.get(opts.relationship)) {
 		return;
 	}
 
-	const featureForms = $$(uiSelectors[opts.myftFeature], opts.context);
-	const idProperty = idProperties[opts.myftFeature];
+	const featureForms = $$(uiSelectorsMap.get(opts.relationship), opts.context);
+	const idProperty = idPropertiesMap.get(opts.relationship);
 	const uuids = opts.subjects.map(getUuid);
 
 	// if there are multiple buttons, use the button with the same value as the rel property
@@ -107,7 +83,7 @@ function updateUiForFeature (opts) {
 			});
 
 			// add a BEM modifier for on/off-only styling of the form (e.g. show RSS link if RSS pref is on)
-			form.classList.toggle(`myft-ui--${opts.myftFeature}-on`, !!opts.state);
+			form.classList.toggle(`myft-ui--${opts.relationship}-on`, !!opts.state);
 		}
 	});
 }
@@ -142,7 +118,7 @@ function setUpSaveToExistingListListeners (overlay, contentId) {
 		saveToExistingListButton.addEventListener('click', ev => {
 			ev.preventDefault();
 
-			if(!listSelect.value) {
+			if (!listSelect.value) {
 				const nameFormGroup = overlay.content.querySelector('.js-uuid-group');
 				nameFormGroup.className += ' o-forms--error n-myft-ui__error--no-name';
 				return;
@@ -167,7 +143,7 @@ function setUpNewListListeners (overlay, contentId) {
 	createListButton.addEventListener('click', ev => {
 		ev.preventDefault();
 
-		if(!nameInput.value) {
+		if (!nameInput.value) {
 			const nameFormGroup = overlay.content.querySelector('.js-name-group');
 			nameFormGroup.className += ' o-forms--error n-myft-ui__error--no-name';
 			return;
@@ -180,7 +156,7 @@ function setUpNewListListeners (overlay, contentId) {
 
 		myftClient.add('user', null, 'created', 'list', uuid(), createListData)
 			.then(detail => {
-				if(contentId) {
+				if (contentId) {
 					return myftClient.add('list', detail.subject, 'contained', 'content', contentId);
 				} else {
 					return detail;
@@ -188,7 +164,7 @@ function setUpNewListListeners (overlay, contentId) {
 
 			})
 			.then(detail => {
-				if(contentId){
+				if (contentId) {
 					updateAfterIO('contained', detail);
 				}
 				overlay.close();
@@ -238,20 +214,20 @@ function getMessage (relationship, detail, href) {
 
 	const messages = {
 		followed:
-			`<a href="/myft" class="myft-ui__logo" data-trackable="myft-logo"><abbr title="myFT" class="myft-ui__icon"></abbr></a>
+		`<a href="/myft" class="myft-ui__logo" data-trackable="myft-logo"><abbr title="myFT" class="myft-ui__icon"></abbr></a>
 			${detail.results ? 'You are following' : 'You unfollowed'} <b>${detail.data.name}</b>.
 			<a href="${href}" data-trackable="alerts">Manage topics</a>`,
 		saved:
-			`<a href="/myft" class="myft-ui__logo" data-trackable="myft-logo"><abbr title="myFT" class="myft-ui__icon"></abbr></a>
+		`<a href="/myft" class="myft-ui__logo" data-trackable="myft-logo"><abbr title="myFT" class="myft-ui__icon"></abbr></a>
 			${detail.results ? 'Article added to your' : 'Article removed from your'}
 			<a href="${href}" data-trackable="saved-cta">saved articles</a>`,
 		contained:
-			`<a href="/myft" class="myft-ui__logo" data-trackable="myft-logo"><abbr title="myFT" class="myft-ui__icon"></abbr></a>
+		`<a href="/myft" class="myft-ui__logo" data-trackable="myft-logo"><abbr title="myFT" class="myft-ui__icon"></abbr></a>
 			${detail.results ? `Article added to your list.
 			<a href="${href}" data-trackable="alerts">View list</a>` : 'Article removed from your list'}`
 	};
 
-	return (messages.hasOwnProperty(relationship)) ? messages[relationship]: '';
+	return (messages.hasOwnProperty(relationship)) ? messages[relationship] : '';
 }
 
 function getPersonaliseUrlPromise (page, relationship, detail) {
@@ -262,17 +238,17 @@ function getPersonaliseUrlPromise (page, relationship, detail) {
 		}));
 }
 
-function updateAfterIO (myftFeature, detail) {
+function updateAfterIO (relationship, detail) {
 
-	updateUiForFeature({
-		myftFeature,
+	updateUiForRelationship({
+		relationship,
 		subjects: [{ uuid: detail.subject, '_rel': detail.data && detail.data._rel }],
 		state: !!detail.results
 	});
 
 	let messagePromise = Promise.resolve({});
 
-	switch (myftFeature) {
+	switch (relationship) {
 		case 'saved':
 			if (flags.get('myftLists') && detail.results) {
 				messagePromise = myftClient.getAll('created', 'list')
@@ -280,7 +256,7 @@ function updateAfterIO (myftFeature, detail) {
 					.then(createdLists => {
 						if (createdLists.length) {
 							showArticleSavedOverlay(detail.subject);
-							return {message: null};
+							return { message: null };
 						}
 						return {};
 					});
@@ -292,7 +268,7 @@ function updateAfterIO (myftFeature, detail) {
 	}
 
 	messagePromise
-		.then(({message = null, type = null}) => {
+		.then(({ message = null, type = null }) => {
 			if (!message) {
 				return;
 			}
@@ -306,12 +282,12 @@ function updateAfterIO (myftFeature, detail) {
 }
 
 function onLoad (ev) {
-	const myftFeature = myFtFeatureFromEvent(ev);
-	results[myftFeature] = ev.detail.Items || ev.detail.items || [];
+	const relationship = getRelationshipFromEvent(ev);
+	results[relationship] = ev.detail.Items || ev.detail.items || [];
 
-	updateUiForFeature({
-		myftFeature,
-		subjects: results[myftFeature],
+	updateUiForRelationship({
+		relationship,
+		subjects: results[relationship],
 		state: true
 	});
 }
@@ -334,7 +310,7 @@ function extractMetaData (inputs) {
 	return meta;
 }
 
-function getInteractionHandler (myftFeature) {
+function getInteractionHandler (relationship) {
 	return function (ev, el) {
 		ev.preventDefault();
 
@@ -358,8 +334,8 @@ function getInteractionHandler (myftFeature) {
 			action = (isPressed) ? 'remove' : 'add';
 		}
 
-		const id = form.getAttribute(idProperties[myftFeature]);
-		const type = types[myftFeature];
+		const id = form.getAttribute(idPropertiesMap.get(relationship));
+		const type = typesMap.get(relationship);
 		const hiddenFields = $$('input[type="hidden"]', form);
 		const metaFields = (buttonWithValTriggered) ? [activeButton, ...hiddenFields] : hiddenFields;
 
@@ -378,18 +354,18 @@ function getInteractionHandler (myftFeature) {
 						name: names[i],
 						taxonomy: taxonomies[i]
 					});
-					return myftClient[action](actors[myftFeature], actorId, myftFeature, type, conceptId, singleMeta);
+					return myftClient[action](actorsMap.get(relationship), actorId, relationship, type, conceptId, singleMeta);
 				});
 
 				Promise.all(followPromises)
 					.then(() => toggleButton(activeButton, action === 'add'));
 
 			} else {
-				myftClient[action](actors[myftFeature], actorId, myftFeature, type, id, meta);
+				myftClient[action](actorsMap.get(relationship), actorId, relationship, type, id, meta);
 			}
 
 		} else {
-			myftClient[action](myftFeature, type, id, meta);
+			myftClient[action](relationship, type, id, meta);
 		}
 	};
 }
@@ -414,26 +390,26 @@ export function init (opts) {
 	} else {
 		personaliseLinks();
 
-		Object.keys(uiSelectors).forEach(myftFeature => {
-			if (myftClient.loaded[`myftFeature.${types[myftFeature]}`]) {
-				results[myftFeature] = myftClient.loaded[`myftFeature.${types[myftFeature]}`];
+		for (let [relationship, uiSelector] of uiSelectorsMap) {
+			if (myftClient.loaded[`${relationship}.${typesMap.get(relationship)}`]) {
+				results[relationship] = myftClient.loaded[`${relationship}.${typesMap.get(relationship)}`];
 
-				updateUiForFeature({
-					myftFeature,
-					subjects: results[myftFeature],
+				updateUiForRelationship({
+					relationship,
+					subjects: results[relationship],
 					state: true
 				});
 
 			} else {
-				document.body.addEventListener(`myft.user.${myftFeature}.${types[myftFeature]}.load`, onLoad);
+				document.body.addEventListener(`myft.user.${relationship}.${typesMap.get(relationship)}.load`, onLoad);
 			}
 
-			document.body.addEventListener(`myft.${actors[myftFeature]}.${myftFeature}.${types[myftFeature]}.add`, ev => updateAfterIO(myFtFeatureFromEvent(ev), ev.detail, actionFromEvent(ev)));
-			document.body.addEventListener(`myft.${actors[myftFeature]}.${myftFeature}.${types[myftFeature]}.remove`, ev => updateAfterIO(myFtFeatureFromEvent(ev), ev.detail, actionFromEvent(ev)));
-			document.body.addEventListener(`myft.${actors[myftFeature]}.${myftFeature}.${types[myftFeature]}.update`, ev => updateAfterIO(myFtFeatureFromEvent(ev), ev.detail, actionFromEvent(ev)));
+			document.body.addEventListener(`myft.${actorsMap.get(relationship)}.${relationship}.${typesMap.get(relationship)}.add`, ev => updateAfterIO(getRelationshipFromEvent(ev), ev.detail, actionFromEvent(ev)));
+			document.body.addEventListener(`myft.${actorsMap.get(relationship)}.${relationship}.${typesMap.get(relationship)}.remove`, ev => updateAfterIO(getRelationshipFromEvent(ev), ev.detail, actionFromEvent(ev)));
+			document.body.addEventListener(`myft.${actorsMap.get(relationship)}.${relationship}.${typesMap.get(relationship)}.update`, ev => updateAfterIO(getRelationshipFromEvent(ev), ev.detail, actionFromEvent(ev)));
 
-			delegate.on('submit', uiSelectors[myftFeature], getInteractionHandler(myftFeature));
-		});
+			delegate.on('submit', uiSelector, getInteractionHandler(relationship));
+		}
 
 		delegate.on('click', '.n-myft-ui--prefer-group button', getInteractionHandler('preferred'));
 
@@ -450,23 +426,23 @@ export function init (opts) {
 	}
 }
 
-export function	updateUi (el, ignoreLinks) {
+export function updateUi (el, ignoreLinks) {
 	if (!ignoreLinks) {
 		personaliseLinks(el);
 	}
 
-	Object.keys(uiSelectors).forEach(myftFeature => {
-		if (!results[myftFeature]) {
+	for (let relationship of uiSelectorsMap.keys()) {
+		if (!results[relationship]) {
 			return;
 		}
 
-		updateUiForFeature({
-			myftFeature,
-			subjects: results[myftFeature],
+		updateUiForRelationship({
+			relationship,
+			subjects: results[relationship],
 			state: true,
 			context: el
 		});
-	});
+	}
 }
 
 export function personaliseLinks (el) {

--- a/myft/ui/index.js
+++ b/myft/ui/index.js
@@ -1,6 +1,6 @@
 //TODO: refactor the massive out of this
 
-const nextButtons = require('../myft-common');
+const nextButtons = require('../../myft-common');
 const nNotification = require('n-notification');
 const Overlay = require('o-overlay');
 const myftClient = require('next-myft-client');

--- a/myft/ui/relationship-maps/actors.js
+++ b/myft/ui/relationship-maps/actors.js
@@ -1,0 +1,6 @@
+export default new Map([
+	['saved', 'user'],
+	['followed', 'user'],
+	['preferred', 'user'],
+	['contained', 'list']
+]);

--- a/myft/ui/relationship-maps/id-properties.js
+++ b/myft/ui/relationship-maps/id-properties.js
@@ -1,0 +1,6 @@
+export default new Map([
+	['saved', 'data-content-id'],
+	['followed', 'data-concept-id'],
+	['preferred', 'data-preference-name'],
+	['contained', 'data-content-id']
+]);

--- a/myft/ui/relationship-maps/types.js
+++ b/myft/ui/relationship-maps/types.js
@@ -1,0 +1,6 @@
+export default new Map([
+	['saved', 'content'],
+	['followed', 'concept'],
+	['preferred', 'preference'],
+	['contained', 'content']
+]);

--- a/myft/ui/relationship-maps/ui-selectors.js
+++ b/myft/ui/relationship-maps/ui-selectors.js
@@ -1,0 +1,6 @@
+export default new Map([
+	['saved', '[data-myft-ui="saved"]'],
+	['followed', '[data-myft-ui="follow"]'],
+	['preferred', '[data-myft-ui="prefer"]'],
+	['contained', '[data-myft-ui="contained"]']
+]);


### PR DESCRIPTION
A few early steps towards the end goal of 'refactoring the massive out of this', including:

- Make all references to a `myFtFeature`/`relationship` (e.g. followed) consistently `relationship`, as this makes the most sense I think
- Extract these maps of variables for each relationship into their own files so that they can be shared between smaller, broken-up files

This is a forerunner to the CAPI v2 compatibility stuff coming in.

A bit of manual testing has been done with next-article, but I'll do much more before I release. Also looking into getting in a demo app, which will be useful for pa11y at the very least (easier said than done)