### PR TITLE
Use VoltDB for cross-device last visited time

### DIFF
--- a/components/unread-articles-indicator/api.js
+++ b/components/unread-articles-indicator/api.js
@@ -1,19 +1,24 @@
+import sessionClient from 'next-session-client';
 import { json as fetchJson } from 'fetchres';
 const removeLineBreaks = str => encodeURIComponent(str.replace(/\s+/g, ' '));
 
-export const fetchUserLastVisitedAt = (uuid) => {
-	const gqlQuery = `
-		query userLastVisitedAt($uuid: String!) {
-			user(uuid: $uuid) {
-				lastSeenTimestamp
-			}
-		}
-		`;
-	const variables = { uuid };
-	const url = `https://next-api.ft.com/v2/query?query=${removeLineBreaks(gqlQuery)}&variables=${JSON.stringify(variables)}&source=next-myft`;
-	const options = { credentials: 'include' };
+export const fetchUserLastVisitedAt = () => {
+	return sessionClient.uuid()
+		.then(({ uuid }) => uuid)
+		.then(uuid => {
+			const gqlQuery = `
+				query userLastVisitedAt($uuid: String!) {
+					user(uuid: $uuid) {
+						lastSeenTimestamp
+					}
+				}
+			`;
+			const variables = { uuid };
+			const url = `https://next-api.ft.com/v2/query?query=${removeLineBreaks(gqlQuery)}&variables=${JSON.stringify(variables)}&source=next-myft`;
+			const options = { credentials: 'include' };
 
-	return fetch(url, options)
+			return fetch(url, options);
+		})
 		.then(fetchJson)
 		.then(body => body.data)
 		.then(data => data.user.lastSeenTimestamp)

--- a/components/unread-articles-indicator/api.js
+++ b/components/unread-articles-indicator/api.js
@@ -1,0 +1,21 @@
+import { json as fetchJson } from 'fetchres';
+const removeLineBreaks = str => encodeURIComponent(str.replace(/\s+/g, ' '));
+
+export const fetchUserLastVisitedAt = (uuid) => {
+	const gqlQuery = `
+		query userLastVisitedAt($uuid: String!) {
+			user(uuid: $uuid) {
+				lastSeenTimestamp
+			}
+		}
+		`;
+	const variables = { uuid };
+	const url = `https://next-api.ft.com/v2/query?query=${removeLineBreaks(gqlQuery)}&variables=${JSON.stringify(variables)}&source=next-myft`;
+	const options = { credentials: 'include' };
+
+	return fetch(url, options)
+		.then(fetchJson)
+		.then(body => body.data)
+		.then(data => data.user.lastSeenTimestamp)
+		.catch(() => Promise.resolve(null));
+};

--- a/components/unread-articles-indicator/chronology.js
+++ b/components/unread-articles-indicator/chronology.js
@@ -9,22 +9,20 @@ const deviceSession = new DeviceSession();
  * @param {string} uuid  User uuid
  * @return {string} ISO date when we now determine articles to be 'new' for the user
  */
-export const determineNewArticlesSinceTime = (userNewArticlesSince, uuid) => {
-
+export const determineNewArticlesSinceTime = userNewArticlesSince => {
 	if (isToday(userNewArticlesSince) && !deviceSession.isNewSession()) {
 		return Promise.resolve(userNewArticlesSince);
 	}
 
 	const earliestNewArticlesSince = startOfDay(new Date()).toISOString();
 
-	return fetchUserLastVisitedAt(uuid)
+	return fetchUserLastVisitedAt()
 		.then(userLastVisitedAt => {
 			return isToday(userLastVisitedAt) ? userLastVisitedAt : earliestNewArticlesSince;
 		})
 		.catch(() => {
 			return earliestNewArticlesSince;
 		});
-
 };
 
 export const filterArticlesToNewSinceTime = (articles, publishedAfterTime) => {

--- a/components/unread-articles-indicator/chronology.js
+++ b/components/unread-articles-indicator/chronology.js
@@ -1,30 +1,30 @@
-import { differenceInMinutes, isAfter, startOfDay } from 'date-fns';
+import { isAfter, isToday, startOfDay } from 'date-fns';
+import { fetchUserLastVisitedAt } from './api';
+import DeviceSession from './device-session';
 
-const SAME_VISIT_THRESHOLD_MINUTES = 30;
-
-const isValidPublishedSince = (dateToValidate, defaultPublishedSince) => {
-	return typeof dateToValidate === 'string' && isAfter(dateToValidate, defaultPublishedSince);
-};
-
-const dateIsWithinSameVisitThreshold = date => differenceInMinutes(new Date(), date) <= SAME_VISIT_THRESHOLD_MINUTES;
+const deviceSession = new DeviceSession();
 
 /**
- * @param {string} userLastVisitedAt    ISO date representing when a user last visited ft.com
  * @param {string} userNewArticlesSince  ISO date representing the time we last used to determine if articles are new for the user
+ * @param {string} uuid  User uuid
  * @return {string} ISO date when we now determine articles to be 'new' for the user
  */
-export const determineNewArticlesSinceTime = (userLastVisitedAt, userNewArticlesSince) => {
+export const determineNewArticlesSinceTime = (userNewArticlesSince, uuid) => {
+
+	if (isToday(userNewArticlesSince) && !deviceSession.isNewSession()) {
+		return Promise.resolve(userNewArticlesSince);
+	}
+
 	const earliestNewArticlesSince = startOfDay(new Date()).toISOString();
 
-	if (!isValidPublishedSince(userLastVisitedAt, earliestNewArticlesSince)) {
-		return earliestNewArticlesSince;
-	}
+	return fetchUserLastVisitedAt(uuid)
+		.then(userLastVisitedAt => {
+			return isToday(userLastVisitedAt) ? userLastVisitedAt : earliestNewArticlesSince;
+		})
+		.catch(() => {
+			return earliestNewArticlesSince;
+		});
 
-	if (dateIsWithinSameVisitThreshold(userLastVisitedAt)) {
-		return isValidPublishedSince(userNewArticlesSince, earliestNewArticlesSince) ? userNewArticlesSince : earliestNewArticlesSince;
-	} else {
-		return userLastVisitedAt;
-	}
 };
 
 export const filterArticlesToNewSinceTime = (articles, publishedAfterTime) => {

--- a/components/unread-articles-indicator/device-session.js
+++ b/components/unread-articles-indicator/device-session.js
@@ -1,0 +1,23 @@
+import { isAfter, addMinutes } from 'date-fns';
+import * as storage from './storage';
+const SESSION_THRESHOLD_MINUTES = 30;
+
+class DeviceSession {
+
+	constructor () {
+		this.expiry = storage.getDeviceSessionExpiry();
+		const newExpiry = addMinutes(new Date(), SESSION_THRESHOLD_MINUTES).toISOString();
+		storage.setDeviceSessionExpiry(newExpiry);
+	}
+
+	isNewSession () {
+		if (this.expiry) {
+			return isAfter(new Date(), this.expiry);
+		} else {
+			return true;
+		}
+	}
+
+}
+
+module.exports = DeviceSession;

--- a/components/unread-articles-indicator/fetch-new-articles.js
+++ b/components/unread-articles-indicator/fetch-new-articles.js
@@ -1,3 +1,4 @@
+import sessionClient from 'next-session-client';
 import { json as fetchJson } from 'fetchres';
 import { isAfter } from 'date-fns';
 
@@ -54,8 +55,10 @@ const extractArticlesFromSinceTime = (articles, since) => {
 	return articles.filter(article => isAfter(article.contentTimeStamp, since));
 };
 
-export default function (uuid, since) {
-	return Promise.all([readingHistory(uuid), contentFromPersonalisedFeed(uuid)])
+export default since => {
+	return sessionClient.uuid()
+		.then(({ uuid }) => uuid)
+		.then(uuid => Promise.all([readingHistory(uuid), contentFromPersonalisedFeed(uuid)]))
 		.then(([readingHistory, userFeedLast24Hours]) => decorateWithHasBeenRead(readingHistory, userFeedLast24Hours))
 		.then(articles => extractArticlesFromSinceTime(articles, since));
 };

--- a/components/unread-articles-indicator/index.js
+++ b/components/unread-articles-indicator/index.js
@@ -59,12 +59,11 @@ export default () => {
 	});
 
 	return getNewArticlesSinceTime()
-		.then((newArticlesSinceTime) => showUnreadArticlesCount(newArticlesSinceTime, true))
+		.then(newArticlesSinceTime => showUnreadArticlesCount(newArticlesSinceTime, true))
 		.then(() => {
 			document.addEventListener('visibilitychange', () => {
 				if (document.visibilityState === 'visible') {
-					getNewArticlesSinceTime()
-						.then((newArticlesSinceTime) => showUnreadArticlesCount(newArticlesSinceTime));
+					getNewArticlesSinceTime().then(showUnreadArticlesCount);
 				}
 			});
 		});

--- a/components/unread-articles-indicator/index.js
+++ b/components/unread-articles-indicator/index.js
@@ -34,9 +34,9 @@ const showUnreadArticlesCount = ({ uuid, newArticlesSinceTime, withTracking = fa
 
 let newArticlesSinceTime;
 
-export const getNewArticlesSinceTime = (uuid) => {
+export const getNewArticlesSinceTime = () => {
 	if (!newArticlesSinceTime) {
-		return determineNewArticlesSinceTime(storage.getNewArticlesSinceTime(), uuid)
+		return determineNewArticlesSinceTime(storage.getNewArticlesSinceTime())
 			.then(timestamp => {
 				storage.setNewArticlesSinceTime(timestamp);
 				newArticlesSinceTime = timestamp;
@@ -60,7 +60,7 @@ export default () => {
 	});
 
 	const userIdPromise = sessionClient.uuid().then(({ uuid }) => uuid);
-	const newArticleSincePromise = userIdPromise.then(getNewArticlesSinceTime);
+	const newArticleSincePromise = getNewArticlesSinceTime();
 
 	return Promise.all([userIdPromise, newArticleSincePromise])
 		.then(([uuid, newArticlesSinceTime]) => showUnreadArticlesCount({

--- a/components/unread-articles-indicator/storage.js
+++ b/components/unread-articles-indicator/storage.js
@@ -1,4 +1,4 @@
-const LAST_VISITED_AT = 'lastVisitedAt';
+const DEVICE_SESSION_EXPIRY = 'deviceSessionExpiry';
 const NEW_ARTICLES_SINCE = 'newArticlesSinceTime';
 const INDICATOR_DISMISSED_AT = 'myFTIndicatorDismissedAt';
 
@@ -11,9 +11,9 @@ const getTimestampItemAsIsoDate = key => {
 	return !item || isNaN(timestamp) ? null : timestampToIsoDate(timestamp);
 };
 
-export const getLastVisitedAt = () => getTimestampItemAsIsoDate(LAST_VISITED_AT);
+export const getDeviceSessionExpiry = () => getTimestampItemAsIsoDate(DEVICE_SESSION_EXPIRY);
 
-export const setLastVisitedAt = () => window.localStorage.setItem(LAST_VISITED_AT, String(Date.now()));
+export const setDeviceSessionExpiry = isoDate => window.localStorage.setItem(DEVICE_SESSION_EXPIRY, String(new Date(isoDate).getTime()));
 
 export const getNewArticlesSinceTime = () => getTimestampItemAsIsoDate(NEW_ARTICLES_SINCE);
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/Financial-Times/n-myft-ui#readme",
   "devDependencies": {
-    "@financial-times/n-gage": "^2.0.4",
+    "@financial-times/n-gage": "^2.1.2",
     "@financial-times/n-heroku-tools": "^6.19.0",
     "@financial-times/n-internal-tool": "^1.2.3",
     "@financial-times/n-webpack": "^3.0.2",
@@ -67,7 +67,7 @@
     "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "^3.0.0",
     "lintspaces-cli": "^0.6.0",
-    "lolex": "^1.5.0",
+    "lolex": "^3.0.0",
     "mocha": "^3.4.1",
     "mockery": "^1.7.0",
     "node-fetch": "^1.6.0",
@@ -78,8 +78,8 @@
     "postcss-loader": "^0.9.1",
     "sass-loader": "^3.2.0",
     "semver": "^5.3.0",
-    "sinon": "^2.2.0",
-    "sinon-chai": "^2.10.0"
+    "sinon": "^7.1.0",
+    "sinon-chai": "^3.2.0"
   },
   "dependencies": {
     "date-fns": "^1.29.0",

--- a/test/unread-articles-indicator/chronology.spec.js
+++ b/test/unread-articles-indicator/chronology.spec.js
@@ -1,100 +1,131 @@
 /* global expect */
 
 import sinon from 'sinon';
-import { addMinutes } from 'date-fns';
-import { determineNewArticlesSinceTime, filterArticlesToNewSinceTime } from '../../components/unread-articles-indicator/chronology';
+import dateFns from 'date-fns';
 
-const clientTimezoneOffset = new Date().getTimezoneOffset();
-const toLocal = date => addMinutes(date, clientTimezoneOffset).toISOString();
+const toLocal = date => dateFns.addMinutes(date, new Date().getTimezoneOffset()).toISOString();
 
 const SOME_TIME_YESTERDAY = '2018-06-01T12:00:00.000Z';
 const EARLIEST_NEW_ARTICLES_TIME = '2018-06-02T00:00:00.000Z';
 const TODAY_0600 = '2018-06-02T06:00:00.000Z';
-const TODAY_0700 = '2018-06-02T07:00:00.000Z';
+const TODAY_0750 = '2018-06-02T07:50:00.000Z';
 const TODAY_0800 = '2018-06-02T08:00:00.000Z';
 const TODAY_0801 = '2018-06-02T08:01:00.000Z';
 const TODAY_1000 = '2018-06-02T10:00:00.000Z';
 
+const uuid = 'user-id';
+
 describe('chronology', () => {
 	let clock;
-	let timeNow;
 	let userLastVisitedAt;
 	let userNewArticlesSince;
+	let isNewSession;
+
+	const subjectInjector = require('inject-loader!../../components/unread-articles-indicator/chronology');
+	const subject = subjectInjector({
+		'date-fns': dateFns,
+		'./api': {
+			fetchUserLastVisitedAt: sinon.stub().callsFake(() => Promise.resolve(userLastVisitedAt))
+		},
+		'./device-session': sinon.stub().callsFake(() => ({ isNewSession: () => isNewSession }))
+	});
+
+	const determineNewArticlesSinceTime = subject.determineNewArticlesSinceTime;
+	const filterArticlesToNewSinceTime = subject.filterArticlesToNewSinceTime;
+	const setFakeClock = time => sinon.useFakeTimers({ now: new Date(time), shouldAdvanceTime: true });
 
 	afterEach(() => {
+		userLastVisitedAt = undefined;
+		userNewArticlesSince = undefined;
+		isNewSession = undefined;
 		clock.restore();
 	});
 
 	describe('determineNewArticlesSinceTime', () => {
+
 		describe('given the user is visiting for the first time today', () => {
 			beforeEach(() => {
 				userLastVisitedAt = SOME_TIME_YESTERDAY;
 				userNewArticlesSince = SOME_TIME_YESTERDAY;
-				timeNow = new Date(TODAY_0800);
-				clock = sinon.useFakeTimers(timeNow);
+				isNewSession = true;
+				clock = setFakeClock(TODAY_0800);
 			});
 
 			it('should return the EARLIEST_NEW_ARTICLES_TIME', () => {
-				const newArticlesSinceTime = determineNewArticlesSinceTime(userLastVisitedAt, userNewArticlesSince);
-
-				expect(newArticlesSinceTime).to.equal(toLocal(EARLIEST_NEW_ARTICLES_TIME));
+				return determineNewArticlesSinceTime(userNewArticlesSince, uuid)
+					.then(newArticlesSinceTime => {
+						expect(newArticlesSinceTime).to.equal(toLocal(EARLIEST_NEW_ARTICLES_TIME));
+					});
 			});
 		});
 
-		describe('given the user has visited today and returns within the same-visit threshold', () => {
+		describe('given the user has visited today', () => {
 			beforeEach(() => {
 				userLastVisitedAt = TODAY_0800;
-				userNewArticlesSince = TODAY_0700;
-				timeNow = new Date(TODAY_0801);
-				clock = sinon.useFakeTimers(timeNow);
+				userNewArticlesSince = TODAY_0750;
 			});
 
-			describe('and there is a valid userNewArticlesSince time set', () => {
+			describe('and returns within the device session', () => {
 				it('should return the userNewArticlesSince time', () => {
-					const newArticlesSinceTime = determineNewArticlesSinceTime(userLastVisitedAt, userNewArticlesSince);
+					isNewSession = false;
+					clock = setFakeClock(TODAY_0801);
 
-					expect(newArticlesSinceTime).to.equal(userNewArticlesSince);
+					return determineNewArticlesSinceTime(userNewArticlesSince, uuid)
+						.then(newArticlesSinceTime => {
+							expect(newArticlesSinceTime).to.equal(userNewArticlesSince);
+						});
 				});
 			});
 
-			describe('and there is no (or an invalid) userNewArticlesSince time set', () => {
-				it('should return the EARLIEST_NEW_ARTICLES_TIME', () => {
-					const newArticlesSinceTime = determineNewArticlesSinceTime(userLastVisitedAt, null);
+			describe('and returns after the device session', () => {
+				beforeEach(() => {
+					isNewSession = true;
+					clock = setFakeClock(TODAY_1000);
+				});
 
+				it('should return the userLastVisitedAt time', () => {
+					return determineNewArticlesSinceTime(userNewArticlesSince, uuid)
+						.then(newArticlesSinceTime => {
+							expect(newArticlesSinceTime).to.equal(userLastVisitedAt);
+						});
+				});
+
+				it('should return the EARLIEST_NEW_ARTICLES_TIME if userLastVisitedAt is invalid', () => {
+					userLastVisitedAt = null;
+
+					return determineNewArticlesSinceTime(userNewArticlesSince, uuid)
+					.then(newArticlesSinceTime => {
+						expect(newArticlesSinceTime).to.equal(toLocal(EARLIEST_NEW_ARTICLES_TIME));
+					});
+				});
+
+			});
+		});
+
+		describe('given there is no (or invalid) userNewArticlesSince time set', () => {
+			beforeEach(() => {
+				clock = setFakeClock(TODAY_0801);
+			});
+
+			it('should return the userLastVisitedAt time if userLastVisitedAt is today', () => {
+				userLastVisitedAt = TODAY_0800;
+
+				return determineNewArticlesSinceTime(null, uuid)
+				.then(newArticlesSinceTime => {
+					expect(newArticlesSinceTime).to.equal(userLastVisitedAt);
+				});
+			});
+
+			it('should return the EARLIEST_NEW_ARTICLES_TIME if userLastVisitedAt is not today', () => {
+				userLastVisitedAt = SOME_TIME_YESTERDAY;
+
+				return determineNewArticlesSinceTime(null, uuid)
+				.then(newArticlesSinceTime => {
 					expect(newArticlesSinceTime).to.equal(toLocal(EARLIEST_NEW_ARTICLES_TIME));
 				});
 			});
 		});
 
-		describe('given the user has visited today and returns after the same-visit threshold', () => {
-			beforeEach(() => {
-				userLastVisitedAt = TODAY_0800;
-				userNewArticlesSince = TODAY_0600;
-				timeNow = new Date(TODAY_1000);
-				clock = sinon.useFakeTimers(timeNow);
-			});
-
-			it('should return the userLastVisitedAt time', () => {
-				const newArticlesSinceTime = determineNewArticlesSinceTime(userLastVisitedAt, userNewArticlesSince);
-
-				expect(newArticlesSinceTime).to.equal(userLastVisitedAt);
-			});
-
-		});
-
-		describe('given there is an invalid userLastVisited time set', () => {
-			beforeEach(() => {
-				userNewArticlesSince = TODAY_0600;
-				timeNow = new Date(TODAY_1000);
-				clock = sinon.useFakeTimers(timeNow);
-			});
-
-			it('should return the EARLIEST_NEW_ARTICLES_TIME', () => {
-				const newArticlesSinceTime = determineNewArticlesSinceTime(null, userNewArticlesSince);
-
-				expect(newArticlesSinceTime).to.equal(toLocal(EARLIEST_NEW_ARTICLES_TIME));
-			});
-		});
 	});
 
 	describe('filterArticlesToNewSinceTime', () => {

--- a/test/unread-articles-indicator/device-session.spec.js
+++ b/test/unread-articles-indicator/device-session.spec.js
@@ -1,0 +1,98 @@
+/* global expect */
+import sinon from 'sinon';
+import dateFns from 'date-fns';
+const sandbox = sinon.sandbox.create();
+
+const expiryTimestamp = '2018-06-14T12:00:00.000Z';
+const timestampBeforeExpiry = '2018-06-14T11:40:00.000Z';
+const timestampAfterExpiry = '2018-06-14T12:10:00.000Z';
+
+const SESSION_THRESHOLD_MINUTES = 30;
+
+describe('DeviceSession', () => {
+
+	let clock;
+	let deviceSession;
+	let deviceSessionExpiry;
+
+	const mockStorage = {
+		getDeviceSessionExpiry: sandbox.stub().callsFake(() => deviceSessionExpiry),
+		setDeviceSessionExpiry: sandbox.spy()
+	};
+
+	const subjectInjector = require('inject-loader!../../components/unread-articles-indicator/device-session');
+	const DeviceSession = subjectInjector({
+		'date-fns': dateFns,
+		'./storage': mockStorage
+	});
+
+	afterEach(() => {
+		deviceSessionExpiry = undefined;
+		clock.restore();
+		sandbox.resetHistory();
+	});
+
+	describe('constructor:', () => {
+
+		const timeNow = timestampBeforeExpiry;
+
+		beforeEach(() => {
+			clock = sinon.useFakeTimers(new Date(timeNow));
+			deviceSessionExpiry = expiryTimestamp;
+			deviceSession = new DeviceSession();
+		});
+
+		it('should set this.expiry a timestamp from localStorage', () => {
+			expect(mockStorage.getDeviceSessionExpiry).to.have.been.calledOnce;
+			expect(deviceSession.expiry).to.equal(expiryTimestamp);
+		});
+
+		it('should call storage.setDeviceSessionExpiry with correct timestamp', () => {
+			const correctTimestamp = dateFns.addMinutes(timeNow, SESSION_THRESHOLD_MINUTES).toISOString();
+
+			expect(mockStorage.setDeviceSessionExpiry).to.have.been.calledOnce;
+			expect(mockStorage.setDeviceSessionExpiry).to.have.been.calledWith(correctTimestamp);
+		});
+	});
+
+	describe('isNewSession:', () => {
+
+		it('should return true if the user visits for the first time (initially no value in localStorage)', () => {
+			const timeNow = '2018-06-14T08:00:00.000Z';
+			const newExpiryTimestamp = dateFns.addMinutes(timeNow, SESSION_THRESHOLD_MINUTES).toISOString();
+
+			clock = sinon.useFakeTimers(new Date(timeNow));
+			deviceSessionExpiry = undefined;
+			deviceSession = new DeviceSession();
+
+			expect(deviceSession.isNewSession()).to.be.true;
+			expect(mockStorage.setDeviceSessionExpiry).to.have.been.calledWith(newExpiryTimestamp);
+		});
+
+		it('should return true if the user returns after session (initial value in localStorage is in the past)', () => {
+			const timeNow = timestampAfterExpiry;
+			const newExpiryTimestamp = dateFns.addMinutes(timeNow, SESSION_THRESHOLD_MINUTES).toISOString();
+
+			clock = sinon.useFakeTimers(new Date(timeNow));
+			deviceSessionExpiry = expiryTimestamp;
+			deviceSession = new DeviceSession();
+
+			expect(deviceSession.isNewSession()).to.be.true;
+			expect(mockStorage.setDeviceSessionExpiry).to.have.been.calledWith(newExpiryTimestamp);
+		});
+
+		it('should return false if the user returns within session (initial value in localStorage is in the future)', () => {
+			const timeNow = timestampBeforeExpiry;
+			const newExpiryTimestamp = dateFns.addMinutes(timeNow, SESSION_THRESHOLD_MINUTES).toISOString();
+
+			clock = sinon.useFakeTimers(new Date(timeNow));
+			deviceSessionExpiry = expiryTimestamp;
+			deviceSession = new DeviceSession();
+
+			expect(deviceSession.isNewSession()).to.be.false;
+			expect(mockStorage.setDeviceSessionExpiry).to.have.been.calledWith(newExpiryTimestamp);
+		});
+
+	});
+
+});

--- a/test/unread-articles-indicator/fetch-new-articles.spec.js
+++ b/test/unread-articles-indicator/fetch-new-articles.spec.js
@@ -3,7 +3,6 @@
 import fetchMock from 'fetch-mock';
 import fetchNewArticles from '../../components/unread-articles-indicator/fetch-new-articles';
 
-const USER_UUID = '0-0-0-0';
 const SINCE = '2018-06-05T06:48:26.635Z';
 
 const ARTICLE_PUBLISH_BEFORE_SINCE = '2018-06-04T06:48:26.635Z';
@@ -54,7 +53,7 @@ describe('fetch-new-articles', () => {
 		fetchMock.get('begin:https://next-api.ft.com/v2/', mockReadingHistoryData);
 		fetchMock.get('begin:/__myft/api/onsite/feed/', mockPersonalisedFeedData);
 
-		return fetchNewArticles(USER_UUID, SINCE)
+		return fetchNewArticles(SINCE)
 			.then(resolvedValue => {
 				data = resolvedValue;
 			});

--- a/test/unread-articles-indicator/index.spec.js
+++ b/test/unread-articles-indicator/index.spec.js
@@ -9,7 +9,6 @@ const NEW_ARTICLES = [
 const NEW_UNDISMISSED_ARTICLES = [
 	{ id: 'article-3' }
 ];
-const USER_ID = '123-456';
 const STORED_NEW_ARTICLES_SINCE_TIME = '2018-06-05T10:00:00.000Z';
 const STORED_INDICATOR_DISMISSED_TIME = '2018-06-05T16:00:00.000Z';
 const DETERMINED_NEW_ARTICLES_SINCE_TIME = '2018-06-05T16:07:37.639Z';
@@ -45,7 +44,6 @@ describe('unread stories indicator', () => {
 		};
 		mockFetchNewArticles = sinon.stub().returns(Promise.resolve(NEW_ARTICLES));
 		unreadStoriesIndicator = require('inject-loader!../../components/unread-articles-indicator')({
-			'next-session-client': { uuid: () => Promise.resolve({ uuid: USER_ID }) },
 			'./chronology': mockChronology,
 			'./fetch-new-articles': mockFetchNewArticles,
 			'./storage': mockStorage,
@@ -86,7 +84,7 @@ describe('unread stories indicator', () => {
 			});
 
 			it('should fetch the new articles for the user using the determined newArticlesSinceTime', () => {
-				expect(mockFetchNewArticles.calledWith(USER_ID, DETERMINED_NEW_ARTICLES_SINCE_TIME)).to.equal(true);
+				expect(mockFetchNewArticles.calledWith(DETERMINED_NEW_ARTICLES_SINCE_TIME)).to.equal(true);
 			});
 
 			it('should filter new articles to undismissed ones', () => {

--- a/test/unread-articles-indicator/index.spec.js
+++ b/test/unread-articles-indicator/index.spec.js
@@ -134,10 +134,10 @@ describe('unread stories indicator', () => {
 	describe('getNewArticlesSinceTime', () => {
 		describe('when called for the first time', () => {
 			it('should determineNewArticlesSinceTime', () => {
-				unreadStoriesIndicator.getNewArticlesSinceTime(USER_ID);
+				unreadStoriesIndicator.getNewArticlesSinceTime();
 
 				expect(mockStorage.getNewArticlesSinceTime).to.have.been.calledOnce;
-				expect(mockChronology.determineNewArticlesSinceTime).to.have.been.calledWith(STORED_NEW_ARTICLES_SINCE_TIME, USER_ID);
+				expect(mockChronology.determineNewArticlesSinceTime).to.have.been.calledWith(STORED_NEW_ARTICLES_SINCE_TIME);
 			});
 
 			it('should update the values in storage the first time it is called', () => {

--- a/test/unread-articles-indicator/index.spec.js
+++ b/test/unread-articles-indicator/index.spec.js
@@ -10,7 +10,6 @@ const NEW_UNDISMISSED_ARTICLES = [
 	{ id: 'article-3' }
 ];
 const USER_ID = '123-456';
-const STORED_LAST_VISITED = '2018-06-04T13:00:00.000Z';
 const STORED_NEW_ARTICLES_SINCE_TIME = '2018-06-05T10:00:00.000Z';
 const STORED_INDICATOR_DISMISSED_TIME = '2018-06-05T16:00:00.000Z';
 const DETERMINED_NEW_ARTICLES_SINCE_TIME = '2018-06-05T16:07:37.639Z';
@@ -27,14 +26,12 @@ describe('unread stories indicator', () => {
 
 	beforeEach(() => {
 		mockChronology = {
-			determineNewArticlesSinceTime: sinon.stub().returns(DETERMINED_NEW_ARTICLES_SINCE_TIME),
+			determineNewArticlesSinceTime: sinon.stub().returns(Promise.resolve(DETERMINED_NEW_ARTICLES_SINCE_TIME)),
 			filterArticlesToNewSinceTime: sinon.stub().returns(NEW_UNDISMISSED_ARTICLES)
 		};
 		mockStorage = {
 			getIndicatorDismissedTime: sinon.stub().returns(STORED_INDICATOR_DISMISSED_TIME),
 			setIndicatorDismissedTime: sinon.stub(),
-			getLastVisitedAt: sinon.stub().returns(STORED_LAST_VISITED),
-			setLastVisitedAt: sinon.stub(),
 			getNewArticlesSinceTime: sinon.stub().returns(STORED_NEW_ARTICLES_SINCE_TIME),
 			setNewArticlesSinceTime: sinon.stub(),
 			isAvailable: sinon.stub().callsFake(() => isStorageAvailable)
@@ -62,7 +59,6 @@ describe('unread stories indicator', () => {
 			it('should not do anything if storage is not available', () => {
 				isStorageAvailable = false;
 				unreadStoriesIndicator.default();
-
 				expect(mockUi.createIndicators).to.not.have.been.called;
 				expect(mockUi.setCount).to.not.have.been.called;
 				expect(mockFetchNewArticles).to.not.have.been.called;
@@ -138,46 +134,57 @@ describe('unread stories indicator', () => {
 	describe('getNewArticlesSinceTime', () => {
 		describe('when called for the first time', () => {
 			it('should determineNewArticlesSinceTime', () => {
-				unreadStoriesIndicator.getNewArticlesSinceTime();
+				unreadStoriesIndicator.getNewArticlesSinceTime(USER_ID);
 
-				expect(mockStorage.getLastVisitedAt).to.have.been.calledOnce;
 				expect(mockStorage.getNewArticlesSinceTime).to.have.been.calledOnce;
-				expect(mockChronology.determineNewArticlesSinceTime).to.have.been.calledWith(STORED_LAST_VISITED, STORED_NEW_ARTICLES_SINCE_TIME);
+				expect(mockChronology.determineNewArticlesSinceTime).to.have.been.calledWith(STORED_NEW_ARTICLES_SINCE_TIME, USER_ID);
 			});
 
 			it('should update the values in storage the first time it is called', () => {
-				unreadStoriesIndicator.getNewArticlesSinceTime();
-
-				expect(mockStorage.setNewArticlesSinceTime).to.have.been.calledWith(DETERMINED_NEW_ARTICLES_SINCE_TIME);
-				expect(mockStorage.setNewArticlesSinceTime).to.have.been.calledAfter(mockChronology.determineNewArticlesSinceTime);
-				expect(mockStorage.setLastVisitedAt).to.have.been.calledOnce;
-				expect(mockStorage.setLastVisitedAt).to.have.been.calledAfter(mockChronology.determineNewArticlesSinceTime);
+				return unreadStoriesIndicator.getNewArticlesSinceTime()
+				.then(() => {
+					expect(mockStorage.setNewArticlesSinceTime).to.have.been.calledWith(DETERMINED_NEW_ARTICLES_SINCE_TIME);
+					expect(mockStorage.setNewArticlesSinceTime).to.have.been.calledAfter(mockChronology.determineNewArticlesSinceTime);
+				});
 			});
 
 			it('should return the the newArticlesSinceTime', () => {
-				expect(unreadStoriesIndicator.getNewArticlesSinceTime()).to.equal(DETERMINED_NEW_ARTICLES_SINCE_TIME);
+				return unreadStoriesIndicator.getNewArticlesSinceTime()
+					.then(result => {
+						expect(result).to.equal(DETERMINED_NEW_ARTICLES_SINCE_TIME);
+					});
 			});
 		});
 
 		describe('should not change the values when called subsequent times', () => {
 			it('should not determineNewArticlesSinceTime more than once', () => {
-				unreadStoriesIndicator.getNewArticlesSinceTime();
-				unreadStoriesIndicator.getNewArticlesSinceTime();
-
-				expect(mockStorage.getLastVisitedAt).to.have.been.calledOnce;
-				expect(mockStorage.getNewArticlesSinceTime).to.have.been.calledOnce;
+				return unreadStoriesIndicator.getNewArticlesSinceTime()
+					.then(() => {
+						return unreadStoriesIndicator.getNewArticlesSinceTime()
+							.then(() => {
+								expect(mockStorage.getNewArticlesSinceTime).to.have.been.calledOnce;
+							});
+					});
 			});
 
 			it('should not update the values in storage more than once', () => {
-				unreadStoriesIndicator.getNewArticlesSinceTime();
-				unreadStoriesIndicator.getNewArticlesSinceTime();
-
-				expect(mockStorage.setNewArticlesSinceTime).to.have.been.calledOnce;
-				expect(mockStorage.setLastVisitedAt).to.have.been.calledOnce;
+				return unreadStoriesIndicator.getNewArticlesSinceTime()
+					.then(() => {
+						return unreadStoriesIndicator.getNewArticlesSinceTime()
+							.then(() => {
+								expect(mockStorage.setNewArticlesSinceTime).to.have.been.calledOnce;
+							});
+					});
 			});
 
-			it('should return the the newArticlesSinceTime', () => {
-				expect(unreadStoriesIndicator.getNewArticlesSinceTime()).to.equal(DETERMINED_NEW_ARTICLES_SINCE_TIME);
+			it('should return the newArticlesSinceTime', () => {
+				return unreadStoriesIndicator.getNewArticlesSinceTime()
+					.then(() => {
+						return unreadStoriesIndicator.getNewArticlesSinceTime()
+							.then(result => {
+								expect(result).to.equal(DETERMINED_NEW_ARTICLES_SINCE_TIME);
+							});
+					});
 			});
 		});
 	});

--- a/test/unread-articles-indicator/storage.spec.js
+++ b/test/unread-articles-indicator/storage.spec.js
@@ -22,43 +22,45 @@ describe('storage', () => {
 		clock.restore();
 	});
 
-	describe('getLastVisitedAt', () => {
+	describe('getDeviceSessionExpiry', () => {
 		describe('given a valid timestamp is stored', () => {
 			beforeEach(() => {
-				mockStorage.lastVisitedAt = String(now.getTime());
+				mockStorage.deviceSessionExpiry = String(now.getTime());
 			});
 
 			it('should return the correct iso date', () => {
-				expect(storage.getLastVisitedAt()).to.equal(now.toISOString());
+				expect(storage.getDeviceSessionExpiry()).to.equal(now.toISOString());
 			});
 		});
 
 		describe('given no value is stored', () => {
 			beforeEach(() => {
-				mockStorage.lastVisitedAt = null;
+				mockStorage.deviceSessionExpiry = null;
 			});
 
 			it('should return null', () => {
-				expect(storage.getLastVisitedAt()).to.equal(null);
+				expect(storage.getDeviceSessionExpiry()).to.equal(null);
 			});
 		});
 
 		describe('given an invalid value is stored', () => {
 			beforeEach(() => {
-				mockStorage.lastVisitedAt = 'abc';
+				mockStorage.deviceSessionExpiry = 'abc';
 			});
 
 			it('should return null', () => {
-				expect(storage.getLastVisitedAt()).to.equal(null);
+				expect(storage.getDeviceSessionExpiry()).to.equal(null);
 			});
 		});
 	});
 
-	describe('setLastVisitedAt', () => {
+	describe('setDeviceSessionExpiry', () => {
 		it('should store the date as a timestamp', () => {
-			storage.setLastVisitedAt();
+			const date = new Date(2018, 6, 14, 11, 0, 0);
 
-			expect(mockStorage.lastVisitedAt).to.equal(String(now.getTime()));
+			storage.setDeviceSessionExpiry(date.toISOString());
+
+			expect(mockStorage.deviceSessionExpiry).to.equal(String(date.getTime()));
 		});
 	});
 


### PR DESCRIPTION
Reverts Financial-Times/n-myft-ui#250 (i.e. brings the changes back in).

We will use this an integration branch for the short term as we may need to gradually roll this change out.

