### PR TITLE
Instant alerts button bug

### DIFF
--- a/myft/templates/instant-alert.html
+++ b/myft/templates/instant-alert.html
@@ -16,7 +16,6 @@
 			{{else}}
 				aria-pressed="false"
 			{{/ifAll}}
-			aria-pressed="false"
 			class="n-myft-ui__button
 				{{#variant}} n-myft-ui__button--{{this}}{{/variant}}
 				{{#size}} n-myft-ui__button--{{this}}{{/size}}

--- a/myft/templates/instant-alert.html
+++ b/myft/templates/instant-alert.html
@@ -11,6 +11,11 @@
 		{{/if}}
 		<button
 			aria-label="Get instant alerts for {{name}}"
+			{{#ifAll hasInstantAlert @root.cacheablePersonalisedUrl}}
+				aria-pressed="true"
+			{{else}}
+				aria-pressed="false"
+			{{/ifAll}}
 			aria-pressed="false"
 			class="n-myft-ui__button
 				{{#variant}} n-myft-ui__button--{{this}}{{/variant}}


### PR DESCRIPTION
## What was done
Solves the bug that is described in the trello card attached.
Summary: Instant alert buttons are not highlighted/selected when the topic cards are redrawn

## Note
Comes together with the PR https://github.com/Financial-Times/next-myft-page/pull/1760

 🐿 v2.8.0