### PR TITLE
Remove redundant n-notification type

### DIFF
--- a/myft/ui/lists.js
+++ b/myft/ui/lists.js
@@ -37,7 +37,6 @@ function updateAfterAddToList (listId, contentId, wasAdded) {
 			}
 			nNotification.show({
 				content: message,
-				type: 'default',
 				trackable: 'myft-feedback-notification'
 			});
 		});


### PR DESCRIPTION
All `type: 'default'` does is cause this modifier class to be set on the notification: `n-notification--default` - and that's not used by anything.