### PR TITLE
Add core experience for follow, save and instant buttons

### DIFF
--- a/components/follow-button/follow-button.html
+++ b/components/follow-button/follow-button.html
@@ -1,16 +1,17 @@
 <form
 	class="n-myft-ui n-myft-ui--follow {{extraClasses}}"
-	method="POST"
+	method="GET"
 	data-myft-ui="follow"
 	data-concept-id="{{conceptId}}"
 	{{#if followPlusDigestEmail}}
 		action="/__myft/api/core/follow-plus-digest-email/{{conceptId}}?method=put"
 		data-myft-ui-variant="followPlusDigestEmail"
 	{{else}}
+		action="/myft/add/{{conceptId}}"
 		{{#ifAll setFollowButtonStateToSelected @root.cacheablePersonalisedUrl}}
-			action="/__myft/api/core/followed/concept/{{conceptId}}?method=delete"
+			data-js-action="/__myft/api/core/followed/concept/{{conceptId}}?method=delete"
 		{{else}}
-			action="/__myft/api/core/followed/concept/{{conceptId}}?method=put"
+			data-js-action="/__myft/api/core/followed/concept/{{conceptId}}?method=put"
 		{{/ifAll}}
 	{{/if}}>
 	{{> n-myft-ui/components/csrf-token/input}}

--- a/components/follow-button/unfollow-button.html
+++ b/components/follow-button/unfollow-button.html
@@ -1,7 +1,8 @@
-<form class="n-myft-ui n-myft-ui--follow" method="POST"
+<form class="n-myft-ui n-myft-ui--follow" method="GET"
 	data-myft-ui="follow"
 	data-concept-id="{{conceptId}}"
-	action="/__myft/api/core/followed/concept/{{conceptId}}?method=delete">
+	action="/myft/add/{{conceptId}}"
+	data-js-action="/__myft/api/core/followed/concept/{{conceptId}}?method=delete">
 	<input type="hidden" value="{{name}}" name="name">
 	{{> n-myft-ui/components/csrf-token/input}}
 	<button

--- a/myft/templates/instant-alert.html
+++ b/myft/templates/instant-alert.html
@@ -1,8 +1,9 @@
 {{#if @root.flags.myFtApiWrite}}
-	<form class="n-myft-ui n-myft-ui--instant {{extraClasses}}" method="POST"
+	<form class="n-myft-ui n-myft-ui--instant {{extraClasses}}" method="GET"
 		data-myft-ui="instant"
 		data-concept-id="{{conceptId}}"
-		action="/__myft/api/core/followed/concept/{{conceptId}}?method=put">
+		action="/myft/add/{{conceptId}}?instant=true"
+		data-js-action="/__myft/api/core/followed/concept/{{conceptId}}?method=put">
 		{{> n-myft-ui/components/csrf-token/input}}
 		<input type="hidden" value="{{name}}" name="name">
 		{{#if directType}}

--- a/myft/templates/save-for-later.html
+++ b/myft/templates/save-for-later.html
@@ -1,8 +1,9 @@
 {{#if @root.flags.myFtApiWrite}}
-<form class="n-myft-ui n-myft-ui--save" method="POST"
+<form class="n-myft-ui n-myft-ui--save" method="GET"
 	data-content-id="{{contentId}}"
 	data-myft-ui="saved"
-	action="/__myft/api/core/saved/content/{{contentId}}?method=put">
+	action="/myft/save/{{conceptId}}"
+	data-js-action="/__myft/api/core/saved/content/{{contentId}}?method=put">
 	{{> n-myft-ui/components/csrf-token/input}}
 	<button
 		type="submit"

--- a/myft/templates/unsave-for-later.html
+++ b/myft/templates/unsave-for-later.html
@@ -1,8 +1,9 @@
 {{#if @root.flags.myFtApiWrite}}
-<form class="n-myft-ui n-myft-ui--save" method="POST"
+<form class="n-myft-ui n-myft-ui--save" method="GET"
 	data-content-id="{{contentId}}"
 	data-myft-ui="saved"
-	action="/__myft/api/core/saved/content/{{contentId}}?method=delete">
+	action="/myft/save/{{conceptId}}"
+	data-js-action="/__myft/api/core/saved/content/{{contentId}}?method=delete">
 	{{> n-myft-ui/components/csrf-token/input}}
 	<button
 		type="submit"

--- a/myft/ui/myft-buttons/enhance-action-urls.js
+++ b/myft/ui/myft-buttons/enhance-action-urls.js
@@ -1,0 +1,12 @@
+
+
+export default function (context = document) {
+	['follow', 'save', 'instant']
+		.forEach(type => {
+			Array.from(context.querySelectorAll(`form.n-myft-ui--${type}`))
+				.forEach(form => {
+					form.setAttribute('method', 'POST');
+					form.setAttribute('action', form.getAttribute('data-js-action'));
+				});
+		});
+}

--- a/myft/ui/myft-buttons/init.js
+++ b/myft/ui/myft-buttons/init.js
@@ -9,6 +9,7 @@ import Delegate from 'ftdomdelegate';
 import personaliseLinks from '../personalise-links';
 import doFormSubmit from './do-form-submit';
 import initPinButtons from '../../../components/pin-button';
+import enhanceActionUrls from './enhance-action-urls';
 import Cookies from 'js-cookie';
 
 const delegate = new Delegate(document.body);
@@ -85,6 +86,7 @@ export default function (opts) {
 
 	if (!initialised) {
 		initialised = true;
+		enhanceActionUrls();
 		if (opts && opts.anonymous) {
 			anonEventListeners();
 		} else {


### PR DESCRIPTION
# Add core experience for follow, save and instant buttons

## What
- switches default method on follow, save and instant buttons to `GET`
- moves existing `POST` action on follow, save and instant buttons to `data-js-action`
- adds 'enhance-action-urls' javascript which fires on calls to `init()` which switches methods back to `POST` and switches actions back to the content of `data-js-action`
 
## Checks
🐿 v2.9.0