### PR TITLE
fix(signin-redirect): correct url after signin

### DIFF
--- a/myft/ui/myft-buttons/init.js
+++ b/myft/ui/myft-buttons/init.js
@@ -18,9 +18,9 @@ function getInteractionHandler (relationshipName) {
 }
 
 function anonEventListeners () {
-
+	const currentPath = window.location.pathname;
 	const subscribeUrl = '/products?segID=400863&segmentID=190b4443-dc03-bd53-e79b-b4b6fbd04e64';
-	const signInLink = '/login';
+	const signInLink = `/login${currentPath.length ? `?location=${currentPath}` : ''}`;
 	const messages = {
 		follow: `Please <a href="${subscribeUrl}" data-trackable="Subscribe">subscribe</a> or <a href="${signInLink}" data-trackable="Sign In">sign in</a> to add this topic to myFT.`,
 		save: `Please <a href="${subscribeUrl}" data-trackable="Subscribe">subscribe</a> or <a href="${signInLink}" data-trackable="Sign In">sign in</a> to save this article.`


### PR DESCRIPTION
Fixes https://jira.ft.com/browse/NFT-845
* appends correct url path to sign in url in the `n-notification`