### PR TITLE
Unread articles indicator no longer affects width of sticky header 

### DIFF
--- a/components/unread-articles-indicator/main.scss
+++ b/components/unread-articles-indicator/main.scss
@@ -5,7 +5,7 @@
 .myft__indicator {
 	position: absolute;
 	top: 0;
-	right: -13px;
+	right: -7px;
 	border-radius: 15px;
 	padding: 0 5px;
 	background-color: oColorsGetPaletteColor('teal');


### PR DESCRIPTION
...so doesn't go off edge of screen.

The position is now the same on the normal and sticky headers:

<img width="122" alt="screen shot 2018-07-02 at 15 56 45" src="https://user-images.githubusercontent.com/2759279/42171681-d9e1de1e-7e11-11e8-8e2d-8b4e430526b0.png">

A strange quirk with the sticky header meant that if the indicator position was `right: -10px` or more, the whole header width would increase - putting the right-edge of the header off-screen.