### PR TITLE
Cache digest data request

### DIFF
--- a/myft-notification/fetch-digest-data.js
+++ b/myft-notification/fetch-digest-data.js
@@ -43,7 +43,7 @@ const orderByUnreadFirst = data => {
 	return data;
 };
 
-export default async (uuid) => {
+const fetchData = uuid => {
 	const digestQuery = `
 		${teaserFragments.teaserExtraLight}
 		${teaserFragments.teaserLight}
@@ -85,4 +85,14 @@ export default async (uuid) => {
 		.then(extractArticlesFromSections)
 		.then(decorateWithHasBeenRead)
 		.then(orderByUnreadFirst);
+};
+
+let data;
+
+export default (uuid, force = false) => {
+	if (!data || force) {
+		data = fetchData(uuid);
+	}
+
+	return data;
 };


### PR DESCRIPTION
The myFT notification drawer, article digest journey tail, and article digest journey ribbon, all need the same digest data, but requesting it each time is wasteful. Cache it for the page life.

This is very simplistic/MVP caching...