### PR TITLE
Refresh unread articles indicator on page visibility change

### DIFF
--- a/components/unread-articles-indicator/index.js
+++ b/components/unread-articles-indicator/index.js
@@ -30,7 +30,7 @@ export default () => {
 			setLastVisitedAt();
 
 			document.addEventListener('visibilitychange', () => {
-				if (!document.hidden) {
+				if (document.visibilityState === 'visible') {
 					getUserId.then(uuid => showUnreadArticlesCount(uuid, newArticlesSinceTime));
 				}
 			});

--- a/components/unread-articles-indicator/index.js
+++ b/components/unread-articles-indicator/index.js
@@ -10,11 +10,21 @@ import {
 import fetchNewArticles from './fetch-new-articles';
 import { createIndicators, setCount } from './ui';
 
+const MAX_UPDATE_FREQUENCY = 1000 * 60 * 5;
+let canUpdate = true;
+
 const showUnreadArticlesCount = (uuid, newArticlesSinceTime) => {
-	return fetchNewArticles(uuid, newArticlesSinceTime)
-		.then(articles => filterArticlesToNewSinceTime(articles, getIndicatorDismissedTime()))
-		.then(newArticles => setCount(newArticles.length))
-		.catch(() => {});
+	if (canUpdate) {
+		canUpdate = false;
+		setTimeout(() => { canUpdate = true; }, MAX_UPDATE_FREQUENCY);
+
+		return fetchNewArticles(uuid, newArticlesSinceTime)
+			.then(articles => filterArticlesToNewSinceTime(articles, getIndicatorDismissedTime()))
+			.then(newArticles => setCount(newArticles.length))
+			.catch(() => {});
+	}
+
+	return Promise.resolve();
 };
 
 export default () => {

--- a/components/unread-articles-indicator/index.js
+++ b/components/unread-articles-indicator/index.js
@@ -21,7 +21,9 @@ const showUnreadArticlesCount = (uuid, newArticlesSinceTime) => {
 		return fetchNewArticles(uuid, newArticlesSinceTime)
 			.then(articles => filterArticlesToNewSinceTime(articles, getIndicatorDismissedTime()))
 			.then(newArticles => setCount(newArticles.length))
-			.catch(() => {});
+			.catch(() => {
+				canUpdate = true;
+			});
 	}
 
 	return Promise.resolve();

--- a/components/unread-articles-indicator/test/index.spec.js
+++ b/components/unread-articles-indicator/test/index.spec.js
@@ -67,5 +67,11 @@ describe('unread stories indicator', () => {
 		expect(mockStorage.setNewArticlesSinceTime.calledWith(NEW_ARTICLES_SINCE_TIME)).to.equal(true);
 	});
 
-	it('should fetch and show the unread articles count again on page visibility change');
+	it('should fetch and show the unread articles count again on page visibility change', () => {
+		mockChronology.filterArticlesToNewSinceTime.returns(NEW_ARTICLES);
+
+		document.dispatchEvent(new Event('visibilitychange'));
+
+		expect(mockUi.setCount.calledWith(NEW_ARTICLES.length));
+	});
 });

--- a/components/unread-articles-indicator/test/index.spec.js
+++ b/components/unread-articles-indicator/test/index.spec.js
@@ -66,4 +66,6 @@ describe('unread stories indicator', () => {
 	it('should update the newArticlesSinceTime', () => {
 		expect(mockStorage.setNewArticlesSinceTime.calledWith(NEW_ARTICLES_SINCE_TIME)).to.equal(true);
 	});
+
+	it('should fetch and show the unread articles count again on page visibility change');
 });


### PR DESCRIPTION
Unfortunately unit testing this new feature is not straightforward as `document.hidden` is not mutable. I have added a pending test though.