### PR TITLE
Remove redundant x-follow-button state setting.

### DIFF
--- a/components/x-button-integration/index.js
+++ b/components/x-button-integration/index.js
@@ -10,6 +10,7 @@ const listenForButtonClicks = (buttonEventName) => {
 	});
 };
 
+// TODO: Remove when all x-article-save-buttons are updated to >0.0.7, as they don't listen for x-interaction events
 const dispatchButtonAction = (selector, action) => {
 	const event = new CustomEvent('x-interaction.trigger-action', {
 		detail: { action }
@@ -20,19 +21,6 @@ const dispatchButtonAction = (selector, action) => {
 };
 
 export const initFollowButtons = () => {
-	const getSelector = id => `form[data-concept-id="${id}"]`;
-
-	document.body.addEventListener('myft.user.followed.concept.load', () => {
-		nextMyftClient.loaded['followed.concept'].items.forEach(item =>
-			dispatchButtonAction(getSelector(item.uuid), 'followed'));
-	});
-
-	document.body.addEventListener('myft.user.followed.concept.add', ({ detail }) =>
-		dispatchButtonAction(getSelector(detail.subject), 'followed'));
-
-	document.body.addEventListener('myft.user.followed.concept.remove', ({ detail }) =>
-		dispatchButtonAction(getSelector(detail.subject), 'unfollowed'));
-
 	listenForButtonClicks('x-follow-button');
 };
 
@@ -40,8 +28,10 @@ export const initSaveButtons = () => {
 	const getSelector = id => `form[data-content-id="${id}"]`;
 
 	document.body.addEventListener('myft.user.saved.content.load', () => {
-		nextMyftClient.loaded['saved.content'].items.forEach(item =>
-			dispatchButtonAction(getSelector(item.uuid), 'saved'));
+		if (nextMyftClient.loaded['saved.content']) {
+			nextMyftClient.loaded['saved.content'].items.forEach(item =>
+				dispatchButtonAction(getSelector(item.uuid), 'saved'));
+		}
 	});
 
 	document.body.addEventListener('myft.user.saved.content.add', ({ detail }) =>

--- a/test/x-button-integration.spec.js
+++ b/test/x-button-integration.spec.js
@@ -19,12 +19,19 @@ const createButtonMock = (attribute, id) => {
 const dispatchBodyEvent = (name, detail = {}) => document.body.dispatchEvent(new CustomEvent(name, { detail }));
 
 describe('x-button-integration', () => {
+	const ACTOR_ID = null;
+	const ACTOR_TYPE = 'user';
+	const CSRF_TOKEN = 'dummy-token';
+	const CONCEPT_ID = '0000-0000-0000-0000';
+	const CONTENT_ID = '1111-1111-1111-1111';
 	let xButtonIntegration;
 	let mockClient;
 	let mockButtons;
 
 	beforeEach(() => {
 		mockClient = {
+			remove: sinon.spy(),
+			saved: sinon.stub(),
 			init: sinon.stub().returns(Promise.resolve()),
 			load: sinon.stub(),
 			loaded: {}
@@ -41,62 +48,30 @@ describe('x-button-integration', () => {
 				createButtonMock('data-concept-id', 'concept-id-2')
 			];
 			mockButtons.forEach(button => document.body.appendChild(button.el));
+			xButtonIntegration.initFollowButtons();
 		});
 
 		afterEach(() => {
 			mockButtons.forEach(buttonMock => buttonMock.el.remove());
 		});
 
-		describe('handling myFT client load of followed concepts', () => {
-			beforeEach(() => {
-				mockClient.loaded = {
-					'followed.concept': {
-						items: [
-							{ uuid: mockButtons[0].id }
-						]
-					}
-				};
-				xButtonIntegration.initFollowButtons();
-			});
+		it('invokes myft client when a button dispatches its event', () => {
+			mockButtons[0].el.dispatchEvent(new CustomEvent('x-follow-button', {
+				bubbles: true,
+				detail: {
+					action: 'remove',
+					actorType: ACTOR_TYPE,
+					actorId: ACTOR_ID,
+					relationshipName: 'followed',
+					subjectType: 'concept',
+					subjectId: CONCEPT_ID,
+					token: CSRF_TOKEN
+				}
+			}));
 
-			it('should set states of any buttons found in page', done => {
-				mockButtons[0].el.addEventListener('x-interaction.trigger-action', event => {
-					expect(event.detail).to.deep.equal({ action: 'followed' });
-					done();
-				});
-
-				dispatchBodyEvent('myft.user.followed.concept.load');
-			});
-		});
-
-		describe('handling myFT client followed event', () => {
-			beforeEach(() => {
-				xButtonIntegration.initFollowButtons();
-			});
-
-			it('should set states of any buttons found in page', done => {
-				mockButtons[0].el.addEventListener('x-interaction.trigger-action', event => {
-					expect(event.detail).to.deep.equal({ action: 'followed' });
-					done();
-				});
-
-				dispatchBodyEvent('myft.user.followed.concept.add', { subject: mockButtons[0].id });
-			});
-		});
-
-		describe('handling myFT client unfollowed event', () => {
-			beforeEach(() => {
-				xButtonIntegration.initFollowButtons();
-			});
-
-			it('should set states of any buttons found in page', done => {
-				mockButtons[0].el.addEventListener('x-interaction.trigger-action', event => {
-					expect(event.detail).to.deep.equal({ action: 'unfollowed' });
-					done();
-				});
-
-				dispatchBodyEvent('myft.user.followed.concept.remove', { subject: mockButtons[0].id });
-			});
+			expect(mockClient.remove).to.have.been.calledWith(ACTOR_TYPE, ACTOR_ID, 'followed', 'concept', CONCEPT_ID, sinon.match({
+				token: CSRF_TOKEN
+			}));
 		});
 	});
 
@@ -111,6 +86,31 @@ describe('x-button-integration', () => {
 
 		afterEach(() => {
 			mockButtons.forEach(buttonMock => buttonMock.el.remove());
+		});
+
+		describe('invokes myFT client when a button dispatches its event', () => {
+			beforeEach(() => {
+				xButtonIntegration.initSaveButtons();
+			});
+
+			it('invokes myft client when a button dispatches its event', () => {
+				mockButtons[0].el.dispatchEvent(new CustomEvent('x-article-save-button', {
+					bubbles: true,
+					detail: {
+						action: 'remove',
+						actorType: ACTOR_TYPE,
+						actorId: ACTOR_ID,
+						relationshipName: 'saved',
+						subjectType: 'content',
+						subjectId: CONTENT_ID,
+						token: CSRF_TOKEN
+					}
+				}));
+
+				expect(mockClient.remove).to.have.been.calledWith(ACTOR_TYPE, ACTOR_ID, 'saved', 'content', CONTENT_ID, sinon.match({
+					token: CSRF_TOKEN
+				}));
+			});
 		});
 
 		describe('handling myFT client load of saved content', () => {


### PR DESCRIPTION
There are now no uses of the old x-follow-button, so the integration code that sets those button states can be removed.