### PR TITLE
Collections button colour

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ public/main.css
 public/main.css.map
 pa11y_screenCapture/
 .idea/
+
+package-lock.json

--- a/components/collections/main.scss
+++ b/components/collections/main.scss
@@ -52,8 +52,8 @@
 .collection-follow-all__button {
 	@include oButtons();
 	@include oButtonsTheme($theme: (
-		background: 'claret',
+		background: 'claret-70',
 		accent: 'white',
-		colorizer: 'claret'
+		colorizer: 'claret-70'
 	));
 }


### PR DESCRIPTION
Based on Trello card [§214](https://trello.com/c/Upm5V71r/214-make-add-all-to-myft-the-same-colour-as-the-background-of-the-rest-of-the-collections-box)

## What was done 
"Add all to myFT" button now is the same colour as the background of the rest of the collections box

<img width="1205" alt="screen shot 2018-04-25 at 11 37 08" src="https://user-images.githubusercontent.com/10063385/39240965-4774efe0-487d-11e8-92dc-2b73008a600b.png">
