### PR TITLE
Add csrf tokens to follow/unfollow forms

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -25,6 +25,7 @@
     "next-session-client": "^2.3.4",
     "fetchres": "^1.7.2",
     "o-expander": "^4.4.4",
-    "o-tooltip": "^3.1.2"
+    "o-tooltip": "^3.1.2",
+    "js-cookie": "^2.2.0"
   }
 }

--- a/components/follow-button/follow-button.html
+++ b/components/follow-button/follow-button.html
@@ -13,6 +13,11 @@
 			action="/__myft/api/core/followed/concept/{{conceptId}}?method=put"
 		{{/ifAll}}
 	{{/if}}>
+	<input
+		data-myft-csrf-token
+		value="{{@root.csrfToken}}"
+		type="hidden"
+		name="token">
 	<button
 		{{#ifAll setFollowButtonStateToSelected @root.cacheablePersonalisedUrl}}
 			aria-label="Remove {{name}} from myFT"

--- a/components/follow-button/unfollow-button.html
+++ b/components/follow-button/unfollow-button.html
@@ -3,6 +3,11 @@
 	data-concept-id="{{conceptId}}"
 	action="/__myft/api/core/followed/concept/{{conceptId}}?method=delete">
 	<input type="hidden" value="{{name}}" name="name">
+	<input
+		data-myft-csrf-token
+		value="{{@root.csrfToken}}"
+		type="hidden"
+		name="token">
 	<button
 		aria-label="Remove {{name}} from myFT"
 		aria-pressed="true"

--- a/myft/ui/lib/set-tokens.js
+++ b/myft/ui/lib/set-tokens.js
@@ -1,7 +1,7 @@
-import { $$ } from 'n-ui-foundations';
+import { $$ as findElements } from 'n-ui-foundations';
 
 export default function (token) {
-	const inputs = $$('[data-myft-csrf-token]');
+	const inputs = findElements('[data-myft-csrf-token]');
 
 	inputs.forEach(input => {
 		input.value = token;

--- a/myft/ui/lib/set-tokens.js
+++ b/myft/ui/lib/set-tokens.js
@@ -1,0 +1,9 @@
+import { $$ } from 'n-ui-foundations';
+
+export default function (token) {
+	const inputs = $$('[data-myft-csrf-token]');
+
+	inputs.forEach(input => {
+		input.value = token;
+	});
+}

--- a/myft/ui/myft-buttons/init.js
+++ b/myft/ui/myft-buttons/init.js
@@ -96,7 +96,7 @@ export default function (opts) {
 		if (opts && opts.anonymous) {
 			anonEventListeners();
 		} else {
-			const session = Cookies.get('FTSession');
+			const session = Cookies.get('FTSession_s') || Cookies.get('FTSession');
 			setTokens(session);
 			signedInEventListeners();
 			personaliseLinks();

--- a/myft/ui/myft-buttons/init.js
+++ b/myft/ui/myft-buttons/init.js
@@ -3,11 +3,13 @@ import * as buttonStates from '../lib/button-states';
 import * as tracking from '../lib/tracking';
 import * as loadedRelationships from '../lib/loaded-relationships';
 import relationshipConfig from '../lib/relationship-config';
+import setTokens from '../lib/set-tokens';
 import nNotification from 'n-notification';
 import Delegate from 'ftdomdelegate';
 import personaliseLinks from '../personalise-links';
 import doFormSubmit from './do-form-submit';
 import pinning, {findButton, setLoading} from './pin-button';
+import Cookies from 'js-cookie';
 
 const delegate = new Delegate(document.body);
 let initialised;
@@ -94,9 +96,11 @@ export default function (opts) {
 		if (opts && opts.anonymous) {
 			anonEventListeners();
 		} else {
+			const session = Cookies.get('FTSession');
+			setTokens(session);
 			signedInEventListeners();
 			personaliseLinks();
-			if(opts.flags && opts.flags.get('myftPrioritiseTopics')) {
+			if (opts.flags && opts.flags.get('myftPrioritiseTopics')) {
 				pinButtonEventListeners();
 			}
 		}

--- a/myft/ui/personalise-links.js
+++ b/myft/ui/personalise-links.js
@@ -1,8 +1,8 @@
 import myFtClient from 'next-myft-client';
-import { $$ } from 'n-ui-foundations';
+import { $$ as findElements } from 'n-ui-foundations';
 
 export default function (el) {
-	const links = (el && el.nodeName === 'A') ? [el] : $$('a[href^="/myft"]', el);
+	const links = (el && el.nodeName === 'A') ? [el] : findElements('a[href^="/myft"]', el);
 	return Promise.all(links.map(link => myFtClient.personaliseUrl(link.getAttribute('href'))
 		.then(personalisedUrl => link.setAttribute('href', personalisedUrl)))
 	);

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "sinon-chai": "^2.10.0"
   },
   "dependencies": {
-    "@financial-times/n-teaser": "^4.8.13"
+    "@financial-times/n-teaser": "^4.8.13",
+    "js-cookie": "^2.2.0"
   }
 }


### PR DESCRIPTION
This adds CSRF tokens to the follow/unfollow forms so we can prevent people from creating a form on their own page which causes a follow or unfollow on ft.com.

normally we'd create a separate cookie for this so that the session could be HttpOnly, and if we ever do decide to make the session HttpOnly (which is probably a wise idea, as it makes certain XSS attacks harder) then we'll want to change this out for that instead.

It will also render `@root.csrfToken` should an app which to print out the token by itself, instead of having it set by JS.

financial-times/next-myft-proxy#37 will need to be merged first or else this PR will break follow buttons altogether.

financial-times/next-myft-client#134 will need to be merged or else `DELETE` bodies will not be passed along.