### PR TITLE
Move instant alert styles out of common mixin

### DIFF
--- a/components/instant-alert/main.scss
+++ b/components/instant-alert/main.scss
@@ -1,3 +1,17 @@
+@import "../../mixins/buttons";
+
+.n-myft-ui--instant {
+	position: relative;
+
+	.n-myft-ui__button {
+		@include buttonWithIcon(26, 24, getColor('teal-40'), 'mail', 'mail', getColor('white'));
+	}
+
+	.n-myft-ui__button--inverse {
+		@include buttonWithIcon(26, 24, getColor('teal-80'), 'mail', 'mail', getColor('white'));
+	}
+}
+
 .n-myft-ui__button--instant.n-myft-ui__button--instant-light {
 	$icon-width: 36;
 	border: 0;

--- a/mixins/buttons.scss
+++ b/mixins/buttons.scss
@@ -1,0 +1,23 @@
+@mixin buttonWithIcon($iconSpace, $iconSize, $colorOff, $iconOff, $iconOn: $iconOff, $colorOn: $colorOff) {
+	$topMargin: #{$iconSize * -0.5}px;
+	$horizontalMargin: #{($iconSpace - $iconSize) / 2}px;
+	position: relative;
+	padding-left: #{$iconSpace}px;
+
+	&::before {
+		@include oIconsGetIcon($iconOff, $colorOff, $iconSize, $iconset-version: 1);
+		content: ' ';
+		position: absolute;
+		top: 50%;
+		left: $horizontalMargin;
+		margin: $topMargin $horizontalMargin 0 0;
+	}
+
+	&[aria-pressed="true"]::before {
+		@include oIconsGetIcon($iconOn, $colorOn, $iconSize, $iconset-version: 1);
+	}
+
+	&[aria-pressed="true"]:hover::before {
+		@include oIconsGetIcon($iconOn, $colorOff, $iconSize, $iconset-version: 1);
+	}
+}

--- a/myft-common/main.scss
+++ b/myft-common/main.scss
@@ -1,30 +1,6 @@
 @import 'o-buttons/main';
 @import '../components/follow-button/main';
 
-@mixin buttonWithIcon($iconSpace, $iconSize, $colorOff, $iconOff, $iconOn: $iconOff, $colorOn: $colorOff) {
-	$topMargin: #{$iconSize * -0.5}px;
-	$horizontalMargin: #{($iconSpace - $iconSize) / 2}px;
-	position: relative;
-	padding-left: #{$iconSpace}px;
-
-	&::before {
-		@include oIconsGetIcon($iconOff, $colorOff, $iconSize, $iconset-version: 1);
-		content: ' ';
-		position: absolute;
-		top: 50%;
-		left: $horizontalMargin;
-		margin: $topMargin $horizontalMargin 0 0;
-	}
-
-	&[aria-pressed="true"]::before {
-		@include oIconsGetIcon($iconOn, $colorOn, $iconSize, $iconset-version: 1);
-	}
-
-	&[aria-pressed="true"]:hover::before {
-		@include oIconsGetIcon($iconOn, $colorOff, $iconSize, $iconset-version: 1);
-	}
-}
-
 @mixin nUiMyftCommon () {
 	.myft-ui,
 	.n-myft-ui {
@@ -61,18 +37,6 @@
 
 	.n-myft-ui__button--big {
 		@include oButtonsSize(big);
-	}
-
-	.n-myft-ui--instant {
-		position: relative;
-
-		.n-myft-ui__button {
-			@include buttonWithIcon(26, 24, getColor('teal-40'), 'mail', 'mail', getColor('white'));
-		}
-
-		.n-myft-ui__button--inverse {
-			@include buttonWithIcon(26, 24, getColor('teal-80'), 'mail', 'mail', getColor('white'));
-		}
 	}
 
 	.myft-ui__logo {


### PR DESCRIPTION
These styles are used by **next-myft-page** and **n-topic-card**. Both these import `n-myft-ui/myft/main.scss` which imports the instant-alert component styles - which is where these moved styles now live.

https://github.com/Financial-Times/n-topic-card/blob/master/main.scss#L1
https://github.com/Financial-Times/next-myft-page/blob/master/client/main.scss#L161