### PR TITLE
Unpin Firefox version if Browserstack bug is fixed

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -144,11 +144,10 @@ module.exports = function (karma) {
 				os: 'Windows',
 				os_version: '10'
 			},
-			// TODO - unpin firefox version once browserstack bug is fixed
 			firefoxLatest: {
 				base: 'BrowserStack',
 				browser: 'firefox',
-				browser_version: '64',
+				browser_version: 'latest',
 				os: 'Windows',
 				os_version: '10'
 			},


### PR DESCRIPTION
See more info [here](https://trello.com/c/pbQlK40K/654-firefox-latest-tests-broken-for-n-ui-and-n-myft-ui)

If the Circle CI build pass, then the Browserstack has fixed the bug, and we can unpin the `browser_version` for `firefoxLatest`.