### PR TITLE
Fix word-break in concept-list

### DIFF
--- a/components/concept-list/main.scss
+++ b/components/concept-list/main.scss
@@ -34,7 +34,7 @@
 }
 
 .concept-list__concept {
-	word-break: break-all;
+	word-break: keep-all;
 	@include oTypographyTopic;
 	@include oTypographySans(0);
 	@include oTypographyMargin($top: 1, $bottom: 1);


### PR DESCRIPTION
## What

Based on the issue
https://trello.com/c/riNfp87l/400-break-word-issue-on-side-concept-list

### Before
![screen shot 2018-10-16 at 14 26 18](https://user-images.githubusercontent.com/10063385/47019696-978caa80-d14f-11e8-88fe-a803329bc85a.png)

### After
![screen shot 2018-10-16 at 14 26 56](https://user-images.githubusercontent.com/10063385/47019709-9d828b80-d14f-11e8-8996-09726e624de0.png)

### Browser support
https://developer.mozilla.org/en-US/docs/Web/CSS/word-break

