### PR TITLE
Separate pin button init from general myft-ui init

### DIFF
--- a/components/pin-button/index.js
+++ b/components/pin-button/index.js
@@ -33,13 +33,17 @@ const togglePrioritised = (conceptId, prioritised) => {
 };
 
 export default () => {
-	delegate.on('click', 'button[data-prioritise-button]', event => {
-		event.preventDefault();
+	myftApiClient.init()
+		.then(() => {
+			delegate.off();
+			delegate.on('click', 'button[data-prioritise-button]', event => {
+				event.preventDefault();
 
-		const { conceptId, prioritised } = event.target.dataset;
-		const wrapper = findAncestor(event.target, 'myft-pin-button-wrapper');
+				const { conceptId, prioritised } = event.target.dataset;
+				const wrapper = findAncestor(event.target, 'myft-pin-button-wrapper');
 
-		setLoading(wrapper);
-		togglePrioritised(conceptId, prioritised === 'true');
-	});
+				setLoading(wrapper);
+				togglePrioritised(conceptId, prioritised === 'true');
+			});
+		});
 };

--- a/myft/ui/myft-buttons/init.js
+++ b/myft/ui/myft-buttons/init.js
@@ -1,4 +1,3 @@
-import myftApiClient from 'next-myft-client';
 import * as buttonStates from '../lib/button-states';
 import * as tracking from '../lib/tracking';
 import * as loadedRelationships from '../lib/loaded-relationships';
@@ -8,7 +7,6 @@ import nNotification from 'n-notification';
 import Delegate from 'ftdomdelegate';
 import personaliseLinks from '../personalise-links';
 import doFormSubmit from './do-form-submit';
-import initPinButtons from '../../../components/pin-button';
 import enhanceActionUrls from './enhance-action-urls';
 
 const delegate = new Delegate(document.body);
@@ -84,15 +82,12 @@ export default function (opts) {
 	if (!initialised) {
 		initialised = true;
 		enhanceActionUrls();
+
 		if (opts && opts.anonymous) {
 			anonEventListeners();
 		} else {
 			signedInEventListeners();
 			personaliseLinks();
-
-			if (opts.flags && opts.flags.get('myftPrioritiseTopics')) {
-				myftApiClient.init().then(() => initPinButtons());
-			}
 		}
 	}
 }


### PR DESCRIPTION
* Make pin button init safe to call multiple times
* Pin button init will init `next-myft-client` itself (which is safe to do multiple times)
* myft-buttons init will no longer init the pin-buttons - consumers will need to do that explicitly

Fixes #241 

**Breaking change!** Consumers of `n-myft-ui` that need pin buttons will need to call `n-myft-ui/components/pin-button/index.js` default export explicitly.