### PR TITLE
Save button with icon: set alternate text into correct element

### DIFF
--- a/components/button/main.scss
+++ b/components/button/main.scss
@@ -32,7 +32,7 @@
 	width: $icon-size;
 	position: relative;
 
-	span {
+	.save-button-with-icon-copy {
 		position: absolute;
 		top: $icon-size - 5px;
 		left: 0;

--- a/demos/templates/demo.html
+++ b/demos/templates/demo.html
@@ -30,10 +30,10 @@
 				{{/saveButton}}
 
 				{{#saveButton}}
-				<h2 class="demo-section__title">
-					Save button with icon
-				</h2>
-				{{> n-myft-ui/myft/templates/save-for-later saveButtonWithIcon=true }}
+					<h2 class="demo-section__title">
+						Save button with icon
+					</h2>
+					{{> n-myft-ui/myft/templates/save-for-later saveButtonWithIcon=true }}
 				{{/saveButton}}
 
 				{{#saveButton}}

--- a/myft/templates/save-for-later.html
+++ b/myft/templates/save-for-later.html
@@ -12,7 +12,11 @@
 		data-alternate-label="Saved to myFT"
 		aria-pressed="false"
 		{{#unlessEquals appIsStreamPage true}}
-			data-text-variant="save-button-longer-copy"
+			{{#if saveButtonWithIcon}}
+				data-text-variant="save-button-with-icon-copy"
+			{{else}}
+				data-text-variant="save-button-longer-copy"
+			{{/if}}
 		{{/unlessEquals}}
 		{{#if alternateText}}
 			data-alternate-text="{{alternateText}}"
@@ -24,7 +28,7 @@
 		title="{{#if title}}Save {{title}} to myFT for later{{else}}Save this article to myFT for later{{/if}}"
 		>
 			{{#if saveButtonWithIcon}}
-				<span>{{#if buttonText}}{{buttonText}}{{else}}Save{{/if}}</span>
+				<span class="save-button-with-icon-copy" data-variant-label>{{#if buttonText}}{{buttonText}}{{else}}Save{{/if}}</span>
 			{{else}}
 				{{#if buttonText}}
 					{{buttonText}}

--- a/myft/templates/unsave-for-later.html
+++ b/myft/templates/unsave-for-later.html
@@ -9,6 +9,9 @@
 		type="submit"
 		class="{{#if saveButtonWithIcon}}n-myft-ui__save-button-with-icon{{else}}n-myft-ui__button{{#variant}} n-myft-ui__button--{{this}}{{/variant}}{{/if}}"
 		data-trackable="save-for-later"
+		{{#if saveButtonWithIcon}}
+			data-text-variant="save-button-with-icon-copy"
+		{{/if}}
 		data-alternate-label="Save to myFT"
 		data-alternate-text="Save"
 		data-content-id="{{contentId}}" {{! duplicated here for tracking}}
@@ -17,7 +20,7 @@
 		aria-pressed="true"
 	>
 		{{#if saveButtonWithIcon}}
-			<span>{{#if buttonText}}{{buttonText}}{{else}}Saved{{/if}}</span>
+			<span class="save-button-with-icon-copy" data-variant-label>{{#if buttonText}}{{buttonText}}{{else}}Saved{{/if}}</span>
 		{{else}}
 			{{#if buttonText}}{{buttonText}}{{else}}Saved{{/if}}
 		{{/if}}


### PR DESCRIPTION
 🐿 v2.10.2

Fix a bug which set alternate text into wrong element(directly into `button` not into `span`) after clicking save button.

```js
// before click
<button>
  <span>Save</span>
</button>
```
```js
// after click
<button>
  Saved
</button>
```
- add `data-text-variant` and `data-variant-label` which are needed to toggle the button correctly
https://github.com/Financial-Times/n-myft-ui/blob/master/myft-common/index.js#L16