### PR TITLE
Add classname to recursive call in findAncestor

### DIFF
--- a/components/pin-button/index.js
+++ b/components/pin-button/index.js
@@ -15,7 +15,7 @@ const trackPinningAction = ({ action }) =>
 
 const findAncestor = (el, classname) => el.classList.contains(classname)
 	? el
-	: el.parentNode && findAncestor(el.parentNode);
+	: el.parentElement && findAncestor(el.parentElement, classname)
 
 const setLoading = el => el && el.classList.add('loading');
 


### PR DESCRIPTION
also ensure we are hidding parentElement, not parentNode (otherwise we get the document upstairs !!)