### PR TITLE
Remove redundant code relating to early x-article-save-button versions.

### DIFF
--- a/components/x-button-integration/index.js
+++ b/components/x-button-integration/index.js
@@ -1,44 +1,18 @@
 import nextMyftClient from 'next-myft-client';
 
+const buttonEventHandler = ({ detail }) => {
+	const formData = {
+		token: detail.token
+	};
+
+	nextMyftClient[detail.action](detail.actorType, detail.actorId, detail.relationshipName, detail.subjectType, detail.subjectId, formData);
+};
+
 const listenForButtonClicks = (buttonEventName) => {
-	document.body.addEventListener(buttonEventName, ({ detail }) => {
-		const formData = {
-			token: detail.token
-		};
-
-		nextMyftClient[detail.action](detail.actorType, detail.actorId, detail.relationshipName, detail.subjectType, detail.subjectId, formData);
-	});
+	document.body.removeEventListener(buttonEventName, buttonEventHandler);
+	document.body.addEventListener(buttonEventName, buttonEventHandler);
 };
 
-// TODO: Remove when all x-article-save-buttons are updated to >0.0.7, as they don't listen for x-interaction events
-const dispatchButtonAction = (selector, action) => {
-	const event = new CustomEvent('x-interaction.trigger-action', {
-		detail: { action }
-	});
-	const buttonsForContentId = Array.from(document.querySelectorAll(selector));
+export const initFollowButtons = () => listenForButtonClicks('x-follow-button');
 
-	buttonsForContentId.forEach(el => el.parentNode.dispatchEvent(event));
-};
-
-export const initFollowButtons = () => {
-	listenForButtonClicks('x-follow-button');
-};
-
-export const initSaveButtons = () => {
-	const getSelector = id => `form[data-content-id="${id}"]`;
-
-	document.body.addEventListener('myft.user.saved.content.load', () => {
-		if (nextMyftClient.loaded['saved.content']) {
-			nextMyftClient.loaded['saved.content'].items.forEach(item =>
-				dispatchButtonAction(getSelector(item.uuid), 'saved'));
-		}
-	});
-
-	document.body.addEventListener('myft.user.saved.content.add', ({ detail }) =>
-		dispatchButtonAction(getSelector(detail.subject), 'saved'));
-
-	document.body.addEventListener('myft.user.saved.content.remove', ({ detail }) =>
-		dispatchButtonAction(getSelector(detail.subject), 'unsaved'));
-
-	listenForButtonClicks('x-article-save-button');
-};
+export const initSaveButtons = () => listenForButtonClicks('x-article-save-button');

--- a/test/x-button-integration.spec.js
+++ b/test/x-button-integration.spec.js
@@ -16,8 +16,6 @@ const createButtonMock = (attribute, id) => {
 	};
 };
 
-const dispatchBodyEvent = (name, detail = {}) => document.body.dispatchEvent(new CustomEvent(name, { detail }));
-
 describe('x-button-integration', () => {
 	const ACTOR_ID = null;
 	const ACTOR_TYPE = 'user';
@@ -110,58 +108,6 @@ describe('x-button-integration', () => {
 				expect(mockClient.remove).to.have.been.calledWith(ACTOR_TYPE, ACTOR_ID, 'saved', 'content', CONTENT_ID, sinon.match({
 					token: CSRF_TOKEN
 				}));
-			});
-		});
-
-		describe('handling myFT client load of saved content', () => {
-			beforeEach(() => {
-				mockClient.loaded = {
-					'saved.content': {
-						items: [
-							{ uuid: mockButtons[0].id }
-						]
-					}
-				};
-				xButtonIntegration.initSaveButtons();
-			});
-
-			it('should set states of any buttons found in page', done => {
-				mockButtons[0].el.addEventListener('x-interaction.trigger-action', event => {
-					expect(event.detail).to.deep.equal({ action: 'saved' });
-					done();
-				});
-
-				dispatchBodyEvent('myft.user.saved.content.load');
-			});
-		});
-
-		describe('handling myFT client save event', () => {
-			beforeEach(() => {
-				xButtonIntegration.initSaveButtons();
-			});
-
-			it('should set states of any buttons found in page', done => {
-				mockButtons[0].el.addEventListener('x-interaction.trigger-action', event => {
-					expect(event.detail).to.deep.equal({ action: 'saved' });
-					done();
-				});
-
-				dispatchBodyEvent('myft.user.saved.content.add', { subject: mockButtons[0].id });
-			});
-		});
-
-		describe('handling myFT client unsaved event', () => {
-			beforeEach(() => {
-				xButtonIntegration.initSaveButtons();
-			});
-
-			it('should set states of any buttons found in page', done => {
-				mockButtons[0].el.addEventListener('x-interaction.trigger-action', event => {
-					expect(event.detail).to.deep.equal({ action: 'unsaved' });
-					done();
-				});
-
-				dispatchBodyEvent('myft.user.saved.content.remove', { subject: mockButtons[0].id });
 			});
 		});
 	});


### PR DESCRIPTION
The latest versions of **x-article-save-buttons** no longer listen for events to set thei state, so there's some code in `n-myft-ui/components/x-button-integration` that will be redundant.

This can be merged and released once https://github.com/Financial-Times/next-myft-page/pull/1952 is merged.