### PR TITLE
Shorter follow copy when myFtFollowButtonShorterCopy flag set

### DIFF
--- a/.pa11yci.js
+++ b/.pa11yci.js
@@ -14,7 +14,8 @@ const viewports = [
 ];
 
 const urls = [
-	'http://localhost:5005/'
+	'http://localhost:5005/',
+	'http://localhost:5005/short-copy'
 ];
 
 const config = {

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ demo-build:
 	@mkdir bower_components/n-myft-ui
 	@mkdir bower_components/n-myft-ui/myft
 	@cp -r myft/templates/ bower_components/n-myft-ui/myft/templates/
+	@cp -r components bower_components/n-myft-ui/components/
 	@node-sass demos/src/demo.scss public/main.css --include-path bower_components
 	@$(DONE)
 

--- a/components/collections/collections.html
+++ b/components/collections/collections.html
@@ -13,10 +13,64 @@
 	</ul>
 	<div class="card__collection-meta">
 		<div class="card__collection-datum" aria-hidden="true">{{concepts.length}}<br/>topics</div>
-			<form method="POST" action="#" data-myft-ui="follow" data-concept-id="{{#concepts}}{{id}}{{#unless @last}},{{/unless}}{{/concepts}}" class="n-myft-ui n-myft-ui--follow card__collection-follow n-util-hide-core">
-			<input type="hidden" name="directType" value="{{#concepts}}{{directType}}{{#unless @last}},{{/unless}}{{/concepts}}" />
-				<input type="hidden" name="name" value="{{#concepts}}{{prefLabel}}{{#unless @last}},{{/unless}}{{/concepts}}" />
-				<button type="submit" aria-label="Add all topics in the {{name}} collection to my F T" aria-pressed="false" class="n-myft-ui__button" data-alternate-label="Remove all topics in the {{name}} collection from my F T" data-alternate-text="Added" data-trackable="follow" data-concept-id="{{#concepts}}{{id}}{{#unless @last}},{{/unless}}{{/concepts}}" title="Add all topics in the {{name}} collection to my F T">Add all to myFT</button>
-			</form>
+		<form
+			method="POST"
+			action="#"
+			data-myft-ui="follow"
+			data-concept-id="
+				{{~#concepts~}}
+					{{id}}
+					{{~#unless @last~}}
+						,
+					{{~/unless~}}
+				{{~/concepts~}}"
+			class="n-myft-ui n-myft-ui--follow card__collection-follow n-util-hide-core"
+		>
+			<input
+				type="hidden"
+				name="directType"
+				value="
+					{{~#concepts~}}
+						{{directType}}
+						{{~#unless @last~}}
+							,
+						{{~/unless~}}
+					{{~/concepts~}}"
+			/>
+			<input
+				type="hidden"
+				name="name"
+				value="
+					{{~#concepts~}}
+						{{prefLabel}}
+					{{~#unless @last~}}
+						,
+					{{~/unless~}}
+				{{~/concepts~}}"
+			/>
+			<button
+				type="submit"
+				aria-label="Add all topics in the {{name}} collection to my F T"
+				aria-pressed="false"
+				class="n-myft-ui__button"
+				data-alternate-label="Remove all topics in the {{name}} collection from my F T"
+				data-alternate-text="Added"
+				data-trackable="follow"
+				data-concept-id="
+					{{~#concepts~}}
+						{{id}}
+						{{~#unless @last~}}
+							,
+						{{~/unless~}}
+					{{~/concepts~}}"
+				title="Add all topics in the {{name}} collection to my F T"
+			>
+				{{~#if @root.flags.myFtFollowButtonShorterCopy~}}
+					myFT
+				{{~else~}}
+					Add all to myFT
+				{{~/if~}}
+			</button>
+		</form>
 	</div>
 </section>

--- a/components/collections/collections.html
+++ b/components/collections/collections.html
@@ -54,7 +54,13 @@
 				aria-pressed="false"
 				class="n-myft-ui__button"
 				data-alternate-label="Remove all topics in the {{name}} collection from my F T"
-				data-alternate-text="Added"
+				data-alternate-text="
+					{{~#if @root.flags.myFtFollowButtonShorterCopy~}}
+						myFT
+					{{~else~}}
+						Added
+					{{~/if~}}
+				"
 				data-trackable="follow"
 				data-concept-id="
 					{{~#concepts~}}

--- a/demos/app.js
+++ b/demos/app.js
@@ -3,6 +3,11 @@ const chalk = require('chalk');
 const errorHighlight = chalk.bold.red;
 const highlight = chalk.bold.green;
 
+const fixtures = {
+	followButton: require('./fixtures/follow-button'),
+	collections: require('./fixtures/collections')
+};
+
 const app = module.exports = express({
 	name: 'public',
 	systemCode: 'n-myft-ui-demo',
@@ -26,13 +31,20 @@ app.get('/', (req, res) => {
 		flags: {
 			myFtApi: true,
 			myFtApiWrite: true
-		},
-		followButton: {
-			conceptId: '00000000-0000-0000-0000-000000000000',
-			name: 'Keith inc.',
-			directType: 'http://www.ft.com/ontology/company/PublicCompany'
 		}
-	}));
+	}, fixtures.followButton, fixtures.collections));
+});
+
+app.get('/short-copy', (req, res) => {
+	res.render('demo', Object.assign({
+		title: 'n-myft-ui short copy demo',
+		layout: 'demo-layout',
+		flags: {
+			myFtApi: true,
+			myFtApiWrite: true,
+			myFtFollowButtonShorterCopy: true
+		}
+	}, fixtures.followButton, fixtures.collections));
 });
 
 function runPa11yTests () {

--- a/demos/fixtures/collections.json
+++ b/demos/fixtures/collections.json
@@ -1,0 +1,33 @@
+{
+	"collections": [
+		{
+			"title": "European Union",
+			"concepts": [
+				{
+					"id": "00000000-0000-0000-0000-000000000000",
+					"prefLabel": "EU immigration",
+					"directType": "http://www.ft.com/ontology/Topic",
+					"url": "https://www.ft.com/stream/00000000-0000-0000-0000-000000000000"
+				},
+				{
+					"id": "00000000-0000-0000-0000-000000000000",
+					"prefLabel": "Europe Quantitative Easing",
+					"directType": "http://www.ft.com/ontology/Topic",
+					"url": "https://www.ft.com/stream/00000000-0000-0000-0000-000000000000"
+				},
+				{
+					"id": "00000000-0000-0000-0000-000000000000",
+					"prefLabel": "EU financial regulation",
+					"directType": "http://www.ft.com/ontology/Topic",
+					"url": "https://www.ft.com/stream/00000000-0000-0000-0000-000000000000"
+				},
+				{
+					"id": "00000000-0000-0000-0000-000000000000",
+					"prefLabel": "EU trade",
+					"directType": "http://www.ft.com/ontology/Topic",
+					"url": "https://www.ft.com/stream/00000000-0000-0000-0000-000000000000"
+				}
+			]
+		}
+	]
+}

--- a/demos/fixtures/follow-button.json
+++ b/demos/fixtures/follow-button.json
@@ -1,0 +1,7 @@
+{
+	"followButton": {
+		"conceptId": "00000000-0000-0000-0000-000000000000",
+		"name": "Keith inc.",
+		"directType": "http://www.ft.com/ontology/company/PublicCompany"
+	}
+}

--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -1,3 +1,4 @@
 @import 'n-ui-foundations/main';
 @import '../../myft-common/main';
 @import '../../myft/main';
+@import '../../components/collections/main';

--- a/demos/templates/demo.html
+++ b/demos/templates/demo.html
@@ -1,11 +1,29 @@
 <div class="o-grid-container">
-<h1>Demos of n-myft-ui components</h1>
+<h1>{{title}}</h1>
 	<div class="o-grid-row">
-		<div data-o-grid-colspan="12 M4">
+		<div data-o-grid-colspan="12">
 			<h2>Follow button</h2>
+
 			{{#followButton}}
-				{{>n-myft-ui/myft/templates/follow}}
+				{{> n-myft-ui/myft/templates/follow }}
 			{{/followButton}}
+
+
+			<h2>Unfollow button</h2>
+
+			{{#followButton}}
+				{{> n-myft-ui/myft/templates/unfollow }}
+			{{/followButton}}
+		</div>
+	</div>
+
+	<div class="o-grid-row">
+		<div data-o-grid-colspan="3">
+			<h2>Collections</h2>
+
+			{{#collections}}
+				{{> n-myft-ui/components/collections/collections }}
+			{{/collections}}
 		</div>
 	</div>
 </div>

--- a/myft/templates/follow.html
+++ b/myft/templates/follow.html
@@ -23,7 +23,13 @@
 				{{#if buttonText}}
 					data-alternate-text="{{buttonText}}"
 				{{else}}
-					data-alternate-text="Added"
+					data-alternate-text="
+						{{~#if @root.flags.myFtFollowButtonShorterCopy~}}
+							myFT
+						{{~else~}}
+							Added
+						{{~/if~}}
+					"
 				{{/if}}
 			{{/if}}
 			data-concept-id="{{conceptId}}" {{! duplicated here for tracking}}

--- a/myft/templates/follow.html
+++ b/myft/templates/follow.html
@@ -30,7 +30,15 @@
 			data-trackable="follow"
 			title="Add {{name}}"
 			type="submit"
-		>{{#if buttonText}}{{buttonText}}{{else}}Add to myFT{{/if}}</button>
+		>
+			{{~#if buttonText~}}
+				{{buttonText}}
+			{{~else if @root.flags.myFtFollowButtonShorterCopy~}}
+				myFT
+			{{~else~}}
+				Add to myFT
+			{{~/if~}}
+		</button>
 	</form>
 {{else}}
 	<!-- Add to myFT button hidden due to myFtApiWrite being off -->

--- a/myft/templates/unfollow.html
+++ b/myft/templates/unfollow.html
@@ -29,7 +29,15 @@
 		data-concept-id="{{conceptId}}" {{! duplicated here for tracking}}
 		title="Unfollow {{name}}"
 		type="submit"
-	>{{#if buttonText}}{{buttonText}}{{else}}Following{{/if}}</button>
+	>
+			{{~#if buttonText~}}
+				{{buttonText}}
+			{{~else if @root.flags.myFtFollowButtonShorterCopy~}}
+				myFT
+			{{~else~}}
+				Following
+			{{~/if~}}
+		</button>
 </form>
 {{else}}
 <!-- Unfollow button hidden due to myFtApiWrite being off -->

--- a/myft/templates/unfollow.html
+++ b/myft/templates/unfollow.html
@@ -22,7 +22,13 @@
 		{{#if buttonText}}
 			data-alternate-text="{{buttonText}}"
 		{{else}}
-			data-alternate-text="Follow"
+			data-alternate-text="
+				{{~#if @root.flags.myFtFollowButtonShorterCopy~}}
+					myFT
+				{{~else~}}
+					Follow
+				{{~/if~}}
+			"
 		{{/if}}
 		{{/if}}
 		data-trackable="follow"


### PR DESCRIPTION
Without `myFtFollowButtonShorterCopy`:

![screen shot 2017-06-21 at 14 55 15](https://user-images.githubusercontent.com/4622378/27387826-b2971e1c-5691-11e7-958f-3e693fe55302.png)


With `myFtFollowButtonShorterCopy`:

![screen shot 2017-06-21 at 14 55 21](https://user-images.githubusercontent.com/4622378/27387832-b5db3edc-5691-11e7-8ae1-b70ca76efd37.png)



Also:
- Added collections to demo
- Reformatted collections template a bit ([`~`  all the things](https://stackoverflow.com/a/26057807/1841845))
- Move follow button demo fixture into its own file