### PR TITLE
Integration for x-article-save-button

### DIFF
--- a/components/article-save-button/index.js
+++ b/components/article-save-button/index.js
@@ -1,0 +1,57 @@
+import nextMyftClient from 'next-myft-client';
+
+const loadSavedArticles = () => {
+	return nextMyftClient.init()
+		.then(() => {
+			if (!nextMyftClient.loaded['saved.content']) {
+				nextMyftClient.load({
+					relationship: 'saved',
+					type: 'content'
+				});
+			}
+		});
+};
+
+const listenForApiSaveEvents = () => {
+	document.body.addEventListener('myft.user.saved.content.load', () => {
+		nextMyftClient.loaded['saved.content'].items.map(item => setButtonState(item.uuid, true));
+	});
+	document.body.addEventListener('myft.user.saved.content.add', ({ detail }) => setButtonState(detail.subject, true));
+	document.body.addEventListener('myft.user.saved.content.remove', ({ detail }) => setButtonState(detail.subject, false));
+};
+
+const listenForSaveButtonClicks = () => {
+	document.body.addEventListener('x-article-save-button', ({ detail }) => {
+		const formData = {
+			token: detail.token
+		};
+
+		nextMyftClient[detail.action](detail.actorType, detail.actorId, detail.relationshipName, detail.subjectType, detail.subjectId, formData);
+	});
+};
+
+const setButtonState = (id, saved) => {
+	const event = new CustomEvent('x-interaction.trigger-action', {
+		detail: {
+			action: saved ? 'saved' : 'unsaved'
+		}
+	});
+	const buttonsForContentId = Array.from(document.querySelectorAll(`form[data-content-id="${id}"]`));
+
+	buttonsForContentId.forEach(el => el.dispatchEvent(event));
+};
+
+let initialised = false;
+
+module.exports = {
+	init: () => {
+		if (initialised) {
+			return Promise.resolve();
+		}
+
+		initialised = true;
+		listenForApiSaveEvents();
+		listenForSaveButtonClicks();
+		return loadSavedArticles();
+	}
+};

--- a/components/article-save-button/index.js
+++ b/components/article-save-button/index.js
@@ -38,7 +38,7 @@ const setButtonState = (id, saved) => {
 	});
 	const buttonsForContentId = Array.from(document.querySelectorAll(`form[data-content-id="${id}"]`));
 
-	buttonsForContentId.forEach(el => el.dispatchEvent(event));
+	buttonsForContentId.forEach(el => el.parentNode.dispatchEvent(event));
 };
 
 let initialised = false;

