### PR TITLE
Instant button update doesn't break if results is empty object

### DIFF
--- a/myft/ui-instant.js
+++ b/myft/ui-instant.js
@@ -18,8 +18,11 @@ const UI_HOOK = '[data-myft-ui="instant"]';
 let config;
 
 // until API is updated to return modelled response data from create calls, fallback to old raw format
-function apiBackwardsCompatibility (response) {
-	return (response._rel) ? response._rel.instant : response.results[0].rel.properties.instant;
+function getNewInstantState (response) {
+	if(!response._rel && !(response.results && response.results[0])) {
+		return false;
+	}
+	return Boolean(response._rel ? response._rel.instant : response.results[0].rel.properties.instant);
 }
 
 function updateConceptData (subjectId, data) {
@@ -48,7 +51,7 @@ function conceptRemoved (conceptData) {
 }
 
 function conceptUpdated (conceptData) {
-	const newState = apiBackwardsCompatibility(conceptData);
+	const newState = getNewInstantState(conceptData);
 	updateButtons(conceptData.subject, newState);
 }
 

--- a/myft/ui/myft-buttons/do-form-submit.js
+++ b/myft/ui/myft-buttons/do-form-submit.js
@@ -40,11 +40,8 @@ export default function (relationshipName, formEl) {
 
 	if (collections.formIsFollowCollection(relationshipName, formEl)) {
 		return collections.doAction(action, actorId, formEl, formData);
-	} else if (formEl.getAttribute('data-myft-ui-variant') === 'followPlusDigestEmail'
-				&& action === 'add') {
-
-		myFtClient.followPlusDigestEmail(formEl.getAttribute('data-concept-id'), formData);
-
+	} else if (formEl.getAttribute('data-myft-ui-variant') === 'followPlusDigestEmail' && action === 'add') {
+		return myFtClient.followPlusDigestEmail(formEl.getAttribute('data-concept-id'), formData);
 	} else {
 		const relConfig = relationshipConfigs[relationshipName];
 		const subjectId = formEl.getAttribute(relConfig.idProperty);


### PR DESCRIPTION
Which is the case with [the follow-plus-digest stuff](https://github.com/Financial-Times/next-myft-page/blob/master/server/controllers/api/follow-plus-digest-email.js)