### PR TITLE
Move n-myft-digest-promo style out of common mixin

### DIFF
--- a/components/digest-promo/main.scss
+++ b/components/digest-promo/main.scss
@@ -5,6 +5,7 @@ $icon-width-m: 90px;
 
 .n-myft-digest-promo {
 	@include oNormaliseClearfix;
+	display: none;
 	float: none;
 	position: relative;
 	background-color: getColor('white-60');

--- a/myft-common/main.scss
+++ b/myft-common/main.scss
@@ -99,8 +99,4 @@
 		width: 34px;
 		margin: 0 8px -5px;
 	}
-
-	.n-myft-digest-promo {
-		display: none;
-	}
 }


### PR DESCRIPTION
Only **next-stream-page** uses the digest-promo, so it shouldn't be in the common mixin.

Also, **next-stream-page** sets this style itself anyway:
https://github.com/Financial-Times/next-stream-page/blob/master/client/main.scss#L27