### PR TITLE
Remove proxy entry point for instant alert javascript

### DIFF
--- a/myft/index.js
+++ b/myft/index.js
@@ -1,5 +1,4 @@
 module.exports = {
 	client: require('next-myft-client'),
-	ui: require('./ui'),
-	uiInstant: require('../components/instant-alert')
+	ui: require('./ui')
 };


### PR DESCRIPTION
Consumers should import the Instant Alert script directly from `n-myft-ui/components/instant-alert`.

Places it's called:
https://github.com/search?q=org%3AFinancial-Times+uiInstant&type=Code

This can be merged once the following have been merged:
https://github.com/Financial-Times/next-front-page/pull/1916
https://github.com/Financial-Times/next-myft-page/pull/1888
https://github.com/Financial-Times/next-stream-page/pull/2051