### PR TITLE
Fixes syntax error on Object.assign

### DIFF
--- a/components/digest-promo/index.js
+++ b/components/digest-promo/index.js
@@ -75,7 +75,7 @@ function addToDigest () {
 		}
 	};
 
-	const promises = [myFtClient.add('user', null, 'preferred', 'preference', 'email-digest', Object.assign({}, {token: csrfToken}), metaEmail)];
+	const promises = [myFtClient.add('user', null, 'preferred', 'preference', 'email-digest', Object.assign({}, {token: csrfToken}, metaEmail)];
 
 	if (conceptId) {
 		promises.push(myFtClient.add('user', null, 'followed', 'concept', conceptId, Object.assign({}, {token: csrfToken}, metaConcept)));


### PR DESCRIPTION
This meant that not all the data needed was sent in the request and meant that users were not being assigned to an email group