--- a/test/article-save-button.spec.js
+++ b/test/article-save-button.spec.js
@@ -1,0 +1,134 @@
+/* global expect */
+import sinon from 'sinon';
+
+const injector = require('inject-loader!../components/article-save-button');
+
+const createSaveButtonMock = contentId => {
+	const form = document.createElement('form');
+
+	form.setAttribute('data-content-id', contentId);
+
+	return {
+		id: contentId,
+		el: form
+	};
+};
+
+const dispatchBodyEvent = (name, detail = {}) => document.body.dispatchEvent(new CustomEvent(name, { detail }));
+
+describe('article-save-button', () => {
+	let articleSaveButton;
+	let mockClient;
+	let mockButtons;
+
+	beforeEach(() => {
+		mockButtons = [
+			createSaveButtonMock('content-id-1'),
+			createSaveButtonMock('content-id-2')
+		];
+		mockButtons.forEach(button => document.body.appendChild(button.el));
+		mockClient = {
+			init: sinon.stub().returns(Promise.resolve()),
+			load: sinon.stub(),
+			loaded: {}
+		};
+		articleSaveButton = injector({
+			'next-myft-client': mockClient
+		});
+	});
+
+	afterEach(() => {
+		mockButtons.forEach(buttonMock => buttonMock.el.remove());
+	});
+
+	describe('handling myFT client load of saved content', () => {
+		beforeEach(() => {
+			mockClient.loaded = {
+				'saved.content': {
+					items: [
+						{ uuid: mockButtons[0].id }
+					]
+				}
+			};
+			articleSaveButton.init();
+		});
+
+		it('should init the myft client', () => {
+			expect(mockClient.init).to.have.been.called;
+		});
+
+		it('should set states of any buttons found in page', done => {
+			mockButtons[0].el.addEventListener('x-interaction.trigger-action', event => {
+				expect(event.detail).to.deep.equal({ action: 'saved' });
+				done();
+			});
+
+			dispatchBodyEvent('myft.user.saved.content.load');
+		});
+	});
+
+	describe('handling myFT client save event', () => {
+		beforeEach(() => {
+			return articleSaveButton.init();
+		});
+
+		it('should set states of any buttons found in page', done => {
+			mockButtons[0].el.addEventListener('x-interaction.trigger-action', event => {
+				expect(event.detail).to.deep.equal({ action: 'saved' });
+				done();
+			});
+
+			dispatchBodyEvent('myft.user.saved.content.add', { subject: mockButtons[0].id });
+		});
+	});
+
+	describe('handling myFT client unsaved event', () => {
+		beforeEach(() => {
+			return articleSaveButton.init();
+		});
+
+		it('should set states of any buttons found in page', done => {
+			mockButtons[0].el.addEventListener('x-interaction.trigger-action', event => {
+				expect(event.detail).to.deep.equal({ action: 'unsaved' });
+				done();
+			});
+
+			dispatchBodyEvent('myft.user.saved.content.remove', { subject: mockButtons[0].id });
+		});
+	});
+
+	describe('initialise and load next myFT client', () => {
+		describe('and the saved articles have not yet been loaded', () => {
+			beforeEach(() => {
+				mockClient.loaded = {};
+				return articleSaveButton.init();
+			});
+
+			it('should init the myft client', () => {
+				expect(mockClient.init).to.have.been.called;
+			});
+
+			it('should load saved content', () => {
+				expect(mockClient.load).to.have.been.calledWith({
+					relationship: 'saved',
+					type: 'content'
+				});
+			});
+		});
+
+		describe('and the saved articles have been loaded', () => {
+			beforeEach(() => {
+				mockClient.loaded = { 'saved.content': {} };
+				return articleSaveButton.init();
+			});
+
+			it('should init the myft client', () => {
+				expect(mockClient.init).to.have.been.called;
+			});
+
+			it('should not load saved content', () => {
+				expect(mockClient.load).to.not.have.been.called;
+			});
+		});
+	});
+});

--- a/test/article-save-button.spec.js
+++ b/test/article-save-button.spec.js
@@ -4,13 +4,15 @@ import sinon from 'sinon';
 const injector = require('inject-loader!../components/article-save-button');
 
 const createSaveButtonMock = contentId => {
+	const xInteractionWrapper = document.createElement('div');
 	const form = document.createElement('form');
 
 	form.setAttribute('data-content-id', contentId);
+	xInteractionWrapper.appendChild(form);
 
 	return {
 		id: contentId,
-		el: form
+		el: xInteractionWrapper
 	};
 };
 


### PR DESCRIPTION
This code will:

1. Initialise **next-myft-client**
2. Load `saved.content` into the client (if it's not already loaded)
3. Set initial states of any **x-article-save-button**s when `saved.content` has loaded
4. Listen for **x-article-save-button** clicks and perform the save/unsave action using **next-myft-client** 
5. Listen for events from **next-myft-client** and set the **x-article-save-button** button state accordingly

The consumer app is expected to import the **x-article-save-button** code and to `hydrate` the client-side instances.

It will work alongside any legacy **n-myft-ui** save buttons

**Tracking is dependent on legacy button code**

Currently, the tracking of saves/unsaves using these new buttons is handled by the legacy **n-myft-ui** button code: https://github.com/Financial-Times/n-myft-ui/blob/article-save-button/myft/ui/myft-buttons/init.js#L63

Once all article save buttons have been migrated to **x-article-save-button**, then tracking should be added to this new integration code, and the legacy code changed to not handle saving any more.