### PR TITLE
Only sort the digest data for the notification drawer

### DIFF
--- a/myft-notification/fetch-digest-data.js
+++ b/myft-notification/fetch-digest-data.js
@@ -21,6 +21,7 @@ const extractArticlesFromSections = data => {
 	return data;
 };
 
+// read state in articlesFromReadingHistory will be delayed by up to ~1 minute
 const decorateWithHasBeenRead = data => {
 	const readArticles = data.user.articlesFromReadingHistory ? data.user.articlesFromReadingHistory.articles : [];
 
@@ -30,14 +31,6 @@ const decorateWithHasBeenRead = data => {
 		if (readArticleInDigest) {
 			readArticleInDigest.hasBeenRead = true;
 		}
-	});
-
-	return data;
-};
-
-const orderByUnreadFirst = data => {
-	data.user.digest.articles.sort((a, b) => {
-		return (a.hasBeenRead && b.hasBeenRead) ? 0 : a.hasBeenRead ? 1 : -1;
 	});
 
 	return data;
@@ -83,8 +76,7 @@ const fetchData = uuid => {
 		.then(fetchJson)
 		.then(checkDigestDataExist)
 		.then(extractArticlesFromSections)
-		.then(decorateWithHasBeenRead)
-		.then(orderByUnreadFirst);
+		.then(decorateWithHasBeenRead);
 };
 
 let data;

--- a/myft-notification/index.js
+++ b/myft-notification/index.js
@@ -99,6 +99,14 @@ const dismissNotification = () => {
 
 const moveNotificationContentTo = (el) => el.appendChild(notificationContentExpander.contentEl);
 
+const orderArticlesByUnreadFirst = data => {
+	data.articles.sort((a, b) => {
+		return (a.hasBeenRead && b.hasBeenRead) ? 0 : a.hasBeenRead ? 1 : -1;
+	});
+
+	return data;
+};
+
 let digestData;
 let notificationContentExpander;
 
@@ -112,6 +120,7 @@ export default async (flags = {}, options = {}) => {
 
 	digestData = new DigestData(userId);
 	digestData.fetch()
+		.then(orderArticlesByUnreadFirst)
 		.then(data => {
 			const expanderDiv = createNotificationContent(data, flags);
 			const stickyHeader = document.querySelector('.o-header--sticky');

--- a/myft-notification/notification-toggle-button.html
+++ b/myft-notification/notification-toggle-button.html
@@ -1,3 +1,3 @@
-<button class="myft-notification__icon {{#if withDot}}myft-notification__icon--with-dot{{/if}}" aria-label="My F T {{digestFrequency}} digest notification">
+<button class="myft-notification__icon {{#if withNotification}}myft-notification__icon--with-dot{{/if}}" aria-label="My F T {{digestFrequency}} digest notification">
 	<span class="myft-notification__text-button">{{digestFrequency}} digest (1)</span>
 </button>


### PR DESCRIPTION
Remove the sorting by unread->read by default for the digest data. Only sort it like that for the digest notification drawer.

This fixes the problem of the unpredictable ordering of which article index you are on whilst in the article digest journey. 