### PR TITLE
instant-alert button value should be opposite of hasInstantAlert

### DIFF
--- a/components/instant-alert/instant-alert.html
+++ b/components/instant-alert/instant-alert.html
@@ -38,7 +38,7 @@
 	data-trackable="instant"
 	title="Get instant alerts for {{name}}"
 	name="_rel.instant"
-	value="true"
+	value="{{#if hasInstantAlert}}false{{else}}true{{/if}}"
 	type="submit"
 	>{{#if buttonText}}{{buttonText}}{{else}}Instant alerts{{/if}}</button>
 </form>


### PR DESCRIPTION
Spotted this problem whilst working on https://github.com/Financial-Times/next-myft-page/pull/1912

Without this change, when the button is initially rendered with `hasInstantAlert` set to `true`, it takes two button clicks to turn off the instant alert.