### PR TITLE
Remove tracking for page visibility change refresh

### DIFF
--- a/components/unread-articles-indicator/index.js
+++ b/components/unread-articles-indicator/index.js
@@ -8,7 +8,7 @@ import * as ui from './ui';
 const MAX_UPDATE_FREQUENCY = 1000 * 60 * 5;
 let canUpdate = true;
 
-const showUnreadArticlesCount = (uuid, newArticlesSinceTime, cause) => {
+const showUnreadArticlesCount = ({ uuid, newArticlesSinceTime, withTracking = false }) => {
 	if (canUpdate && uuid) {
 		canUpdate = false;
 		setTimeout(() => canUpdate = true, MAX_UPDATE_FREQUENCY);
@@ -19,7 +19,10 @@ const showUnreadArticlesCount = (uuid, newArticlesSinceTime, cause) => {
 				const count = newArticles.length;
 
 				ui.setCount(count);
-				tracking.countShown(count, newArticlesSinceTime, cause);
+
+				if (withTracking) {
+					tracking.countShown(count, newArticlesSinceTime);
+				}
 			})
 			.catch(() => {
 				canUpdate = true;
@@ -52,11 +55,18 @@ export default () => {
 	});
 
 	return getUserId
-		.then(uuid => showUnreadArticlesCount(uuid, getNewArticlesSinceTime(), 'initial-render'))
+		.then(uuid => showUnreadArticlesCount({
+			uuid,
+			newArticlesSinceTime: getNewArticlesSinceTime(),
+			withTracking: true
+		}))
 		.then(() => {
 			document.addEventListener('visibilitychange', () => {
 				if (document.visibilityState === 'visible') {
-					getUserId.then(uuid => showUnreadArticlesCount(uuid, getNewArticlesSinceTime(), 'page-visibility-change'));
+					getUserId.then(uuid => showUnreadArticlesCount({
+						uuid,
+						newArticlesSinceTime: getNewArticlesSinceTime()
+					}));
 				}
 			});
 		});

--- a/components/unread-articles-indicator/test/index.spec.js
+++ b/components/unread-articles-indicator/test/index.spec.js
@@ -87,7 +87,7 @@ describe('unread stories indicator', () => {
 			});
 
 			it('should track initial update of count', () => {
-				expect(mockTracking.countShown).calledWith(NEW_UNDISMISSED_ARTICLES.length, DETERMINED_NEW_ARTICLES_SINCE_TIME, 'initial-render');
+				expect(mockTracking.countShown).calledWith(NEW_UNDISMISSED_ARTICLES.length, DETERMINED_NEW_ARTICLES_SINCE_TIME);
 			});
 		});
 
@@ -115,7 +115,7 @@ describe('unread stories indicator', () => {
 			});
 
 			it('should track new update of count', () => {
-				expect(mockTracking.countShown).calledWith(NEW_ARTICLES.length, DETERMINED_NEW_ARTICLES_SINCE_TIME, 'page-visibility-change');
+				expect(mockTracking.countShown).not.to.have.been.called;
 			});
 		});
 	});

--- a/components/unread-articles-indicator/test/tracking.spec.js
+++ b/components/unread-articles-indicator/test/tracking.spec.js
@@ -6,7 +6,6 @@ describe('unread-articles-indicator tracking', () => {
 		let dispatchedEvent;
 		const COUNT = 3;
 		const NEW_ARTICLES_SINCE_TIME = '2018-06-18T14:22:51.098Z';
-		const CAUSE = 'the-cause';
 
 		beforeEach(() => {
 			dispatchedEvent = null;
@@ -14,14 +13,13 @@ describe('unread-articles-indicator tracking', () => {
 		});
 
 		it('should should dispatch the event', () => {
-			tracking.countShown(COUNT, NEW_ARTICLES_SINCE_TIME, CAUSE);
+			tracking.countShown(COUNT, NEW_ARTICLES_SINCE_TIME);
 
 			expect(dispatchedEvent.detail).to.deep.equal({
 				category: 'unread-articles-indicator',
 				action: 'render',
 				count: COUNT,
-				newArticlesSinceTime: NEW_ARTICLES_SINCE_TIME,
-				cause: CAUSE
+				newArticlesSinceTime: NEW_ARTICLES_SINCE_TIME
 			});
 		});
 	});

--- a/components/unread-articles-indicator/tracking.js
+++ b/components/unread-articles-indicator/tracking.js
@@ -7,10 +7,9 @@ function dispatchEvent (detail) {
 	document.body.dispatchEvent(event);
 }
 
-export const countShown = (count, newArticlesSinceTime, cause) => dispatchEvent({
+export const countShown = (count, newArticlesSinceTime) => dispatchEvent({
 	category: 'unread-articles-indicator',
 	action: 'render',
 	count,
-	newArticlesSinceTime,
-	cause
+	newArticlesSinceTime
 });


### PR DESCRIPTION
The experiment was successful and as we are about to scale this up to all traffic, we do not need such granular tracking information.