### PR TITLE
Fix ios safari flex height issue

### DIFF
--- a/components/collections/main.scss
+++ b/components/collections/main.scss
@@ -9,11 +9,11 @@
 	margin-top: oGridGutter();
 	overflow: visible;
 	background: getColor('claret-70');
-	height: 100%;
 	box-sizing: border-box;
 
 	@include oGridRespondTo(M) {
 		margin-top: oGridGutter(M);
+		height: 100%;
 	}
 }
 


### PR DESCRIPTION
Certain versions for iOS safari don't support flex items having a height
of 100%. We don't need equal heights at small screen sizes so this can
be removed.
 🐿 v2.5.16