### PR TITLE
Clean up myft-common/main

### DIFF
--- a/myft-common/main.scss
+++ b/myft-common/main.scss
@@ -25,13 +25,7 @@
 	}
 }
 
-//TODO this parameter is only necessary up to n-ui@4
-//Auto adding myft to a head stylesheet is no longer a requirement
-@mixin nUiMyftCommon ($force-head: true) {
-	@if $force-head == true {
-		@include nUiStylesheetStart('head-n-ui-core');
-	}
-
+@mixin nUiMyftCommon () {
 	.myft-ui,
 	.n-myft-ui {
 		display: inline-block;
@@ -109,15 +103,6 @@
 	.n-myft-digest-promo {
 		display: none;
 	}
-
-	@if $force-head == true {
-		@include nUiStylesheetEnd('head-n-ui-core');
-	}
 }
 
-$n-ui-myft-common-applied: false !default;
-
-@if $n-ui-myft-common-applied == false {
-	$n-ui-myft-common-applied: true;
-	@include nUiMyftCommon;
-}
+@include nUiMyftCommon;


### PR DESCRIPTION
A couple of small hygiene things in support of #190:

* `nUiMyftCommon` mixin param should be redundant now
* Nothing sets `$n-ui-myft-common-applied` to true, so the condition is redundant

The following repos `import "n-myft-ui/myft-common/main"`. All but two, also `@include nUiMyftCommon(false);`:

|                   | @include nUiMyftCommon(false); |
|-------------------|--------|
| next-front-page | yes   |
| next-tour-page | yes |
| next-video-page | yes |
| next-stream-page | yes |
| next-article | yes |
| next-myft-page | yes |
| next-search-page | yes |
| next-graphics-page | no |
| n-topic-card | no |
 