### PR TITLE
Update button-states.js

### DIFF
--- a/myft/ui/lib/button-states.js
+++ b/myft/ui/lib/button-states.js
@@ -1,4 +1,3 @@
-import oErrors from 'o-errors';
 import relationshipConfig from './relationship-config';
 import * as loadedRelationships from './loaded-relationships';
 import * as nextButtons from '../../../myft-common';
@@ -14,7 +13,6 @@ export function toggleButton (buttonEl, pressed) {
 export function setStateOfManyButtons (relationshipName, subjectIds, state, context = document, data = {}) {
 
 	if (!relationshipConfig[relationshipName]) {
-		oErrors.warn(`Unexpected relationshipName passed to updateButton: ${relationshipName}`);
 		return;
 	}
 


### PR DESCRIPTION
o-errors.warn doesn't get to sentry anyway, and requiring o-errors - as it's included in the page using a separate bundle - causes bloat to the main bundle.

n-ui7 uncovered this problem as it... err... did something