### PR TITLE
Accept directType instead of taxonomy

### DIFF
--- a/components/collections/collections.html
+++ b/components/collections/collections.html
@@ -14,7 +14,16 @@
 	<div class="card__collection-meta">
 		<div class="card__collection-datum" aria-hidden="true">{{concepts.length}}<br/>topics</div>
 			<form method="POST" action="#" data-myft-ui="follow" data-concept-id="{{#concepts}}{{id}}{{#unless @last}},{{/unless}}{{/concepts}}" class="n-myft-ui n-myft-ui--follow card__collection-follow n-util-hide-core">
-				<input type="hidden" name="taxonomy" value="{{#concepts}}{{taxonomy}}{{#unless @last}},{{/unless}}{{/concepts}}" />
+
+				{{! CAPI2_CLEANUP }}
+				{{#if concepts.0.taxonomy}}
+					<input type="hidden" name="taxonomy" value="{{#concepts}}{{taxonomy}}{{#unless @last}},{{/unless}}{{/concepts}}" />
+				{{/if}}
+
+				{{#if concepts.0.directType}}
+					<input type="hidden" name="directType" value="{{#concepts}}{{directType}}{{#unless @last}},{{/unless}}{{/concepts}}" />
+				{{/if}}
+
 				<input type="hidden" name="name" value="{{#concepts}}{{name}}{{#unless @last}},{{/unless}}{{/concepts}}" />
 				<button type="submit" aria-label="Add all topics in the {{name}} collection to my F T" aria-pressed="false" class="n-myft-ui__button" data-alternate-label="Remove all topics in the {{name}} collection from my F T" data-alternate-text="Added" data-trackable="follow" data-concept-id="{{#concepts}}{{id}}{{#unless @last}},{{/unless}}{{/concepts}}" title="Add all topics in the {{name}} collection to my F T">Add all to myFT</button>
 			</form>

--- a/myft-digest-promo/index.js
+++ b/myft-digest-promo/index.js
@@ -55,8 +55,19 @@ function setDismissState () {
 function addToDigest () {
 	const metaConcept = {
 		name: btn.getAttribute('data-title'),
-		taxonomy: btn.getAttribute('data-taxonomy')
 	};
+
+	const taxonomy = btn.getAttribute('data-taxonomy');
+	const directType = btn.getAttribute('data-direct-type');
+
+	// CAPI2_CLEANUP
+	if(taxonomy) {
+		metaConcept.taxonomy = taxonomy;
+	}
+	if(directType) {
+		metaConcept.directType = directType;
+	}
+
 	const metaEmail = {
 		_rel: {
 			type: 'daily',

--- a/myft-digest-promo/promo-message.html
+++ b/myft-digest-promo/promo-message.html
@@ -22,7 +22,8 @@
 													data-trackable="digest-promo"
 													title="Add {{title}}"
 													data-title="{{title}}"
-													data-taxonomy="{{taxonomy}}"
+													{{#if taxonomy}}data-taxonomy="{{taxonomy}}"{{/if}} {{! CAPI2_CLEANUP }}
+													{{#if directType}}data-direct-type="{{directType}}"{{/if}}
 													type="submit">
 													Add to myFT Digest
 									</button>

--- a/myft/templates/follow.html
+++ b/myft/templates/follow.html
@@ -4,7 +4,13 @@
 		data-concept-id="{{conceptId}}"
 		action="/__myft/api/core/followed/concept/{{conceptId}}?method=put">
 		<input type="hidden" value="{{name}}" name="name">
-		<input type="hidden" value="{{taxonomy}}" name="taxonomy">
+		{{! CAPI2_CLEANUP }}
+		{{#if taxonomy}}
+			<input type="hidden" value="{{taxonomy}}" name="taxonomy">
+		{{/if}}
+		{{#if directType}}
+			<input type="hidden" value="{{directType}}" name="directType">
+		{{/if}}
 		<button
 			aria-label="Add {{name}}"
 			aria-pressed="false"

--- a/myft/templates/instant-alert.html
+++ b/myft/templates/instant-alert.html
@@ -4,7 +4,13 @@
 		data-concept-id="{{conceptId}}"
 		action="/__myft/api/core/followed/concept/{{conceptId}}?method=put">
 		<input type="hidden" value="{{name}}" name="name">
-		<input type="hidden" value="{{taxonomy}}" name="taxonomy">
+		{{! CAPI2_CLEANUP }}
+		{{#if taxonomy}}
+			<input type="hidden" value="{{taxonomy}}" name="taxonomy">
+		{{/if}}
+		{{#if directType}}
+			<input type="hidden" value="{{directType}}" name="directType">
+		{{/if}}
 		<button
 			aria-label="Get instant alerts for {{name}}"
 			aria-pressed="false"

--- a/myft/templates/unfollow.html
+++ b/myft/templates/unfollow.html
@@ -4,7 +4,13 @@
 	data-concept-id="{{conceptId}}"
 	action="/__myft/api/core/followed/concept/{{conceptId}}?method=delete">
 	<input type="hidden" value="{{name}}" name="name">
-	<input type="hidden" value="{{taxonomy}}" name="taxonomy">
+	{{! CAPI2_CLEANUP }}
+	{{#if taxonomy}}
+		<input type="hidden" value="{{taxonomy}}" name="taxonomy">
+	{{/if}}
+	{{#if directType}}
+		<input type="hidden" value="{{directType}}" name="directType">
+	{{/if}}
 	<button
 		aria-label="Unfollow {{name}}"
 		aria-pressed="true"

--- a/myft/test/ui/myft-buttons/collections.spec.js
+++ b/myft/test/ui/myft-buttons/collections.spec.js
@@ -203,6 +203,65 @@ describe('Collections', () => {
 					expect(stubs.toggleButtonStub).to.have.been.calledWith(theButton, false);
 				});
 		});
+
+		it('should should accept `directType` in place of `taxonomy`', () => {
+			container.innerHTML = `
+				<form data-followed-subject-id="id1,id2,id3">
+					<button></button>
+				</form>
+			`;
+
+			const action = 'add';
+			const userId = 'some-actor-id';
+			const formData = {
+				commonProp: 'foo',
+				directType: 'type1,type2,type3',
+				name: 'name1,name2,name3'
+			};
+
+			collections.doAction(action, userId, container.querySelector('form'), formData);
+			expect(stubs.myFtClientAddStub.callCount).to.equal(3);
+			expect(stubs.myFtClientAddStub).to.have.been.calledWith(
+				'user',
+				'some-actor-id',
+				'followed',
+				'concept',
+				'id1',
+				{
+					commonProp: 'foo',
+					directType: 'type1',
+					name: 'name1',
+				}
+			);
+
+			expect(stubs.myFtClientAddStub).to.have.been.calledWith(
+				'user',
+				'some-actor-id',
+				'followed',
+				'concept',
+				'id2',
+				{
+					commonProp: 'foo',
+					directType: 'type2',
+					name: 'name2',
+				}
+			);
+
+			expect(stubs.myFtClientAddStub).to.have.been.calledWith(
+				'user',
+				'some-actor-id',
+				'followed',
+				'concept',
+				'id3',
+				{
+					commonProp: 'foo',
+					directType: 'type3',
+					name: 'name3',
+				}
+			);
+
+		});
+
 	});
 
 

--- a/myft/ui/myft-buttons/collections.js
+++ b/myft/ui/myft-buttons/collections.js
@@ -8,17 +8,8 @@ const idProperty = relationshipConfigs['followed'].idProperty;
 function getConceptsData (formEl, rawFormData) {
 	const subjectIds = formEl.getAttribute(idProperty).split(',');
 	const names = rawFormData.name.split(',');
-
-	// CAPI2_CLEANUP
-	let taxonomies = [];
-	if (rawFormData.taxonomy) {
-		taxonomies = rawFormData.taxonomy.split(',');
-	}
-
-	let directTypes = [];
-	if (rawFormData.directType) {
-		directTypes = rawFormData.directType.split(',');
-	}
+	const taxonomies = rawFormData.taxonomy ? rawFormData.taxonomy.split(','): []; // CAPI2_CLEANUP
+	const directTypes = rawFormData.directType ? rawFormData.directType.split(',') : [];
 
 	return subjectIds.map((id, i) => {
 

--- a/myft/ui/myft-buttons/collections.js
+++ b/myft/ui/myft-buttons/collections.js
@@ -7,16 +7,43 @@ const idProperty = relationshipConfigs['followed'].idProperty;
 
 function getConceptsData (formEl, rawFormData) {
 	const subjectIds = formEl.getAttribute(idProperty).split(',');
-	const taxonomies = rawFormData.taxonomy.split(',');
 	const names = rawFormData.name.split(',');
 
-	return subjectIds.map((id, i) => ({
-		id,
-		formData: Object.assign({}, rawFormData, {
-			name: names[i],
-			taxonomy: taxonomies[i]
-		})
-	}));
+	// CAPI2_CLEANUP
+	let taxonomies = [];
+	if (rawFormData.taxonomy) {
+		taxonomies = rawFormData.taxonomy.split(',');
+	}
+
+	let directTypes = [];
+	if (rawFormData.directType) {
+		directTypes = rawFormData.directType.split(',');
+	}
+
+	return subjectIds.map((id, i) => {
+
+		delete rawFormData.name;
+		delete rawFormData.taxonomy; // CAPI2_CLEANUP
+		delete rawFormData.type;
+
+		const formData = Object.assign({
+			name: names[i]
+		}, rawFormData);
+
+		// CAPI2_CLEANUP
+		if(taxonomies[i]) {
+			formData.taxonomy = taxonomies[i];
+		}
+
+		if(directTypes[i]) {
+			formData.directType = directTypes[i];
+		}
+
+		return {
+			id,
+			formData
+		};
+	});
 }
 
 export function formIsFollowCollection (relationshipName, formEl) {


### PR DESCRIPTION
### Now directType compatible:
- follow button
- unfollow button
- instant alert button
- collections
- digest promo

### To do:
- [ ] make absolutely sure the react buttons aren’t used anywhere (they still just look at taxonomy)
- [ ] delete all the react button code