### PR TITLE
Exits early if the uuid doesn't exist

### DIFF
--- a/components/unread-articles-indicator/fetch-new-articles.js
+++ b/components/unread-articles-indicator/fetch-new-articles.js
@@ -20,6 +20,13 @@ const decorateWithHasBeenRead = (readingHistory, allArticles) => {
 };
 
 const contentFromPersonalisedFeed = uuid => {
+	const emptyResponse = { results: [], signals: {} };
+
+	if (!uuid) {
+		return Promise.resolve(emptyResponse);
+	}
+
+
 	const url = `/__myft/api/onsite/feed/${uuid}?originatingSignals=followed&from=-24h`;
 	const options = { credentials: 'include' };
 


### PR DESCRIPTION
Don't call personalised feed if the uuid doesn't exist.