### PR TITLE
Move csrf-token input to its own little template 

### DIFF
--- a/components/csrf-token/input.html
+++ b/components/csrf-token/input.html
@@ -1,0 +1,5 @@
+<input
+	data-myft-csrf-token
+	value="{{#if @root.cacheablePersonalisedUrl}}{{@root.locals.csrfToken}}{{/if}}"
+	type="hidden"
+	name="token">

--- a/components/follow-button/follow-button.html
+++ b/components/follow-button/follow-button.html
@@ -13,11 +13,7 @@
 			action="/__myft/api/core/followed/concept/{{conceptId}}?method=put"
 		{{/ifAll}}
 	{{/if}}>
-	<input
-		data-myft-csrf-token
-		value="{{@root.locals.csrfToken}}"
-		type="hidden"
-		name="token">
+	{{> n-myft-ui/components/csrf-token/input}}
 	<button
 		{{#ifAll setFollowButtonStateToSelected @root.cacheablePersonalisedUrl}}
 			aria-label="Remove {{name}} from myFT"

--- a/components/follow-button/unfollow-button.html
+++ b/components/follow-button/unfollow-button.html
@@ -3,11 +3,7 @@
 	data-concept-id="{{conceptId}}"
 	action="/__myft/api/core/followed/concept/{{conceptId}}?method=delete">
 	<input type="hidden" value="{{name}}" name="name">
-	<input
-		data-myft-csrf-token
-		value="{{@root.locals.csrfToken}}"
-		type="hidden"
-		name="token">
+	{{> n-myft-ui/components/csrf-token/input}}
 	<button
 		aria-label="Remove {{name}} from myFT"
 		aria-pressed="true"

--- a/myft/templates/instant-alert.html
+++ b/myft/templates/instant-alert.html
@@ -3,11 +3,7 @@
 		data-myft-ui="instant"
 		data-concept-id="{{conceptId}}"
 		action="/__myft/api/core/followed/concept/{{conceptId}}?method=put">
-		<input
-			data-myft-csrf-token
-			value="{{#if @root.cacheablePersonalisedUrl}}{{@root.locals.csrfToken}}{{/if}}"
-			type="hidden"
-			name="token">
+		{{> n-myft-ui/components/csrf-token/input}}
 		<input type="hidden" value="{{name}}" name="name">
 		{{#if directType}}
 			<input type="hidden" value="{{directType}}" name="directType">

--- a/myft/templates/pin-button.html
+++ b/myft/templates/pin-button.html
@@ -2,11 +2,7 @@
 <span class="myft-pin-divider"></span>
 <div class="myft-pin-button-wrapper">
 	<form method="post" action="/__myft/api/core/prioritised/concept/{{id}}?method={{#if prioritised}}delete{{else}}put{{/if}}">
-		<input
-			data-myft-csrf-token
-			value="{{#if @root.cacheablePersonalisedUrl}}{{@root.locals.csrfToken}}{{/if}}"
-			type="hidden"
-			name="token">
+		{{> n-myft-ui/components/csrf-token/input }}
 		<input type="hidden" value="{{name}}" name="name"> {{#if directType}}
 		<input type="hidden" value="{{directType}}" name="directType"> {{else}}
 		<input type="hidden" value="http://www.ft.com/ontology/concept/Concept" name="directType"> {{/if}}

--- a/myft/templates/save-for-later.html
+++ b/myft/templates/save-for-later.html
@@ -3,11 +3,7 @@
 	data-content-id="{{contentId}}"
 	data-myft-ui="saved"
 	action="/__myft/api/core/saved/content/{{contentId}}?method=put">
-	<input
-		data-myft-csrf-token
-		value="{{#if @root.cacheablePersonalisedUrl}}{{@root.locals.csrfToken}}{{/if}}"
-		type="hidden"
-		name="token">
+	{{> n-myft-ui/components/csrf-token/input}}
 	<button
 		type="submit"
 		class="n-myft-ui__button{{#variant}} n-myft-ui__button--{{this}}{{/variant}}"

--- a/myft/templates/unsave-for-later.html
+++ b/myft/templates/unsave-for-later.html
@@ -3,11 +3,7 @@
 	data-content-id="{{contentId}}"
 	data-myft-ui="saved"
 	action="/__myft/api/core/saved/content/{{contentId}}?method=delete">
-	<input
-		data-myft-csrf-token
-		value="{{#if @root.cacheablePersonalisedUrl}}{{@root.locals.csrfToken}}{{/if}}"
-		type="hidden"
-		name="token">
+	{{> n-myft-ui/components/csrf-token/input}}
 	<button
 		type="submit"
 		class="n-myft-ui__button{{#variant}} n-myft-ui__button--{{this}}{{/variant}}"

--- a/myft/ui/myft-buttons/init.js
+++ b/myft/ui/myft-buttons/init.js
@@ -14,6 +14,8 @@ import Cookies from 'js-cookie';
 const delegate = new Delegate(document.body);
 let initialised;
 
+const getToken = () => Cookies.get('FTSession_s') || Cookies.get('FTSession');
+
 function getInteractionHandler (relationshipName) {
 	return (ev, formEl) => {
 		ev.preventDefault();
@@ -88,8 +90,7 @@ const pinButtonEventListeners = () => {
 
 export default function (opts) {
 	if (!opts.anonymous) {
-		const session = Cookies.get('FTSession_s') || Cookies.get('FTSession');
-		setTokens(session);
+		setTokens(getToken());
 	}
 
 	if (initialised) {


### PR DESCRIPTION
and put getToken in its own little function


--

so that it can be used in other apps (namely `myft-page`, maybe article?) where the buttons for some operations live (why?)
