### PR TITLE
Remove outside spacing from collections

### DIFF
--- a/components/collections/main.scss
+++ b/components/collections/main.scss
@@ -6,13 +6,11 @@
 	position: relative;
 	width: auto;
 	padding: 12px;
-	margin-top: oGridGutter();
 	overflow: visible;
 	background: getColor('claret-70');
 	box-sizing: border-box;
 
 	@include oGridRespondTo(M) {
-		margin-top: oGridGutter(M);
 		height: 100%;
 	}
 }


### PR DESCRIPTION
The page that is displaying the collection should be responsible for the
spacing.
 🐿 v2.5.16