### PR TITLE
upgrade n-gage to V2

### DIFF
--- a/.pa11yci.js
+++ b/.pa11yci.js
@@ -19,10 +19,8 @@ const urls = [
 
 const config = {
 	defaults: {
-		page: {
-			headers: {
-				'Cookie': 'next-flags=ads:off,cookieMessage:off; secure=true'
-			}
+		headers: {
+			'Cookie': 'next-flags=ads:off,cookieMessage:off; secure=true'
 		},
 		timeout: 25000,
 		rules: ['Principle1.Guideline1_3.1_3_1_AAA']
@@ -37,9 +35,7 @@ for (const viewport of viewports) {
 
 		config.urls.push({
 			url: url,
-			page: {
-				viewport: viewport
-			},
+			viewport: viewport,
 			screenCapture: `./pa11y_screenCapture/${path}.png`
 		});
 	}

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/Financial-Times/n-myft-ui#readme",
   "devDependencies": {
-    "@financial-times/n-gage": "^1.19.14",
+    "@financial-times/n-gage": "^2.0.0",
     "@financial-times/n-heroku-tools": "^6.19.0",
     "@financial-times/n-internal-tool": "^1.2.3",
     "@financial-times/n-webpack": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/Financial-Times/n-myft-ui#readme",
   "devDependencies": {
-    "@financial-times/n-gage": "^2.0.0",
+    "@financial-times/n-gage": "^2.0.4",
     "@financial-times/n-heroku-tools": "^6.19.0",
     "@financial-times/n-internal-tool": "^1.2.3",
     "@financial-times/n-webpack": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "node-sass": "^3.8.0",
     "nodemon": "^1.9.2",
     "npm-prepublish": "^1.2.1",
-    "pa11y-ci": "^0.3.0",
+    "pa11y-ci": "^2.1.0",
     "postcss-loader": "^0.9.1",
     "sass-loader": "^3.2.0",
     "semver": "^5.3.0",


### PR DESCRIPTION
 🐿 v2.10.2

Builds start failing, the detail is below.
Upgrade n-gage to V2 to fix this issue
> V2 uses Puppeteer for Pa11y tests instead of phantom - should be a lot more stable

https://circleci.com/gh/Financial-Times/n-myft-ui/1465
```
✓ demo-build done
warn:  event=EXPRESS_START, app=public, port=5005, nodeVersion=v8.11.4
Running Pa11y on 3 URLs:

 > http://localhost:5005/ - Failed to run
 > http://localhost:5005/ - Failed to run
 > http://localhost:5005/ - Failed to run

Errors in http://localhost:5005/:
 • Error: spawn /usr/local/bin/phantomjs ENOENT

✘ 0/3 URLs passed

Makefile:37: recipe for target 'a11y' failed
make[1]: *** [a11y] Error 2
make[1]: Leaving directory '/home/circleci/project/build'
Makefile:42: recipe for target 'test' failed
make: *** [test] Error 2
Exited with code 2
```