### PR TITLE
Store date/times as ISO strings instead of unix timestamps

### DIFF
--- a/components/unread-articles-indicator/index.js
+++ b/components/unread-articles-indicator/index.js
@@ -36,9 +36,10 @@ let newArticlesSinceTime;
 export const getNewArticlesSinceTime = () => {
 	if (!newArticlesSinceTime) {
 		return determineNewArticlesSinceTime(storage.getNewArticlesSinceTime())
-			.then(timestamp => {
-				storage.setNewArticlesSinceTime(timestamp);
-				newArticlesSinceTime = timestamp;
+			.then(isoDate => {
+				storage.setNewArticlesSinceTime(isoDate);
+				newArticlesSinceTime = isoDate;
+
 				return newArticlesSinceTime;
 			});
 	}

--- a/components/unread-articles-indicator/storage.js
+++ b/components/unread-articles-indicator/storage.js
@@ -1,27 +1,28 @@
+import { isValid } from 'date-fns';
+
 const DEVICE_SESSION_EXPIRY = 'deviceSessionExpiry';
 const NEW_ARTICLES_SINCE = 'newArticlesSinceTime';
 const INDICATOR_DISMISSED_AT = 'myFTIndicatorDismissedAt';
 
-const timestampToIsoDate = ts => new Date(ts).toISOString();
+const isISOString = str => typeof str === 'string' && str.charAt(10) === 'T';
+const getStoredDate = key => {
+	const value = window.localStorage.getItem(key);
+	const date = new Date(value);
 
-const getTimestampItemAsIsoDate = key => {
-	const item = window.localStorage.getItem(key);
-	const timestamp = Number(item);
-
-	return !item || isNaN(timestamp) ? null : timestampToIsoDate(timestamp);
+	return isISOString(value) && isValid(date) ? date.toISOString() : null;
 };
 
-export const getDeviceSessionExpiry = () => getTimestampItemAsIsoDate(DEVICE_SESSION_EXPIRY);
+export const getDeviceSessionExpiry = () => getStoredDate(DEVICE_SESSION_EXPIRY);
 
-export const setDeviceSessionExpiry = isoDate => window.localStorage.setItem(DEVICE_SESSION_EXPIRY, String(new Date(isoDate).getTime()));
+export const setDeviceSessionExpiry = isoDate => window.localStorage.setItem(DEVICE_SESSION_EXPIRY, isoDate);
 
-export const getNewArticlesSinceTime = () => getTimestampItemAsIsoDate(NEW_ARTICLES_SINCE);
+export const getNewArticlesSinceTime = () => getStoredDate(NEW_ARTICLES_SINCE);
 
-export const setNewArticlesSinceTime = isoDate => window.localStorage.setItem(NEW_ARTICLES_SINCE, String(new Date(isoDate).getTime()));
+export const setNewArticlesSinceTime = isoDate => window.localStorage.setItem(NEW_ARTICLES_SINCE, isoDate);
 
-export const getIndicatorDismissedTime = () => getTimestampItemAsIsoDate(INDICATOR_DISMISSED_AT);
+export const getIndicatorDismissedTime = () => getStoredDate(INDICATOR_DISMISSED_AT);
 
-export const setIndicatorDismissedTime = () => window.localStorage.setItem(INDICATOR_DISMISSED_AT, String(Date.now()));
+export const setIndicatorDismissedTime = () => window.localStorage.setItem(INDICATOR_DISMISSED_AT, new Date().toISOString());
 
 export const isAvailable = () => {
 	try {

--- a/test/unread-articles-indicator/storage.spec.js
+++ b/test/unread-articles-indicator/storage.spec.js
@@ -23,9 +23,9 @@ describe('storage', () => {
 	});
 
 	describe('getDeviceSessionExpiry', () => {
-		describe('given a valid timestamp is stored', () => {
+		describe('given a valid iso date is stored', () => {
 			beforeEach(() => {
-				mockStorage.deviceSessionExpiry = String(now.getTime());
+				mockStorage.deviceSessionExpiry = now.toISOString();
 			});
 
 			it('should return the correct iso date', () => {
@@ -52,22 +52,32 @@ describe('storage', () => {
 				expect(storage.getDeviceSessionExpiry()).to.equal(null);
 			});
 		});
+
+		describe('given a unix timestamp is stored (old format)', () => {
+			beforeEach(() => {
+				mockStorage.deviceSessionExpiry = String(now.getTime());
+			});
+
+			it('should return null', () => {
+				expect(storage.getDeviceSessionExpiry()).to.equal(null);
+			});
+		});
 	});
 
 	describe('setDeviceSessionExpiry', () => {
-		it('should store the date as a timestamp', () => {
-			const date = new Date(2018, 6, 14, 11, 0, 0);
+		it('should store the date as an iso string', () => {
+			const date = new Date(2018, 6, 14, 11, 0, 0).toISOString();
 
-			storage.setDeviceSessionExpiry(date.toISOString());
+			storage.setDeviceSessionExpiry(date);
 
-			expect(mockStorage.deviceSessionExpiry).to.equal(String(date.getTime()));
+			expect(mockStorage.deviceSessionExpiry).to.equal(date);
 		});
 	});
 
 	describe('getNewArticlesSinceTime', () => {
-		describe('given a valid timestamp is stored', () => {
+		describe('given a valid iso date is stored', () => {
 			beforeEach(() => {
-				mockStorage.newArticlesSinceTime = String(now.getTime());
+				mockStorage.newArticlesSinceTime = now.toISOString();
 			});
 
 			it('should return the correct iso date', () => {
@@ -94,15 +104,75 @@ describe('storage', () => {
 				expect(storage.getNewArticlesSinceTime()).to.equal(null);
 			});
 		});
+
+		describe('given a unix timestamp is stored (old format)', () => {
+			beforeEach(() => {
+				mockStorage.newArticlesSinceTime = String(now.getTime());
+			});
+
+			it('should return the correct iso date', () => {
+				expect(storage.getNewArticlesSinceTime()).to.equal(null);
+			});
+		});
 	});
 
 	describe('setNewArticlesSinceTime', () => {
-		it('should store the date as a timestamp', () => {
-			const date = new Date(2018, 5, 1, 11, 30, 0);
+		it('should store the date as an iso string', () => {
+			const date = new Date(2018, 5, 1, 11, 30, 0).toISOString();
 
-			storage.setNewArticlesSinceTime(date.toISOString());
+			storage.setNewArticlesSinceTime(date);
 
-			expect(mockStorage.newArticlesSinceTime).to.equal(String(date.getTime()));
+			expect(mockStorage.newArticlesSinceTime).to.equal(date);
+		});
+	});
+
+	describe('getIndicatorDismissedTime', () => {
+		describe('given a valid iso date is stored', () => {
+			beforeEach(() => {
+				mockStorage.myFTIndicatorDismissedAt = now.toISOString();
+			});
+
+			it('should return the correct iso date', () => {
+				expect(storage.getIndicatorDismissedTime()).to.equal(now.toISOString());
+			});
+		});
+
+		describe('given no value is stored', () => {
+			beforeEach(() => {
+				mockStorage.myFTIndicatorDismissedAt = null;
+			});
+
+			it('should return null', () => {
+				expect(storage.getIndicatorDismissedTime()).to.equal(null);
+			});
+		});
+
+		describe('given an invalid value is stored', () => {
+			beforeEach(() => {
+				mockStorage.myFTIndicatorDismissedAt = 'abc';
+			});
+
+			it('should return null', () => {
+				expect(storage.getIndicatorDismissedTime()).to.equal(null);
+			});
+		});
+
+		describe('given a unix timestamp is stored (old format)', () => {
+			beforeEach(() => {
+				mockStorage.myFTIndicatorDismissedAt = String(now.getTime());
+			});
+
+			it('should return the correct iso date', () => {
+				expect(storage.getIndicatorDismissedTime()).to.equal(null);
+			});
+		});
+	});
+
+	describe('setIndicatorDismissedTime', () => {
+		it('should store the date as an iso string', () => {
+			storage.setIndicatorDismissedTime();
+
+			expect(mockStorage.myFTIndicatorDismissedAt).to.equal(now.toISOString());
 		});
 	});
 


### PR DESCRIPTION
Enables easier debugging and captures user timezone.

Legacy unit timestamp values will be treated as `null`.

https://trello.com/c/FXmzHyS8/1164-change-last-visited-and-new-articles-since-localstorage-values-from-unix-timestamp-to-full-iso-date-time