### PR TITLE
pins the version of firefox running our browserstack tests

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -144,10 +144,11 @@ module.exports = function (karma) {
 				os: 'Windows',
 				os_version: '10'
 			},
+			// TODO - unpin firefox version once browserstack bug is fixed
 			firefoxLatest: {
 				base: 'BrowserStack',
 				browser: 'firefox',
-				browser_version: 'latest',
+				browser_version: '64',
 				os: 'Windows',
 				os_version: '10'
 			},


### PR DESCRIPTION
Pins the version of firefox that we run our Browserstack tests against to 64.0 as a temporary fix to unblock the repo while Browsersatck develop a more permanent one.

Details of the bug: https://trello.com/c/pbQlK40K/654-firefox-latest-tests-broken-for-n-ui-and-n-myft-ui

🐿 v2.12.0