### PR TITLE
Save articles longer copy

### DIFF
--- a/.pa11yci.js
+++ b/.pa11yci.js
@@ -15,7 +15,7 @@ const viewports = [
 
 const urls = [
 	'http://localhost:5005/',
-	'http://localhost:5005/short-copy'
+	'http://localhost:5005/alternative-copy'
 ];
 
 const config = {

--- a/demos/app.js
+++ b/demos/app.js
@@ -5,6 +5,7 @@ const highlight = chalk.bold.green;
 
 const fixtures = {
 	followButton: require('./fixtures/follow-button'),
+	saveButton: require('./fixtures/save-button'),
 	collections: require('./fixtures/collections')
 };
 
@@ -32,19 +33,21 @@ app.get('/', (req, res) => {
 			myFtApi: true,
 			myFtApiWrite: true
 		}
-	}, fixtures.followButton, fixtures.collections));
+	}, fixtures.followButton, fixtures.saveButton, fixtures.collections));
 });
 
-app.get('/short-copy', (req, res) => {
+app.get('/alternative-copy', (req, res) => {
 	res.render('demo', Object.assign({
-		title: 'n-myft-ui short copy demo',
+		title: 'n-myft-ui alternative copy demo',
 		layout: 'demo-layout',
 		flags: {
 			myFtApi: true,
 			myFtApiWrite: true,
-			myFtFollowButtonShorterCopy: 'variant'
-		}
-	}, fixtures.followButton, fixtures.collections));
+			myFtFollowButtonShorterCopy: 'variant',
+			myFtSaveButtonLongerCopy: 'variant'
+		},
+		appIsStreamPage: false
+	}, fixtures.followButton, fixtures.saveButton, fixtures.collections));
 });
 
 function runPa11yTests () {

--- a/demos/fixtures/save-button.json
+++ b/demos/fixtures/save-button.json
@@ -1,0 +1,6 @@
+{
+	"saveButton": {
+		"contentId": "00000000-0000-0000-0000-000000000000",
+		"title": "myFT Enterprises"
+	}
+}

--- a/demos/templates/demo.html
+++ b/demos/templates/demo.html
@@ -8,12 +8,23 @@
 				{{> n-myft-ui/myft/templates/follow }}
 			{{/followButton}}
 
-
 			<h2>Unfollow button</h2>
 
 			{{#followButton}}
 				{{> n-myft-ui/myft/templates/unfollow }}
 			{{/followButton}}
+
+			<h2>Save button</h2>
+
+			{{#saveButton}}
+				{{> n-myft-ui/myft/templates/save-for-later }}
+			{{/saveButton}}
+
+			<h2>Unsave button</h2>
+
+			{{#saveButton}}
+				{{> n-myft-ui/myft/templates/unsave-for-later }}
+			{{/saveButton}}
 		</div>
 	</div>
 

--- a/myft-common/index.js
+++ b/myft-common/index.js
@@ -13,10 +13,10 @@ module.exports = {
 
 		if (text) {
 			const textVariant = btn.getAttribute('data-text-variant');
-			const textEl = textVariant ? btn.querySelector(`.${textVariant}`) : btn;
+			const textEl = textVariant ? btn.querySelector('[data-variant-label]') : btn;
 			const alternateText = btn.getAttribute('data-alternate-text') || alternateAriaLabel;
 			textEl.textContent = alternateText;
-			if(btn.querySelector('.save-button-longer-copy')) {
+			if(textVariant) {
 				const setAltText = alternateText.includes('Saved') ? 'Save ' : 'Saved ';
 				btn.setAttribute('data-alternate-text', setAltText);
 			} else {

--- a/myft-common/index.js
+++ b/myft-common/index.js
@@ -12,8 +12,10 @@ module.exports = {
 		const text = btn.textContent || btn.innerText;
 
 		if (text) {
+			const textVariantId = btn.getAttribute('data-text-variant');
+			const textEl = textVariantId ? btn.querySelector(`#${textVariantId}`) : btn;
 			const alternateText = btn.getAttribute('data-alternate-text') || alternateAriaLabel;
-			btn.textContent = alternateText;
+			textEl.textContent = alternateText;
 			btn.setAttribute('data-alternate-text', text);
 		}
 

--- a/myft-common/index.js
+++ b/myft-common/index.js
@@ -16,7 +16,7 @@ module.exports = {
 			const textEl = textVariantId ? btn.querySelector(`#${textVariantId}`) : btn;
 			const alternateText = btn.getAttribute('data-alternate-text') || alternateAriaLabel;
 			textEl.textContent = alternateText;
-			if(btn.querySelector('#save-button-longer-copy')) {
+			if(btn.querySelector('.save-button-longer-copy')) {
 				const setTo = alternateText.includes('Saved') ? 'Save ' : 'Saved ';
 				btn.setAttribute('data-alternate-text', setTo);
 			} else {

--- a/myft-common/index.js
+++ b/myft-common/index.js
@@ -12,13 +12,13 @@ module.exports = {
 		const text = btn.textContent || btn.innerText;
 
 		if (text) {
-			const textVariantId = btn.getAttribute('data-text-variant');
-			const textEl = textVariantId ? btn.querySelector(`#${textVariantId}`) : btn;
+			const textVariant = btn.getAttribute('data-text-variant');
+			const textEl = textVariant ? btn.querySelector(`.${textVariant}`) : btn;
 			const alternateText = btn.getAttribute('data-alternate-text') || alternateAriaLabel;
 			textEl.textContent = alternateText;
 			if(btn.querySelector('.save-button-longer-copy')) {
-				const setTo = alternateText.includes('Saved') ? 'Save ' : 'Saved ';
-				btn.setAttribute('data-alternate-text', setTo);
+				const setAltText = alternateText.includes('Saved') ? 'Save ' : 'Saved ';
+				btn.setAttribute('data-alternate-text', setAltText);
 			} else {
 				btn.setAttribute('data-alternate-text', text);
 			}

--- a/myft-common/index.js
+++ b/myft-common/index.js
@@ -16,7 +16,12 @@ module.exports = {
 			const textEl = textVariantId ? btn.querySelector(`#${textVariantId}`) : btn;
 			const alternateText = btn.getAttribute('data-alternate-text') || alternateAriaLabel;
 			textEl.textContent = alternateText;
-			btn.setAttribute('data-alternate-text', text);
+			if(btn.querySelector('#save-button-longer-copy')) {
+				const setTo = alternateText.includes('Saved') ? 'Save ' : 'Saved ';
+				btn.setAttribute('data-alternate-text', setTo);
+			} else {
+				btn.setAttribute('data-alternate-text', text);
+			}
 		}
 
 		const isPressed = btn.getAttribute('aria-pressed') === 'true';

--- a/myft-common/main.scss
+++ b/myft-common/main.scss
@@ -32,12 +32,10 @@
 
 	.n-myft-ui__button {
 		@include oButtons();
-
 		&:focus {
 			outline: 3px solid getColor('teal-40');
 			outline-offset: 3px;
 		}
-
 	}
 
 	.n-myft-ui__button--viewport-large {
@@ -46,13 +44,6 @@
 			display: inline-block;
 		}
 	}
-
-	// .n-myft-ui__button--viewport-standard {
-	// 	display: block;
-	// 	@include oGridRespondTo('L') {
-	// 		display: none;
-	// 	}
-	// }
 
 	.n-myft-ui__button--inverse {
 		@include oButtonsTheme(inverse);

--- a/myft-common/main.scss
+++ b/myft-common/main.scss
@@ -43,16 +43,16 @@
 	.n-myft-ui__button--viewport-large {
 		display: none;
 		@include oGridRespondTo('L') {
-			display: block;
+			display: inline-block;
 		}
 	}
 
-	.n-myft-ui__button--viewport-standard {
-		display: block;
-		@include oGridRespondTo('L') {
-			display: none;
-		}
-	}
+	// .n-myft-ui__button--viewport-standard {
+	// 	display: block;
+	// 	@include oGridRespondTo('L') {
+	// 		display: none;
+	// 	}
+	// }
 
 	.n-myft-ui__button--inverse {
 		@include oButtonsTheme(inverse);

--- a/myft-common/main.scss
+++ b/myft-common/main.scss
@@ -40,6 +40,20 @@
 
 	}
 
+	.n-myft-ui__button--viewport-large {
+		display: none;
+		@include oGridRespondTo('L') {
+			display: block;
+		}
+	}
+
+	.n-myft-ui__button--viewport-standard {
+		display: block;
+		@include oGridRespondTo('L') {
+			display: none;
+		}
+	}
+
 	.n-myft-ui__button--inverse {
 		@include oButtonsTheme(inverse);
 	}

--- a/myft/templates/save-for-later.html
+++ b/myft/templates/save-for-later.html
@@ -11,25 +11,18 @@
 	{{#if alternateText}}
 		data-alternate-text="{{alternateText}}"
 	{{else}}
-		data-alternate-text="
-			{{~#ifEquals @root.flags.myFtSaveButtonLongerCopy 'variant'~}}
-				Saved to myFT
-			{{~else~}}
-				Save
-			{{~/ifEquals~}}
-		"
+		data-alternate-text="Saved"
 	{{/if}}
 	data-content-id="{{contentId}}" {{! duplicated here for tracking}}
+	data-text-variant="save-button-longer-copy"
 	aria-label="{{#if title}}Save {{title}} to myFT for later{{else}}Save this article to myFT for later{{/if}}"
 	title="{{#if title}}Save {{title}} to myFT for later{{else}}Save this article to myFT for later{{/if}}"
 	>
 		{{~#if buttonText~}}
 			{{buttonText}}
 		{{~else~}}
-		{{log @root}}
 			{{~#ifEquals @root.flags.myFtSaveButtonLongerCopy 'variant'~}}
-				<span class="n-myft-ui__button--viewport-large" aria-hidden="true">Save to myFT</span>
-				<span class="n-myft-ui__button--viewport-standard">Save</span>
+				<span id="save-button-longer-copy">Save</span><span class="n-myft-ui__button--viewport-large" aria-hidden="true"> to myFT</span>
 			{{~else~}}
 				<span>Save</span>
 			{{~/ifEquals~}}

--- a/myft/templates/save-for-later.html
+++ b/myft/templates/save-for-later.html
@@ -26,7 +26,7 @@
 		{{~else~}}
 			{{~#ifEquals @root.flags.myFtSaveButtonLongerCopy 'variant'~}}
 				{{#unlessEquals appIsStreamPage true}}
-					<span id="save-button-longer-copy">Save </span><span class="n-myft-ui__button--viewport-large" aria-hidden="true">to myFT</span>
+					<span class="save-button-longer-copy">Save </span><span class="n-myft-ui__button--viewport-large" aria-hidden="true">to myFT</span>
 				{{~else~}}
 					<span>Save</span>
 				{{/unlessEquals}}

--- a/myft/templates/save-for-later.html
+++ b/myft/templates/save-for-later.html
@@ -24,7 +24,11 @@
 			{{buttonText}}
 		{{~else~}}
 			{{~#ifEquals @root.flags.myFtSaveButtonLongerCopy 'variant'~}}
-				<span id="save-button-longer-copy">Save </span><span class="n-myft-ui__button--viewport-large" aria-hidden="true">to myFT</span>
+				{{#unlessEquals appIsStreamPage true}}
+					<span id="save-button-longer-copy">Save </span><span class="n-myft-ui__button--viewport-large" aria-hidden="true">to myFT</span>
+				{{~else~}}
+					<span>Save</span>
+				{{/unlessEquals}}
 			{{~else~}}
 				<span>Save</span>
 			{{~/ifEquals~}}

--- a/myft/templates/save-for-later.html
+++ b/myft/templates/save-for-later.html
@@ -8,13 +8,15 @@
 	class="n-myft-ui__button{{#variant}} n-myft-ui__button--{{this}}{{/variant}}"
 	data-trackable="save-for-later"
 	data-alternate-label="Saved to myFT"
+	{{~#ifEquals @root.flags.myFtSaveButtonLongerCopy 'variant'~}}
+		data-text-variant="save-button-longer-copy"
+	{{~/ifEquals~}}
 	{{#if alternateText}}
 		data-alternate-text="{{alternateText}}"
 	{{else}}
-		data-alternate-text="Saved"
+		data-alternate-text="Saved "
 	{{/if}}
 	data-content-id="{{contentId}}" {{! duplicated here for tracking}}
-	data-text-variant="save-button-longer-copy"
 	aria-label="{{#if title}}Save {{title}} to myFT for later{{else}}Save this article to myFT for later{{/if}}"
 	title="{{#if title}}Save {{title}} to myFT for later{{else}}Save this article to myFT for later{{/if}}"
 	>
@@ -22,7 +24,7 @@
 			{{buttonText}}
 		{{~else~}}
 			{{~#ifEquals @root.flags.myFtSaveButtonLongerCopy 'variant'~}}
-				<span id="save-button-longer-copy">Save</span><span class="n-myft-ui__button--viewport-large" aria-hidden="true"> to myFT</span>
+				<span id="save-button-longer-copy">Save </span><span class="n-myft-ui__button--viewport-large" aria-hidden="true">to myFT</span>
 			{{~else~}}
 				<span>Save</span>
 			{{~/ifEquals~}}

--- a/myft/templates/save-for-later.html
+++ b/myft/templates/save-for-later.html
@@ -8,9 +8,13 @@
 	class="n-myft-ui__button{{#variant}} n-myft-ui__button--{{this}}{{/variant}}"
 	data-trackable="save-for-later"
 	data-alternate-label="Saved to myFT"
-	{{~#ifEquals @root.flags.myFtSaveButtonLongerCopy 'variant'~}}
-		data-text-variant="save-button-longer-copy"
-	{{~/ifEquals~}}
+	{{#if buttonText}}
+		data-alternate-text="Save "
+	{{else}}
+		{{~#ifEquals @root.flags.myFtSaveButtonLongerCopy 'variant'~}}
+			data-text-variant="save-button-longer-copy"
+		{{~/ifEquals~}}
+	{{/if}}
 	{{#if alternateText}}
 		data-alternate-text="{{alternateText}}"
 	{{else}}

--- a/myft/templates/save-for-later.html
+++ b/myft/templates/save-for-later.html
@@ -11,9 +11,9 @@
 	{{#if buttonText}}
 		data-alternate-text="Save "
 	{{else}}
-		{{~#ifEquals @root.flags.myFtSaveButtonLongerCopy 'variant'~}}
+		{{#ifEquals @root.flags.myFtSaveButtonLongerCopy 'variant'}}
 			data-text-variant="save-button-longer-copy"
-		{{~/ifEquals~}}
+		{{/ifEquals}}
 	{{/if}}
 	{{#if alternateText}}
 		data-alternate-text="{{alternateText}}"
@@ -25,18 +25,18 @@
 	title="{{#if title}}Save {{title}} to myFT for later{{else}}Save this article to myFT for later{{/if}}"
 	>
 	{{!-- TODO: Tidy up this nested logic once we have the results of our A/B test--}}
-		{{~#if buttonText~}}
+		{{#if buttonText}}
 			{{buttonText}}
-		{{~else~}}
-			{{~#ifEquals @root.flags.myFtSaveButtonLongerCopy 'variant'~}}
+		{{else}}
+			{{#ifEquals @root.flags.myFtSaveButtonLongerCopy 'variant'}}
 				{{#unlessEquals appIsStreamPage true}}
-					<span class="save-button-longer-copy">Save </span><span class="n-myft-ui__button--viewport-large" aria-hidden="true">to myFT</span>
-				{{~else~}}
+					<span class="save-button-longer-copy" data-variant-label>Save </span><span class="n-myft-ui__button--viewport-large" aria-hidden="true">to myFT</span>
+				{{else}}
 					<span>Save</span>
 				{{/unlessEquals}}
-			{{~else~}}
+			{{else}}
 				<span>Save</span>
-			{{~/ifEquals~}}
+			{{/ifEquals}}
 		{{/if}}
 		</button>
 	</form>

--- a/myft/templates/save-for-later.html
+++ b/myft/templates/save-for-later.html
@@ -20,6 +20,7 @@
 	aria-label="{{#if title}}Save {{title}} to myFT for later{{else}}Save this article to myFT for later{{/if}}"
 	title="{{#if title}}Save {{title}} to myFT for later{{else}}Save this article to myFT for later{{/if}}"
 	>
+	{{!-- TODO: Tidy up this nested logic once we have the results of our A/B test--}}
 		{{~#if buttonText~}}
 			{{buttonText}}
 		{{~else~}}

--- a/myft/templates/save-for-later.html
+++ b/myft/templates/save-for-later.html
@@ -8,10 +8,32 @@
 	class="n-myft-ui__button{{#variant}} n-myft-ui__button--{{this}}{{/variant}}"
 	data-trackable="save-for-later"
 	data-alternate-label="Saved to myFT"
-	data-alternate-text="Saved"
+	{{#if alternateText}}
+		data-alternate-text="{{alternateText}}"
+	{{else}}
+		data-alternate-text="
+			{{~#ifEquals @root.flags.myFtSaveButtonLongerCopy 'variant'~}}
+				Saved to myFT
+			{{~else~}}
+				Save
+			{{~/ifEquals~}}
+		"
+	{{/if}}
 	data-content-id="{{contentId}}" {{! duplicated here for tracking}}
 	aria-label="{{#if title}}Save {{title}} to myFT for later{{else}}Save this article to myFT for later{{/if}}"
 	title="{{#if title}}Save {{title}} to myFT for later{{else}}Save this article to myFT for later{{/if}}"
->{{#if buttonText}}{{buttonText}}{{else}}Save{{/if}}</button>
-</form>
+	>
+		{{~#if buttonText~}}
+			{{buttonText}}
+		{{~else~}}
+		{{log @root}}
+			{{~#ifEquals @root.flags.myFtSaveButtonLongerCopy 'variant'~}}
+				<span class="n-myft-ui__button--viewport-large" aria-hidden="true">Save to myFT</span>
+				<span class="n-myft-ui__button--viewport-standard">Save</span>
+			{{~else~}}
+				<span>Save</span>
+			{{~/ifEquals~}}
+		{{/if}}
+		</button>
+	</form>
 {{/if}}

--- a/myft/templates/unsave-for-later.html
+++ b/myft/templates/unsave-for-later.html
@@ -8,30 +8,12 @@
 	class="n-myft-ui__button{{#variant}} n-myft-ui__button--{{this}}{{/variant}}"
 	data-trackable="save-for-later"
 	data-alternate-label="Save to myFT"
-	{{~#ifEquals @root.flags.myFtSaveButtonLongerCopy 'variant'~}}
-		data-text-variant="save-button-longer-copy"
-	{{~/ifEquals~}}
-	data-alternate-text="Save "
+	data-alternate-text="Save"
 	data-content-id="{{contentId}}" {{! duplicated here for tracking}}
 	aria-label="Saved to myFT"
 	title="Saved to myFT"
 	aria-pressed="true"
-	>
-	{{!-- TODO: Tidy up this nested logic once we have the results of our A/B test--}}
-	{{~#if buttonText~}}
-		{{buttonText}}
-	{{~else~}}
-		{{~#ifEquals @root.flags.myFtSaveButtonLongerCopy 'variant'~}}
-			{{#unlessEquals appIsStreamPage true}}
-				<span class="save-button-longer-copy">Saved </span><span class="n-myft-ui__button--viewport-large" aria-hidden="true">to myFT</span>
-			{{~else~}}
-				<span>Saved</span>
-			{{/unlessEquals}}
-		{{~else~}}
-			<span>Saved</span>
-		{{~/ifEquals~}}
-	{{/if}}
-	</button>
+>{{#if buttonText}}{{buttonText}}{{else}}Saved{{/if}}</button>
 </form>
 {{else}}
 <!-- Unsave button hidden due to myFtApiWrite being off -->

--- a/myft/templates/unsave-for-later.html
+++ b/myft/templates/unsave-for-later.html
@@ -13,7 +13,22 @@
 	aria-label="Saved to myFT"
 	title="Saved to myFT"
 	aria-pressed="true"
->{{#if buttonText}}{{buttonText}}{{else}}Saved{{/if}}</button>
+	>
+	{{!-- TODO: Tidy up this nested logic once we have the results of our A/B test--}}
+	{{~#if buttonText~}}
+		{{buttonText}}
+	{{~else~}}
+		{{~#ifEquals @root.flags.myFtSaveButtonLongerCopy 'variant'~}}
+			{{#unlessEquals appIsStreamPage true}}
+				<span id="save-button-longer-copy">Saved </span><span class="n-myft-ui__button--viewport-large" aria-hidden="true">to myFT</span>
+			{{~else~}}
+				<span>Saved</span>
+			{{/unlessEquals}}
+		{{~else~}}
+			<span>Saved</span>
+		{{~/ifEquals~}}
+	{{/if}}
+	</button>
 </form>
 {{else}}
 <!-- Unsave button hidden due to myFtApiWrite being off -->

--- a/myft/templates/unsave-for-later.html
+++ b/myft/templates/unsave-for-later.html
@@ -20,7 +20,7 @@
 	{{~else~}}
 		{{~#ifEquals @root.flags.myFtSaveButtonLongerCopy 'variant'~}}
 			{{#unlessEquals appIsStreamPage true}}
-				<span id="save-button-longer-copy">Saved </span><span class="n-myft-ui__button--viewport-large" aria-hidden="true">to myFT</span>
+				<span class="save-button-longer-copy">Saved </span><span class="n-myft-ui__button--viewport-large" aria-hidden="true">to myFT</span>
 			{{~else~}}
 				<span>Saved</span>
 			{{/unlessEquals}}

--- a/myft/templates/unsave-for-later.html
+++ b/myft/templates/unsave-for-later.html
@@ -8,7 +8,10 @@
 	class="n-myft-ui__button{{#variant}} n-myft-ui__button--{{this}}{{/variant}}"
 	data-trackable="save-for-later"
 	data-alternate-label="Save to myFT"
-		data-alternate-text="Save"
+	{{~#ifEquals @root.flags.myFtSaveButtonLongerCopy 'variant'~}}
+		data-text-variant="save-button-longer-copy"
+	{{~/ifEquals~}}
+	data-alternate-text="Save "
 	data-content-id="{{contentId}}" {{! duplicated here for tracking}}
 	aria-label="Saved to myFT"
 	title="Saved to myFT"

--- a/myft/ui/lib/button-states.js
+++ b/myft/ui/lib/button-states.js
@@ -11,7 +11,6 @@ export function toggleButton (buttonEl, pressed) {
 }
 
 export function setStateOfManyButtons (relationshipName, subjectIds, state, context = document) {
-
 	if (!relationshipConfig[relationshipName]) {
 		oErrors.warn(`Unexpected relationshipName passed to updateButton: ${relationshipName}`);
 		return;

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/Financial-Times/n-myft-ui#readme",
   "devDependencies": {
-    "@financial-times/n-gage": "^1.8.5",
+    "@financial-times/n-gage": "^1.8.11",
     "@financial-times/n-heroku-tools": "^6.19.0",
     "@financial-times/n-internal-tool": "^1.2.3",
     "@financial-times/n-webpack": "^3.0.2",


### PR DESCRIPTION
Relater PR: https://github.com/Financial-Times/next-stream-page/pull/1876

For A/B testing.

Adds longer button text on myFT Save buttons on desktop devices while the myFtSaveButtonLongerCopy 'variant' flag is on for article and video pages.

Ideas on how to improve the nested handlebars logic would be welcome, but a lot of this complexity will be removed once we have the results of the A/B test (and if we're going ahead we will need a proper solution for handling Streams pages)

Gifs:
![save-long-copy-article](https://user-images.githubusercontent.com/17549437/28109564-60a15468-66e7-11e7-9257-c4e9f04db173.gif)

![save-long-copy-video](https://user-images.githubusercontent.com/17549437/28109572-673ffbf8-66e7-11e7-9bee-f08cdf3c1eb0.gif)

AND an updated Demo Page:
<img width="435" alt="screen shot 2017-07-11 at 15 45 38" src="https://user-images.githubusercontent.com/17549437/28109609-897ec352-66e7-11e7-9121-95326945cdcf.png">
