### PR TITLE
Report error to Sentry but don't stop form submission

### DIFF
--- a/myft/ui/myft-buttons/do-form-submit.js
+++ b/myft/ui/myft-buttons/do-form-submit.js
@@ -2,6 +2,7 @@ import myFtClient from 'next-myft-client';
 import relationshipConfigs from '../lib/relationship-config';
 import getDataFromInputs from './get-data-from-inputs';
 import * as collections from '../../../components/collections';
+import oErrors from 'o-errors';
 
 function formButtonIsDisabled (formEl) {
 	return formEl.querySelector('button').hasAttribute('disabled');
@@ -48,7 +49,7 @@ export default function (relationshipName, formEl) {
 		const { actorType, subjectType } = relConfig;
 
 		if( !formEl.elements.token || !formEl.elements.token.value ) {
-			throw Error('myFT form submitted without a CSRF token');
+			oErrors.report('myFT form submitted without a CSRF token', {action, actorType, actorId, relationshipName, subjectType, subjectId, formData});
 		}
 
 		return myFtClient[action](actorType, actorId, relationshipName, subjectType, subjectId, formData);

--- a/test/myft-buttons/do-form-submit.spec.js
+++ b/test/myft-buttons/do-form-submit.spec.js
@@ -90,16 +90,15 @@ describe('Do form submit', () => {
 		expect(stubs.myFtClientAddStub).to.have.been.called;
 	});
 
-	it('should not do an add if the CSRF token is missing', () => {
+	it('should still do an add if the CSRF token is missing', () => {
 		container.innerHTML = `
 			<form data-followed-subject-id="some-subject-id">
 				<button></button>
 			</form>
 		`;
 
-		expect( doFormSubmit.bind(null,'followed', container.querySelector('form')) )
-			.to.throw();
-		expect(stubs.myFtClientAddStub).not.to.have.been.called;
+		doFormSubmit('followed', container.querySelector('form'));
+		expect(stubs.myFtClientAddStub).to.have.been.called;
 	});
 
 	it('should do a remove if the button is already pressed', () => {
@@ -114,16 +113,15 @@ describe('Do form submit', () => {
 		expect(stubs.myFtClientRemoveStub).to.have.been.called;
 	});
 
-	it('should not do a remove if the CSRF token is missing', () => {
+	it('should still do a remove if the CSRF token is missing', () => {
 		container.innerHTML = `
 			<form data-followed-subject-id="some-subject-id">
 				<button aria-pressed="true"></button>
 			</form>
 		`;
 
-		expect( doFormSubmit.bind(null, 'followed', container.querySelector('form')) )
-			.to.throw();
-		expect(stubs.myFtClientRemoveStub).not.to.have.been.called;
+		doFormSubmit('followed', container.querySelector('form'));
+		expect(stubs.myFtClientRemoveStub).to.have.been.called;
 	});
 
 	it('should make a fetch request if certain settings are extant', () => {


### PR DESCRIPTION
We are seeing forms submitted without CSRF tokens. This shouldn't happen because : there is no token only if there is no FTSession cookie. But in that case, the submit handler should show a message instead of submitting the form. So this is to try to find what's going on.

Background: https://trello.com/c/FmyFQyxr/3209-allow-users-who-get-blocked-by-csrf-cross-site-request-forgery-to-continue-with-the-action-they-were-trying-to-perform

 🐿 v2.11.0