### PR TITLE
Let Babel do its thing on imported n-teaser fragments

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -50,9 +50,7 @@ module.exports = function (karma) {
 					{
 						test: /\.js$/,
 						loader: 'babel',
-						exclude: [
-							path.resolve('./node_modules')
-						],
+						exclude: /node_modules\/(?!(@financial-times\/n-teaser)\/).*/,
 						query: {
 							cacheDirectory: true,
 							presets: ['es2015'],

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -50,7 +50,7 @@ module.exports = function (karma) {
 					{
 						test: /\.js$/,
 						loader: 'babel',
-						exclude: /node_modules\/(?!(@financial-times\/n-teaser)\/).*/,
+						exclude: /node_modules\/(?!(@financial-times\/n-teaser|@financial-times\/n-display-metadata)\/).*/,
 						query: {
 							cacheDirectory: true,
 							presets: ['es2015'],


### PR DESCRIPTION
Exclude all node_modules but `@financial-times/n-teaser/main` so we can use the query fragments.

This is only under a test (Karma) context.