### PR TITLE
Trim the CSRF token to be the last 36 characters

### DIFF
--- a/myft/ui/lib/get-csrf-token.js
+++ b/myft/ui/lib/get-csrf-token.js
@@ -1,3 +1,8 @@
 import Cookies from 'js-cookie';
+const desiredTokenLength = 36;
 
-module.exports = () => Cookies.get('FTSession_s') || Cookies.get('FTSession');
+module.exports = () => {
+  const token = Cookies.get('FTSession_s') || Cookies.get('FTSession');
+  const trimmedToken = token ? token.slice(-desiredTokenLength) : '';
+  return trimmedToken;
+};


### PR DESCRIPTION
## What

Only use the last 36 characters of the session token for CSRF

## Why

This is to prevent us putting the full session token into the DOM and
potentially leaking it to third parties on the page (Ads etc).

## Extra Details
This PR is complimentary to the PR in [myft-proxy](https://github.com/Financial-Times/next-myft-proxy/pull/244)