### PR TITLE
change the storage place from localStorage to Cookie

### DIFF
--- a/components/unread-articles-indicator/storage.js
+++ b/components/unread-articles-indicator/storage.js
@@ -4,8 +4,17 @@ const INDICATOR_DISMISSED_AT = 'myFTIndicatorDismissedAt';
 
 const timestampToIsoDate = ts => new Date(ts).toISOString();
 
+const setCookie = (name, value) => {
+	document.cookie = `${name}=${value}`;
+};
+
+const getCookie = (name) => {
+	const value = document.cookie.match('(^|;) ?' + name + '=([^;]*)(;|$)');
+	return value ? value[2] : null;
+};
+
 const getTimestampItemAsIsoDate = key => {
-	const item = window.localStorage.getItem(key);
+	const item = getCookie(key);
 	const timestamp = Number(item);
 
 	return !item || isNaN(timestamp) ? null : timestampToIsoDate(timestamp);
@@ -13,11 +22,11 @@ const getTimestampItemAsIsoDate = key => {
 
 export const getLastVisitedAt = () => getTimestampItemAsIsoDate(LAST_VISITED_AT);
 
-export const setLastVisitedAt = () => window.localStorage.setItem(LAST_VISITED_AT, String(Date.now()));
+export const setLastVisitedAt = () => setCookie(LAST_VISITED_AT, String(Date.now()));
 
 export const getNewArticlesSinceTime = () => getTimestampItemAsIsoDate(NEW_ARTICLES_SINCE);
 
-export const setNewArticlesSinceTime = isoDate => window.localStorage.setItem(NEW_ARTICLES_SINCE, String(new Date(isoDate).getTime()));
+export const setNewArticlesSinceTime = isoDate => setCookie(NEW_ARTICLES_SINCE, String(new Date(isoDate).getTime()));
 
 export const getIndicatorDismissedTime = () => getTimestampItemAsIsoDate(INDICATOR_DISMISSED_AT);
 

--- a/components/unread-articles-indicator/test/chronology.spec.js
+++ b/components/unread-articles-indicator/test/chronology.spec.js
@@ -5,8 +5,8 @@ import { determineNewArticlesSinceTime, filterArticlesToNewSinceTime } from '../
 
 const SOME_TIME_YESTERDAY = '2018-06-01T12:00:00.000Z';
 const EARLIEST_NEW_ARTICLES_TIME_TODAY = '2018-06-02T05:00:00.000Z';
+const TODAY_0500 = '2018-06-02T05:00:00.000Z';
 const TODAY_0600 = '2018-06-02T06:00:00.000Z';
-const TODAY_0700 = '2018-06-02T07:00:00.000Z';
 const TODAY_0800 = '2018-06-02T08:00:00.000Z';
 const TODAY_0801 = '2018-06-02T08:01:00.000Z';
 const TODAY_1000 = '2018-06-02T10:00:00.000Z';
@@ -40,7 +40,7 @@ describe('chronology', () => {
 		describe('given the user has visited today and returns within the same-visit threshold', () => {
 			beforeEach(() => {
 				userLastVisitedAt = TODAY_0800;
-				userNewArticlesSince = TODAY_0700;
+				userNewArticlesSince = TODAY_0500; //EARLIEST_NEW_ARTICLES_TIME_TODAY
 				timeNow = new Date(TODAY_0801);
 				clock = sinon.useFakeTimers(timeNow);
 			});

--- a/components/unread-articles-indicator/test/storage.spec.js
+++ b/components/unread-articles-indicator/test/storage.spec.js
@@ -5,90 +5,67 @@ import * as storage from '../storage';
 
 describe('storage', () => {
 	let clock;
-	let mockStorage;
 	let now;
 
 	beforeEach(() => {
-		mockStorage = {};
 		now = new Date();
-		sinon.stub(window.Storage.prototype, 'getItem').callsFake(key => mockStorage[key]);
-		sinon.stub(window.Storage.prototype, 'setItem').callsFake((key, value) => mockStorage[key] = value);
 		clock = sinon.useFakeTimers(now);
 	});
 
 	afterEach(() => {
-		window.Storage.prototype.getItem.restore();
-		window.Storage.prototype.setItem.restore();
+		delete document.cookie;
 		clock.restore();
 	});
 
 	describe('getLastVisitedAt', () => {
 		describe('given a valid timestamp is stored', () => {
-			beforeEach(() => {
-				mockStorage.lastVisitedAt = String(now.getTime());
-			});
-
 			it('should return the correct iso date', () => {
-				expect(storage.getLastVisitedAt()).to.equal(now.toISOString());
+				Object.defineProperty(document, 'cookie', { value: `lastVisitedAt=${String(now.getTime())}`, configurable: true });
+				expect(storage.getLastVisitedAt('lastVisitedAt')).to.equal(now.toISOString());
 			});
 		});
 
 		describe('given no value is stored', () => {
-			beforeEach(() => {
-				mockStorage.lastVisitedAt = null;
-			});
-
 			it('should return null', () => {
-				expect(storage.getLastVisitedAt()).to.equal(null);
+				Object.defineProperty(document, 'cookie', { value: `lastVisitedAt=${null}`, configurable: true });
+				expect(storage.getLastVisitedAt('lastVisitedAt')).to.equal(null);
 			});
 		});
 
 		describe('given an invalid value is stored', () => {
-			beforeEach(() => {
-				mockStorage.lastVisitedAt = 'abc';
-			});
-
 			it('should return null', () => {
-				expect(storage.getLastVisitedAt()).to.equal(null);
+				Object.defineProperty(document, 'cookie', { value: 'lastVisitedAt=abc', configurable: true });
+				expect(storage.getLastVisitedAt('lastVisitedAt')).to.equal(null);
 			});
 		});
 	});
 
 	describe('setLastVisitedAt', () => {
 		it('should store the date as a timestamp', () => {
+			Object.defineProperty(document, 'cookie', { value: '', configurable: true, writable: true });
 			storage.setLastVisitedAt();
-
-			expect(mockStorage.lastVisitedAt).to.equal(String(now.getTime()));
+			expect(document.cookie).to.equal(`lastVisitedAt=${String(now.getTime())}`);
 		});
 	});
 
 	describe('getNewArticlesSinceTime', () => {
 		describe('given a valid timestamp is stored', () => {
-			beforeEach(() => {
-				mockStorage.newArticlesSinceTime = String(now.getTime());
-			});
-
 			it('should return the correct iso date', () => {
+				Object.defineProperty(document, 'cookie', { value: `newArticlesSinceTime=${String(now.getTime())}`, configurable: true });
 				expect(storage.getNewArticlesSinceTime()).to.equal(now.toISOString());
 			});
 		});
 
 		describe('given no value is stored', () => {
-			beforeEach(() => {
-				mockStorage.newArticlesSinceTime = null;
-			});
-
 			it('should return null', () => {
+				Object.defineProperty(document, 'cookie', { value: `newArticlesSinceTime=${null}`, configurable: true });
 				expect(storage.getNewArticlesSinceTime()).to.equal(null);
 			});
 		});
 
 		describe('given an invalid value is stored', () => {
-			beforeEach(() => {
-				mockStorage.newArticlesSinceTime = 'abc';
-			});
-
 			it('should return null', () => {
+				Object.defineProperty(document, 'cookie', { value: 'newArticlesSinceTime=abc', configurable: true });
 				expect(storage.getNewArticlesSinceTime()).to.equal(null);
 			});
 		});
@@ -96,11 +73,11 @@ describe('storage', () => {
 
 	describe('setNewArticlesSinceTime', () => {
 		it('should store the date as a timestamp', () => {
+			Object.defineProperty(document, 'cookie', { value: '', configurable: true, writable: true });
 			const date = new Date(2018, 5, 1, 11, 30, 0);
 
 			storage.setNewArticlesSinceTime(date.toISOString());
-
-			expect(mockStorage.newArticlesSinceTime).to.equal(String(date.getTime()));
+			expect(document.cookie).to.equal(`newArticlesSinceTime=${String(date.getTime())}`);
 		});
 	});
 });


### PR DESCRIPTION
 🐿 v2.9.0

To get `LAST_VISITED_AT` and `NEW_ARTICLES_SINCE ` value on Server side, we change the place from localStorage to Cookie.

This change is for an implementation which displays the latest articles since the users' last visit  on myFT feed page.