### PR TITLE
relationshipConfig is only source of truth for locating button elements in UI

### DIFF
--- a/components/collections/index.js
+++ b/components/collections/index.js
@@ -3,7 +3,7 @@ import relationshipConfigs from '../../myft/ui/lib/relationship-config';
 import * as buttonStates from '../../myft/ui/lib/button-states';
 import uuidv4 from '../../myft/ui/lib/uuid';
 
-const idProperty = relationshipConfigs['followed'].idProperty;
+const { idProperty } = relationshipConfigs.followed;
 
 function getConceptsData (formEl, rawFormData) {
 	const subjectIds = formEl.getAttribute(idProperty).split(',');

--- a/myft/ui/myft-buttons/enhance-action-urls.js
+++ b/myft/ui/myft-buttons/enhance-action-urls.js
@@ -1,12 +1,19 @@
+import relationshipConfig from '../lib/relationship-config';
+
 export default function (context = document) {
-	['follow', 'save', 'instant']
-		.forEach(type => {
-			Array.from(context.querySelectorAll(`form.n-myft-ui--${type}`))
+	[
+		relationshipConfig.followed.uiSelector,
+		relationshipConfig.saved.uiSelector,
+		'[data-myft-ui="instant"]'
+	]
+		.forEach(selector => {
+			Array.from(context.querySelectorAll(selector))
 				.forEach(form => {
-					const action = form.getAttribute('data-js-action');
-					if (!action) return;
-					form.setAttribute('method', 'POST');
-					form.setAttribute('action', action);
+					if (form.dataset.jsAction) {
+						form.setAttribute('method', 'POST');
+						form.setAttribute('action', form.dataset.jsAction);
+						delete form.dataset.jsAction;
+					}
 				});
 		});
 }

--- a/myft/ui/myft-buttons/init.js
+++ b/myft/ui/myft-buttons/init.js
@@ -26,14 +26,14 @@ function anonEventListeners () {
 	const subscribeUrl = '/products?segID=400863&segmentID=190b4443-dc03-bd53-e79b-b4b6fbd04e64';
 	const signInLink = `/login${currentPath.length ? `?location=${currentPath}` : ''}`;
 	const messages = {
-		follow: `Please <a href="${subscribeUrl}" data-trackable="Subscribe">subscribe</a> or <a href="${signInLink}" data-trackable="Sign In">sign in</a> to add this topic to myFT.`,
-		save: `Please <a href="${subscribeUrl}" data-trackable="Subscribe">subscribe</a> or <a href="${signInLink}" data-trackable="Sign In">sign in</a> to save this article.`
+		followed: `Please <a href="${subscribeUrl}" data-trackable="Subscribe">subscribe</a> or <a href="${signInLink}" data-trackable="Sign In">sign in</a> to add this topic to myFT.`,
+		saved: `Please <a href="${subscribeUrl}" data-trackable="Subscribe">subscribe</a> or <a href="${signInLink}" data-trackable="Sign In">sign in</a> to save this article.`
 	};
-	const actions = ['follow', 'save'];
 
-	actions.forEach(action => {
-		delegate.on('submit', `.n-myft-ui--${action}`, event => {
+	['followed', 'saved'].forEach(action => {
+		delegate.on('submit', relationshipConfig[action].uiSelector, event => {
 			event.preventDefault();
+
 			nNotification.show({
 				content: messages[action],
 				trackable: 'myft-anon'


### PR DESCRIPTION
Previously, a few places used the `n-myft-ui--{action}` css class to locate UI elements, and some places used the `uiSelector` property from the config.

This PR makes everywhere consistently use `uiSelector` config property.

The `n-myft-ui--{action}` CSS class remain only for styling purposes.