### PR TITLE
o-overlay-shadow z-index should be the same as overlay itself

### DIFF
--- a/myft/main.scss
+++ b/myft/main.scss
@@ -195,6 +195,10 @@ $o-overlay-is-silent: true;
 		@include oOverlayFullscreen($fill: 'height');
 		@include nUiZIndexFor('overlay');
 	}
+
+	.o-overlay-shadow {
+		@include nUiZIndexFor('overlay');
+	}
 }
 
 .n-myft-ui__button--instant.n-myft-ui__button--instant-light {


### PR DESCRIPTION
 🐿 v2.9.0

Fix of the bug "Not possible anymore to save articles on iPhone" (see trello card attached)

### Bug description

"Dear FT support team,

Since a few weeks, when using myFT on the iphone (FT.com, not the FT App), it is not possible anymore to save articles into one of my predefined folders.

When I click the save button next to an article the page opens where I usually would then pick a folder into which I wanted to save that article. However, the folder menue cannot be opened as actually the entire “save page” appears in grey shade and does not react at all. It also cannot be properly closed again.

When I go back to the original article, however, the save button next to the article is highlighted in green, suggesting the article has been saved. But it is unclear into which folder it was saved.

Fyi, on the PC using the Microsoft Explorer the saving process works fine."

### Screenshot provided
![savearticleissue](https://user-images.githubusercontent.com/10063385/41540884-086828ba-7309-11e8-8d0d-6fd25d376b57.png)
