### PR TITLE
Use personalised-feed-api for content source

### DIFF
--- a/components/unread-articles-indicator/chronology.js
+++ b/components/unread-articles-indicator/chronology.js
@@ -29,6 +29,6 @@ export const determineNewArticlesSinceTime = (userLastVisitedAt, userNewArticles
 
 export const filterArticlesToNewSinceTime = (articles, publishedAfterTime) => {
 	return articles.filter(article => {
-		return article.hasBeenRead !== true && isAfter(article.publishedDate, publishedAfterTime);
+		return article.hasBeenRead !== true && isAfter(article.contentTimeStamp, publishedAfterTime);
 	});
 };

--- a/components/unread-articles-indicator/fetch-new-articles.js
+++ b/components/unread-articles-indicator/fetch-new-articles.js
@@ -18,9 +18,9 @@ const decorateWithHasBeenRead = (readingHistory, allArticles) => {
 	return allArticles;
 };
 
-const contentFromPeronalisedFeed = uuid => {
+const contentFromPersonalisedFeed = uuid => {
 	const url = `/__myft/api/onsite/feed/${uuid}?originatingSignals=followed&from=-24h`;
-	const options = { credentials: 'include', timeout: 5000 };
+	const options = { credentials: 'include' };
 
 	return fetch(url, options)
 		.then(fetchJson)
@@ -41,7 +41,7 @@ const readingHistory = uuid => {
 		`;
 	const variables = { uuid };
 	const url = `https://next-api.ft.com/v2/query?query=${removeLineBreaks(gqlQuery)}&variables=${JSON.stringify(variables)}&source=next-myft`;
-	const options = { credentials: 'include', timeout: 5000 };
+	const options = { credentials: 'include' };
 
 	return fetch(url, options)
 		.then(fetchJson)
@@ -50,11 +50,11 @@ const readingHistory = uuid => {
 };
 
 const extractArticlesFromSinceTime = (articles, since) => {
-	return articles.filter(article => isAfter(article.publishedDate, since));
+	return articles.filter(article => isAfter(article.contentTimeStamp, since));
 };
 
 export default function (uuid, since) {
-	return Promise.all([readingHistory(uuid), contentFromPeronalisedFeed(uuid)])
+	return Promise.all([readingHistory(uuid), contentFromPersonalisedFeed(uuid)])
 		.then(([readingHistory, userFeedLast24Hours]) => decorateWithHasBeenRead(readingHistory, userFeedLast24Hours))
 		.then(articles => extractArticlesFromSinceTime(articles, since));
 };

--- a/components/unread-articles-indicator/fetch-new-articles.js
+++ b/components/unread-articles-indicator/fetch-new-articles.js
@@ -1,65 +1,60 @@
 import { json as fetchJson } from 'fetchres';
+import { isAfter } from 'date-fns';
 
 const removeLineBreaks = str => encodeURIComponent(str.replace(/\s+/g, ' '));
 
-const extractFollowedArticles = data => {
-	const followedConcepts = data.user.followed.reduce((acc, concept) => acc.concat(concept.id), []);
-
-	data.articles = data.latestContent.reduce((articles, article) => {
-		const articleConceptIsFollowed = article.annotations.some(annotation => followedConcepts.includes(annotation.id));
-
-		return articleConceptIsFollowed ? articles.concat(article) : articles;
-	}, []);
-
-	return data;
-};
-
 // read state in articlesFromReadingHistory will be delayed by up to ~1 minute
-const decorateWithHasBeenRead = data => {
-	const allReadArticles = data.user.articlesFromReadingHistory ? data.user.articlesFromReadingHistory.articles : [];
+const decorateWithHasBeenRead = (readingHistory, allArticles) => {
+	const allReadArticles = readingHistory ? readingHistory.articles : [];
 
 	allReadArticles.forEach(readArticle => {
-		const readNewArticle = data.articles.find(article => article.id === readArticle.id);
+		const readNewArticle = allArticles.find(article => article.id === readArticle.id);
 
 		if (readNewArticle) {
 			readNewArticle.hasBeenRead = true;
 		}
 	});
 
-	return data;
+	return allArticles;
 };
 
-export default function (uuid, since) {
+const contentFromPeronalisedFeed = uuid => {
+	const url = `/__myft/api/onsite/feed/${uuid}?originatingSignals=followed&from=-24h`;
+	const options = { credentials: 'include', timeout: 5000 };
+
+	return fetch(url, options)
+		.then(fetchJson)
+		.then(body => body.results);
+}
+
+const readingHistory = uuid => {
 	const gqlQuery = `
-		query newMyFTContentSince($uuid: String!, $since: String!) {
+		query newMyFTContentSince($uuid: String!) {
 			user(uuid: $uuid) {
-				followed {
-					id
-				}
 				articlesFromReadingHistory {
 					articles {
 						id
 					}
 				}
 			}
-
-			latestContent(since: $since, limit: 250) {
-				id
-				publishedDate
-				annotations {
-					id
-				}
-			}
 		}
 		`;
-	const variables = { uuid, since };
+	const variables = { uuid };
 	const url = `https://next-api.ft.com/v2/query?query=${removeLineBreaks(gqlQuery)}&variables=${JSON.stringify(variables)}&source=next-myft`;
 	const options = { credentials: 'include', timeout: 5000 };
 
 	return fetch(url, options)
 		.then(fetchJson)
 		.then(body => body.data)
-		.then(extractFollowedArticles)
-		.then(decorateWithHasBeenRead)
-		.then(data => data.articles);
+		.then(data => data.user.articlesFromReadingHistory);
+};
+
+const extractArticlesFromSinceTime = (articles, since) => {
+	return articles.filter(article => isAfter(article.publishedDate, since));
+};
+
+export default function (uuid, since) {
+	return Promise.all([readingHistory(uuid), contentFromPeronalisedFeed(uuid)])
+		.then(([readingHistory, userFeedLast24Hours]) => decorateWithHasBeenRead(readingHistory, userFeedLast24Hours))
+		.then(articles => extractArticlesFromSinceTime(articles, since));
 };

--- a/components/unread-articles-indicator/test/chronology.spec.js
+++ b/components/unread-articles-indicator/test/chronology.spec.js
@@ -105,20 +105,20 @@ describe('chronology', () => {
 		const mockArticles = [
 			{
 				id: BEFORE_DISMISS_AND_UNREAD,
-				publishedDate: TODAY_0600
+				contentTimeStamp: TODAY_0600
 			},
 			{
 				id: BEFORE_DISMISS_AND_READ,
-				publishedDate: TODAY_0600,
+				contentTimeStamp: TODAY_0600,
 				hasBeenRead: true
 			},
 			{
 				id: AFTER_DISMISS_AND_UNREAD,
-				publishedDate: TODAY_1000
+				contentTimeStamp: TODAY_1000
 			},
 			{
 				id: AFTER_DISMISS_AND_READ,
-				publishedDate: TODAY_1000,
+				contentTimeStamp: TODAY_1000,
 				hasBeenRead: true
 			}
 		];

--- a/components/unread-articles-indicator/test/fetch-new-articles.spec.js
+++ b/components/unread-articles-indicator/test/fetch-new-articles.spec.js
@@ -5,62 +5,54 @@ import fetchNewArticles from '../fetch-new-articles';
 
 const USER_UUID = '0-0-0-0';
 const SINCE = '2018-06-05T06:48:26.635Z';
-const FOLLOWED_CONCEPT = 'followed-concept';
-const UNFOLLOWED_CONCEPT = 'unfollowed-concept';
-const READ_AND_FOLLOWED_ARTICLE = 'read-followed-article';
-const UNREAD_AND_FOLLOWED_ARTICLE = 'unread-followed-article';
-const READ_AND_UNFOLLOWED_ARTICLE = 'read-unfollowed-article';
-const UNREAD_AND_UNFOLLOWED_ARTICLE = 'unread-unfollowed-article';
-const mockData = {
+
+const ARTICLE_PUBLISH_BEFORE_SINCE = '2018-06-04T06:48:26.635Z'
+const ARTICLE_PUBLISH_AFTER_SINCE = '2018-06-05T07:48:26.635Z';
+
+const READ_ARTICLE_AFTER_SINCE = 'read-followed-article-after-since';
+const UNREAD_ARTICLE_AFTER_SINCE = 'unread-followed-article-after-since';
+const READ_ARTICLE_BEFORE_SINCE = 'read-followed-article-before-since';
+const UNREAD_ARTICLE_BEFORE_SINCE = 'unread-followed-article-before-since';
+const mockReadingHistoryData = {
 	data: {
 		user: {
-			followed: [
-				{ id: FOLLOWED_CONCEPT }
-			],
 			articlesFromReadingHistory: {
 				articles: [
-					{ id: READ_AND_FOLLOWED_ARTICLE },
-					{ id: READ_AND_UNFOLLOWED_ARTICLE }
+					{ id: READ_ARTICLE_AFTER_SINCE },
+					{ id: READ_ARTICLE_BEFORE_SINCE }
 				]
 			}
-		},
-		latestContent: [
-			{
-				id: READ_AND_FOLLOWED_ARTICLE,
-				annotations: [
-					{ id: FOLLOWED_CONCEPT },
-					{ id: UNFOLLOWED_CONCEPT }
-				]
-			},
-			{
-				id: UNREAD_AND_FOLLOWED_ARTICLE,
-				annotations: [
-					{ id: FOLLOWED_CONCEPT },
-					{ id: UNFOLLOWED_CONCEPT }
-				]
-			},
-			{
-				id: READ_AND_UNFOLLOWED_ARTICLE,
-				annotations: [
-					{ id: UNFOLLOWED_CONCEPT }
-				]
-			},
-			{
-				id: UNREAD_AND_UNFOLLOWED_ARTICLE,
-				annotations: [
-					{ id: UNFOLLOWED_CONCEPT }
-				]
-			}
-		]
+		}
 	}
 };
+const mockPersonalisedFeedData = {
+	results: [
+		{
+			id: READ_ARTICLE_AFTER_SINCE,
+			publishedDate: ARTICLE_PUBLISH_AFTER_SINCE
+		},
+		{
+			id: UNREAD_ARTICLE_AFTER_SINCE,
+			publishedDate: ARTICLE_PUBLISH_AFTER_SINCE
+		},
+		{
+			id: READ_ARTICLE_BEFORE_SINCE,
+			publishedDate: ARTICLE_PUBLISH_BEFORE_SINCE
+		},
+		{
+			id: UNREAD_ARTICLE_BEFORE_SINCE,
+			publishedDate: ARTICLE_PUBLISH_BEFORE_SINCE
+		}
+	]
+}
 
 describe('fetch-new-articles', () => {
 	let data;
 
 	beforeEach(() => {
 		data = null;
-		fetchMock.get('*', mockData);
+		fetchMock.get('begin:https://next-api.ft.com/v2/', mockReadingHistoryData);
+		fetchMock.get('begin:/__myft/api/onsite/feed/', mockPersonalisedFeedData);
 
 		return fetchNewArticles(USER_UUID, SINCE)
 			.then(resolvedValue => {
@@ -71,21 +63,21 @@ describe('fetch-new-articles', () => {
 	afterEach(fetchMock.reset);
 
 	it('should fetch', () => {
-		expect(fetchMock.calls().matched.length).to.equal(1);
+		expect(fetchMock.calls().matched.length).to.equal(2);
 	});
 
 	it('should return an array of articles', () => {
 		expect(data).to.be.an('array');
 	});
 
-	it('should return only the followed articles', () => {
+	it('should return only the articles after the since date', () => {
 		expect(data.length).to.equal(2);
-		expect(data.some(article => article.id === READ_AND_FOLLOWED_ARTICLE)).to.equal(true);
-		expect(data.some(article => article.id === UNREAD_AND_FOLLOWED_ARTICLE)).to.equal(true);
+		expect(data.some(article => article.id === READ_ARTICLE_AFTER_SINCE)).to.equal(true);
+		expect(data.some(article => article.id === UNREAD_ARTICLE_AFTER_SINCE)).to.equal(true);
 	});
 
 	it('should decorate read articles with hasBeenRead = true', () => {
-		expect(data.find(article => article.id === READ_AND_FOLLOWED_ARTICLE).hasBeenRead).to.equal(true);
-		expect(data.find(article => article.id === UNREAD_AND_FOLLOWED_ARTICLE).hasBeenRead).not.to.equal(true);
+		expect(data.find(article => article.id === READ_ARTICLE_AFTER_SINCE).hasBeenRead).to.equal(true);
+		expect(data.find(article => article.id === UNREAD_ARTICLE_AFTER_SINCE).hasBeenRead).not.to.equal(true);
 	});
 });

--- a/components/unread-articles-indicator/test/fetch-new-articles.spec.js
+++ b/components/unread-articles-indicator/test/fetch-new-articles.spec.js
@@ -29,19 +29,19 @@ const mockPersonalisedFeedData = {
 	results: [
 		{
 			id: READ_ARTICLE_AFTER_SINCE,
-			publishedDate: ARTICLE_PUBLISH_AFTER_SINCE
+			contentTimeStamp: ARTICLE_PUBLISH_AFTER_SINCE
 		},
 		{
 			id: UNREAD_ARTICLE_AFTER_SINCE,
-			publishedDate: ARTICLE_PUBLISH_AFTER_SINCE
+			contentTimeStamp: ARTICLE_PUBLISH_AFTER_SINCE
 		},
 		{
 			id: READ_ARTICLE_BEFORE_SINCE,
-			publishedDate: ARTICLE_PUBLISH_BEFORE_SINCE
+			contentTimeStamp: ARTICLE_PUBLISH_BEFORE_SINCE
 		},
 		{
 			id: UNREAD_ARTICLE_BEFORE_SINCE,
-			publishedDate: ARTICLE_PUBLISH_BEFORE_SINCE
+			contentTimeStamp: ARTICLE_PUBLISH_BEFORE_SINCE
 		}
 	]
 }


### PR DESCRIPTION
We tried next-api, but its intricate caching just can't handle this kind of operation at scale.

As personalised-feed already acts as a caching layer between the site and elasticsearch, and already filters by topics the user follows, this hopefully gives us what we need and can handle the load.