### PR TITLE
Fix CSRF token template

### DIFF
--- a/components/csrf-token/input.html
+++ b/components/csrf-token/input.html
@@ -1,5 +1,5 @@
 <input
 	data-myft-csrf-token
-	value="{{#if @root.cacheablePersonalisedUrl}}{{@root.locals.csrfToken}}{{/if}}"
+	value="{{#if @root.cacheablePersonalisedUrl}}{{@root.csrfToken}}{{/if}}"
 	type="hidden"
 	name="token">

--- a/components/pin-button/index.js
+++ b/components/pin-button/index.js
@@ -15,7 +15,7 @@ const trackPinningAction = ({ action }) =>
 
 const findAncestor = (el, classname) => el.classList.contains(classname)
 	? el
-	: el.parentElement && findAncestor(el.parentElement, classname)
+	: el.parentElement && findAncestor(el.parentElement, classname);
 
 const setLoading = el => el && el.classList.add('loading');
 


### PR DESCRIPTION
# Fix CSRF token template

## What
- fixes csrf token template as the token was namespaced to the `locals` object

## Why
- express merges `res.locals` and the provided model so `@root.locals `will not exist

## Checks
 🐿 v2.9.0