### PR TITLE
Remove the use of oButtons from pin buttons

### DIFF
--- a/myft/templates/pin-button.html
+++ b/myft/templates/pin-button.html
@@ -7,7 +7,7 @@
 		<input type="hidden" value="http://www.ft.com/ontology/concept/Concept" name="directType"> {{/if}}
 		<button class="myft-pin-button" data-prioritise-button data-trackable="prioritised" data-concept-id="{{id}}" data-prioritised="{{#if prioritised}}true{{else}}false{{/if}}"
 			{{#if prioritised}}aria-pressed="true" {{/if}}>
-			<span class="o-buttons-icon__label">{{#if prioritised}}Unpin{{else}}Pin{{/if}}</span>
+			<span class="myft-pin-button__label">{{#if prioritised}}Unpin{{else}}Pin{{/if}}</span>
 		</button>
 	</form>
 </div>

--- a/myft/ui/myft-buttons/pin-button.scss
+++ b/myft/ui/myft-buttons/pin-button.scss
@@ -7,19 +7,24 @@
 
 .myft-pin-button-wrapper .myft-pin-button {
 	$icon-width: 36;
-	@include oButtons();
-	@include oButtonsIconButton($icon-name: pin, $is-icon-only: true);
 	@include oIconsGetIcon('pin', getColor('black-40'), $icon-width, $iconset-version: 1);
-	background-color: transparent;
-	border: 0;
-	padding: 0;
-	min-width: 28px;
 	&[aria-pressed=true],
 	&:not([disabled]):hover {
 		@include oIconsGetIcon('pin', getColor('claret'), $icon-width, $iconset-version: 1);
 		background-color: transparent;
 		border: 0;
 	}
+}
+
+.myft-pin-button__label {
+	@include oNormaliseVisuallyHidden;
+}
+
+.myft-pin-button-wrapper .myft-pin-button {
+	background-color: transparent;
+	border: 0;
+	padding: 0;
+	min-width: 28px;
 }
 
 .myft-pin-button-wrapper {


### PR DESCRIPTION
This fixes an issues that was caused by oButtons because we weren't
using it in a convential way.

 🐿 v2.8.0