### PR TITLE
Email digest on follow for new subscriber

### DIFF
--- a/demos/app.js
+++ b/demos/app.js
@@ -50,6 +50,20 @@ app.get('/alternative-copy', (req, res) => {
 	}, fixtures.followButton, fixtures.saveButton, fixtures.collections));
 });
 
+// TODO: make sure this is using the correct flag name
+app.get('/digest-on-follow', (req, res) => {
+	res.render('demo', Object.assign({
+		title: 'n-myft-ui digest on follow',
+		layout: 'demo-layout',
+		flags: {
+			myFtApi: true,
+			myFtApiWrite: true,
+			newSubscriber: true
+		},
+		appIsStreamPage: false
+	}, fixtures.followButton));
+});
+
 function runPa11yTests () {
 	const spawn = require('child_process').spawn;
 	const pa11y = spawn('pa11y-ci');

--- a/demos/app.js
+++ b/demos/app.js
@@ -5,6 +5,7 @@ const highlight = chalk.bold.green;
 
 const fixtures = {
 	followButton: require('./fixtures/follow-button'),
+	followButtonPlusDigest: require('./fixtures/follow-button-plus-digest'),
 	saveButton: require('./fixtures/save-button'),
 	collections: require('./fixtures/collections')
 };
@@ -50,7 +51,6 @@ app.get('/alternative-copy', (req, res) => {
 	}, fixtures.followButton, fixtures.saveButton, fixtures.collections));
 });
 
