### PR TITLE
fullscreen overlays should have a higher z-index than the sticky header

### DIFF
--- a/myft/main.scss
+++ b/myft/main.scss
@@ -190,6 +190,6 @@ $o-overlay-is-silent: true;
 	.o-overlay--myft-ui {
 		@include oOverlayFullscreen($fill: 'width');
 		@include oOverlayFullscreen($fill: 'height');
-		@include nUiIndexFor('overlay');
+		@include nUiZIndexFor('overlay');
 	}
 }

--- a/myft/main.scss
+++ b/myft/main.scss
@@ -190,6 +190,6 @@ $o-overlay-is-silent: true;
 	.o-overlay--myft-ui {
 		@include oOverlayFullscreen($fill: 'width');
 		@include oOverlayFullscreen($fill: 'height');
-		@include nUiXIndexFor('overlay');
+		@include nUiIndexFor('overlay');
 	}
 }

--- a/myft/main.scss
+++ b/myft/main.scss
@@ -190,5 +190,6 @@ $o-overlay-is-silent: true;
 	.o-overlay--myft-ui {
 		@include oOverlayFullscreen($fill: 'width');
 		@include oOverlayFullscreen($fill: 'height');
+		z-index: 150;
 	}
 }

--- a/myft/main.scss
+++ b/myft/main.scss
@@ -190,6 +190,6 @@ $o-overlay-is-silent: true;
 	.o-overlay--myft-ui {
 		@include oOverlayFullscreen($fill: 'width');
 		@include oOverlayFullscreen($fill: 'height');
-		z-index: 150;
+		@include nUiXIndexFor('overlay');
 	}
 }


### PR DESCRIPTION
 🐿 v2.5.16 
To prevent the sticky header from covering the close buttons when the save articles overlay of open on XS screens.