### PR TITLE
Change disabled state for concept pill add varient

### DIFF
--- a/components/concept-pill/main.scss
+++ b/components/concept-pill/main.scss
@@ -106,7 +106,9 @@
 	}
 }
 
-.n-myft-concept-pill--inverse:hover {
+.n-myft-concept-pill--inverse:hover,
+.n-myft-concept-pill[disabled].n-myft-concept-pill--add,
+.n-myft-concept-pill[disabled].n-myft-concept-pill--add:hover {
 	border: 1px solid getColor('white');
 	color: getColor('white');
 	background-color: oColorsMix('claret-90', 'claret-60', 40);


### PR DESCRIPTION
The pill button that allows you to add and remove topics shouldn't need
different styles for a disabled state. The button does get a disabled
attribute applied to it though after you have clicked it and before
it is dtyled as selected. This PR will prevent that middle state from
looking disabled/odd.


 🐿 v2.5.16