-// TODO: make sure this is using the correct flag name
 app.get('/digest-on-follow', (req, res) => {
 	res.render('demo', Object.assign({
 		title: 'n-myft-ui digest on follow',
@@ -58,10 +58,9 @@ app.get('/digest-on-follow', (req, res) => {
 		flags: {
 			myFtApi: true,
 			myFtApiWrite: true,
-			newSubscriber: true
 		},
 		appIsStreamPage: false
-	}, fixtures.followButton));
+	}, fixtures.followButtonPlusDigest));
 });
 
 function runPa11yTests () {

--- a/demos/fixtures/follow-button-plus-digest.json
+++ b/demos/fixtures/follow-button-plus-digest.json
@@ -1,0 +1,8 @@
+{
+	"followButton": {
+		"conceptId": "00000000-0000-0000-0000-000000000000",
+		"name": "Keith inc.",
+		"directType": "http://www.ft.com/ontology/company/PublicCompany",
+		"followPlusDigestEmail": true
+	}
+}

--- a/myft-digest-promo/main.scss
+++ b/myft-digest-promo/main.scss
@@ -47,6 +47,14 @@ $icon-width-m: 90px;
 	padding-left: $icon-width-s;
 	padding-top: $spacing-unit;
 
+	@include oGridRespondTo('M') {
+		padding-left: $icon-width-m;
+
+		&::before {
+			width: $icon-width-m;
+		}
+	}
+
 	&::before {
 		position: absolute;
 		content: '';
@@ -60,13 +68,6 @@ $icon-width-m: 90px;
 		background-position: 10px 0;
 	}
 
-	@include oGridRespondTo('M') {
-		padding-left: $icon-width-m;
-
-		&::before {
-			width: $icon-width-m;
-		}
-	}
 }
 
 .n-myft-digest-promo__heading {

--- a/myft/templates/follow.html
+++ b/myft/templates/follow.html
@@ -2,7 +2,12 @@
 	<form class="n-myft-ui n-myft-ui--follow {{extraClasses}}" method="POST"
 		data-myft-ui="follow"
 		data-concept-id="{{conceptId}}"
+		<!-- TODO: MAKE SURE THIS IS THE CORRECT URL FORMAT AND FLAG NAME -->
+		{{#if @root.flags.newSubscriber}}
+		action="/__myft/api/follow-plus-digest-email/{{conceptId}}?method=put">
+		{{else}}
 		action="/__myft/api/core/followed/concept/{{conceptId}}?method=put">
+		{{/if}}
 		<input type="hidden" value="{{name}}" name="name">
 		{{#if directType}}
 			<input type="hidden" value="{{directType}}" name="directType">

--- a/myft/templates/follow.html
+++ b/myft/templates/follow.html
@@ -1,20 +1,20 @@
+hello{{followPlusDigestEmail}}
 {{#if @root.flags.myFtApiWrite}}
 	<form class="n-myft-ui n-myft-ui--follow {{extraClasses}}" method="POST"
 		data-myft-ui="follow"
 		data-concept-id="{{conceptId}}"
-		<!-- TODO: MAKE SURE THIS IS THE CORRECT URL FORMAT AND FLAG NAME -->
-		{{#if @root.flags.newSubscriber}}
-		action="/__myft/api/follow-plus-digest-email/{{conceptId}}?method=put">
+		{{#if followPlusDigestEmail}}
+		action="/__myft/api/follow-plus-digest-email/{{conceptId}}?method=put"
 		{{else}}
-		action="/__myft/api/core/followed/concept/{{conceptId}}?method=put">
+		action="/__myft/api/core/followed/concept/{{conceptId}}?method=put"
 		{{/if}}
+		>
 		<input type="hidden" value="{{name}}" name="name">
 		{{#if directType}}
 			<input type="hidden" value="{{directType}}" name="directType">
 		{{else}}
 			<input type="hidden" value="http://www.ft.com/ontology/concept/Concept" name="directType">
 		{{/if}}
-
 		<button
 			aria-label="Add {{name}}"
 			aria-pressed="false"

--- a/myft/templates/follow.html
+++ b/myft/templates/follow.html
@@ -1,4 +1,3 @@
-hello{{followPlusDigestEmail}}
 {{#if @root.flags.myFtApiWrite}}
 	<form class="n-myft-ui n-myft-ui--follow {{extraClasses}}" method="POST"
 		data-myft-ui="follow"

--- a/myft/templates/follow.html
+++ b/myft/templates/follow.html
@@ -3,7 +3,8 @@
 		data-myft-ui="follow"
 		data-concept-id="{{conceptId}}"
 		{{#if followPlusDigestEmail}}
-		action="/__myft/api/follow-plus-digest-email/{{conceptId}}?method=put"
+		action="/__myft/api/core/follow-plus-digest-email/{{conceptId}}?method=put"
+		data-myft-ui-variant="followPlusDigestEmail"
 		{{else}}
 		action="/__myft/api/core/followed/concept/{{conceptId}}?method=put"
 		{{/if}}

--- a/myft/ui/myft-buttons/do-form-submit.js
+++ b/myft/ui/myft-buttons/do-form-submit.js
@@ -2,6 +2,7 @@ import myFtClient from 'next-myft-client';
 import relationshipConfigs from '../lib/relationship-config';
 import getDataFromInputs from './get-data-from-inputs';
 import * as collections from './collections';
+const session = require('next-session-client');
 
 function formButtonIsDisabled (formEl) {
 	return formEl.querySelector('button').hasAttribute('disabled');
@@ -39,6 +40,19 @@ export default function (relationshipName, formEl) {
 
 	if (collections.formIsFollowCollection(relationshipName, formEl)) {
 		return collections.doAction(action, actorId, formEl, formData);
+	} else if (formEl.getAttribute('data-myft-ui-variant') === 'followPlusDigestEmail'
+				&& action === 'add') {
+
+		let conceptId = formEl.getAttribute('data-concept-id');
+		session.uuid()
+		    .then(({ uuid }) => {
+				if (uuid && conceptId) {
+					return fetch('/__myft/api/onsite/' + uuid + '/follow-plus-digest/' + conceptId);
+				} else {
+					throw new Error('Unable to follow-plus-email-digest digest');
+				}
+			});
+
 	} else {
 		const relConfig = relationshipConfigs[relationshipName];
 		const subjectId = formEl.getAttribute(relConfig.idProperty);

--- a/myft/ui/myft-buttons/do-form-submit.js
+++ b/myft/ui/myft-buttons/do-form-submit.js
@@ -2,7 +2,7 @@ import myFtClient from 'next-myft-client';
 import relationshipConfigs from '../lib/relationship-config';
 import getDataFromInputs from './get-data-from-inputs';
 import * as collections from './collections';
-const session = require('next-session-client');
+import session from 'next-session-client';
 
 function formButtonIsDisabled (formEl) {
 	return formEl.querySelector('button').hasAttribute('disabled');
@@ -24,6 +24,7 @@ function getFormData (formEl) {
 }
 
 export default function (relationshipName, formEl) {
+
 	if (formButtonIsDisabled(formEl)) {
 		return;
 	} else {
@@ -44,7 +45,8 @@ export default function (relationshipName, formEl) {
 				&& action === 'add') {
 
 		let conceptId = formEl.getAttribute('data-concept-id');
-		session.uuid()
+
+		return session.uuid()
 		    .then(({ uuid }) => {
 				if (uuid && conceptId) {
 					return fetch('/__myft/api/onsite/' + uuid + '/follow-plus-digest/' + conceptId);

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "commit": "commit-wizard",
     "precommit": "node_modules/.bin/secret-squirrel",
-    "prepush": "make verify -j3"
+    "prepush": "make verify -j3",
+    "commitmsg": "node_modules/.bin/secret-squirrel-commitmsg"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
- [x] check that core experience url is correct (after @laurieboyes has completed api work)
- [x] introduce the enhanced experience behaviour to work in conjunction with @laurieboyes api work

- [x] separately update next article and stream pages to include required `followPlusDigestEmail=true` data attribute when they include the 'Add to myFT' buttons