### PR TITLE
Re-enable the form submit button on error

### DIFF
--- a/myft/ui/myft-buttons/do-form-submit.js
+++ b/myft/ui/myft-buttons/do-form-submit.js
@@ -57,6 +57,10 @@ export default function (relationshipName, formEl) {
 			}));
 		}
 
-		return myFtClient[action](actorType, actorId, relationshipName, subjectType, subjectId, formData);
+		return myFtClient[action](actorType, actorId, relationshipName, subjectType, subjectId, formData)
+			.catch( e => {
+				setTimeout(() => formEl.querySelector('button').removeAttribute('disabled'), 1000);
+				throw e;
+			});
 	}
 }

--- a/test/myft-buttons/do-form-submit.spec.js
+++ b/test/myft-buttons/do-form-submit.spec.js
@@ -15,9 +15,9 @@ describe('Do form submit', () => {
 	beforeEach(() => {
 
 		stubs = {
-			myFtClientAddStub: sinon.stub(),
-			myFtClientRemoveStub: sinon.stub(),
-			followPlusDigestEmail: sinon.stub(),
+			myFtClientAddStub: sinon.stub().returns(Promise.resolve()),
+			myFtClientRemoveStub: sinon.stub().returns(Promise.resolve()),
+			followPlusDigestEmail: sinon.stub().returns(Promise.resolve()),
 			formIsFollowCollectionStub: sinon.stub().returns(false),
 			collectionsDoActionStub: sinon.stub(),
 			getDataFromInputsStub: sinon.stub().returns(fakeExtractedFormData)


### PR DESCRIPTION
Re-enable the form submit button on error instead of leaving it permanently disabled. This is so that the user can have another go at submitting the form if there was a network error, and also prevents the UI from looking broken.

There is a 1 second delay to stop the user rage-clicking the button.

Background: https://trello.com/c/FmyFQyxr/3209-allow-users-who-get-blocked-by-csrf-cross-site-request-forgery-to-continue-with-the-action-they-were-trying-to-perform

 🐿 v2.11.0