### PR TITLE
Offer Instant Alerts with push notifications

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,7 @@
     "n-ui-foundations": "^3.0.0-beta",
     "n-notification": "^6.0.3",
     "next-myft-client": "^7.0.0",
-    "o-overlay": "^2.0.0",
+    "o-overlay": "^2.6.2",
     "o-forms": "^5.0.0",
     "o-errors": "^3.5.2",
     "next-session-client": "^2.3.4",

--- a/components/instant-alerts-confirmation/index.js
+++ b/components/instant-alerts-confirmation/index.js
@@ -1,0 +1,38 @@
+const Overlay = require('o-overlay');
+
+const overlayContent = `
+<div class='instant-alerts-confirmation__text'>Would you like to receive instant alerts?</div>
+<div class='instant-alerts-confirmation__buttons'>
+	<button
+			class="o-buttons instant-alerts-confirmation__button js-instant-alerts-confirmation-no"
+			data-trackable="decline-instant-alerts"
+			type="submit"
+			aria-label="Not now"
+			title="Not now">
+		Not now
+	</button><button
+			class="o-buttons o-buttons--primary instant-alerts-confirmation__button js-instant-alerts-confirmation-yes"
+			data-trackable="accept-instant-alerts"
+			type="submit"
+			aria-label="Yes"
+			title="Yes">
+		Yes
+	</button>
+	</div>
+</div>
+`;
+
+module.exports = () => {
+	const overlay = new Overlay('instant-alerts-confirmation', {
+		heading: {
+			title: 'You have added this topic to <abbr title="myFT" class="myft-ui__icon"></abbr>',
+			shaded: false
+		},
+		modal: true,
+		html: overlayContent
+	});
+
+	overlay.open();
+
+	return overlay;
+};

--- a/components/instant-alerts-confirmation/main.scss
+++ b/components/instant-alerts-confirmation/main.scss
@@ -1,0 +1,55 @@
+.o-overlay.o-overlay--instant-alerts-confirmation {
+
+	@include oTypographySans($scale: 2);
+
+	background-color: getColor('paper');
+	.o-overlay__heading {
+		margin-left: 20px;
+		margin-top: 10px;
+		margin-right: 20px;
+		border-bottom: 1px solid getColor('black-10');
+		font-weight: 400;
+	}
+	.o-overlay__title {
+		@include oTypographySans($scale: 4);
+		overflow: visible;
+		line-height: normal;
+		clear: right;
+		margin: 0 0 10px;
+		padding: 0 50px 10px 0;
+	}
+	.o-overlay__content {
+		padding-top: 30px;
+	}
+	.myft-ui__icon {
+		@include nGetImage('logo', 'brand-myft', getColor('black-80'), 50);
+		margin: 0 0 -19px 0;
+	}
+	.o-overlay__close {
+		border: 0;
+		margin: 0;
+	}
+	.o-overlay__close:after {
+		display: none;
+	}
+	.instant-alerts-confirmation__button {
+		min-width: 80px;
+		margin-left: 10px;
+	}
+}
+
+.instant-alerts-confirmation__buttons {
+	float: right;
+	margin-top: 30px;
+	.n-myft-ui__button {
+		margin-left: 10px;
+	}
+}
+
+.instant-alerts-confirmation__text:before {
+	@include oIconsGetIcon('notifications', getColor('claret'), 42, $iconset-version: 1);
+	content: '';
+	display: inline-block;
+	vertical-align: middle;
+	margin-left: -10px;
+}

--- a/myft/index.js
+++ b/myft/index.js
@@ -1,4 +1,4 @@
 import client from 'next-myft-client';
 import * as ui from './ui';
 
-export { client, ui }
+export { client, ui };

--- a/myft/main.scss
+++ b/myft/main.scss
@@ -15,6 +15,7 @@ $o-overlay-is-silent: true;
 @import './ui/lists';
 @import '../components/pin-button/main';
 @import '../components/instant-alert/main';
+@import '../components/instant-alerts-confirmation/main';
 
 .myft-ui,
 .n-myft-ui {

--- a/myft/ui/lib/get-csrf-token.js
+++ b/myft/ui/lib/get-csrf-token.js
@@ -2,7 +2,7 @@ import Cookies from 'js-cookie';
 const desiredTokenLength = 36;
 
 export default () => {
-  const token = Cookies.get('FTSession_s') || Cookies.get('FTSession');
-  const trimmedToken = token ? token.slice(-desiredTokenLength) : '';
-  return trimmedToken;
+	const token = Cookies.get('FTSession_s') || Cookies.get('FTSession');
+	const trimmedToken = token ? token.slice(-desiredTokenLength) : '';
+	return trimmedToken;
 };

--- a/myft/ui/lib/push-notifications.js
+++ b/myft/ui/lib/push-notifications.js
@@ -1,0 +1,179 @@
+import instantAlertsConfirmation from '../../../components/instant-alerts-confirmation';
+import myftClient from 'next-myft-client';
+import getToken from '../lib/get-csrf-token';
+
+const csrfToken = getToken();
+const isLocalOrHTTPS = document.location.protocol === 'https:' ||
+	document.location.href.indexOf('local') >= 0;
+
+let isServiceWorkerInitialised = false;
+
+const fcmPublicKey = 'BFJGSlVTZ08KYS3heiwOovUPEURcYea478jEXXA5luZ1wo6O6MJ_o2NQckxHudMxa15tOh3YcjDZ-_bKZkPG274';
+let subscribeOptions;
+
+function urlB64ToUint8Array (base64String) {
+	const padding = '='.repeat((4 - base64String.length % 4) % 4);
+	const base64 = (base64String + padding)
+		.replace(/\-/g, '+')
+		.replace(/_/g, '/');
+
+	const rawData = window.atob(base64);
+	const outputArray = new Uint8Array(rawData.length);
+
+	for (let i = 0; i < rawData.length; ++i) {
+		outputArray[i] = rawData.charCodeAt(i);
+	}
+	return outputArray;
+}
+
+function endpointWorkaround (pushSubscription) {
+	// Make sure we only mess with GCM
+	if (pushSubscription.endpoint.indexOf('https://android.googleapis.com/gcm/send') !== 0) {
+		return pushSubscription.endpoint;
+	}
+
+	let mergedEndpoint = pushSubscription.endpoint;
+	// Chrome 42 + 43 will not have the subscriptionId attached
+	// to the endpoint.
+	if (pushSubscription.subscriptionId &&
+		pushSubscription.endpoint.indexOf(pushSubscription.subscriptionId) === -1) {
+		// Handle version 42 where you have separate subId and Endpoint
+		mergedEndpoint = pushSubscription.endpoint + '/' +
+			pushSubscription.subscriptionId;
+	}
+	return mergedEndpoint;
+}
+
+function sendSubscriptionToServer (subscription, isRemove) {
+
+	return myftClient.init()
+		.then(() => myftClient.getAll('enabled', 'endpoint'))
+		.then(function (currentSubscription) {
+			let endpoints = [];
+			let thisEndpoint = endpointWorkaround(subscription);
+
+			if (currentSubscription && currentSubscription.items && currentSubscription.items.length) {
+				endpoints = currentSubscription.items;
+			}
+
+			const authKey = subscription.getKey ? btoa(String.fromCharCode.apply(null, new Uint8Array(subscription.getKey('p256dh')))) : '';
+			const authSecret = subscription.getKey ? btoa(String.fromCharCode.apply(null, new Uint8Array(subscription.getKey('auth')))) : '';
+			const index = endpoints.indexOf(thisEndpoint);
+
+			if (isRemove || (!thisEndpoint && index >= 0)) {
+				myftClient.remove('user', null, 'enabled', 'endpoint', encodeURIComponent(thisEndpoint), {token: csrfToken});
+			} else if (index < 0) {
+				myftClient.add('user', null, 'enabled', 'endpoint', encodeURIComponent(thisEndpoint), {
+					authKey: authKey,
+					authSecret: authSecret,
+					token: csrfToken
+				});
+			}
+			return true;
+		});
+
+}
+
+function enableInstantAlerts (conceptId) {
+	return myftClient.init()
+		.then(() => myftClient.add('user', null, 'followed', 'concept', conceptId, {
+				token: csrfToken,
+				_rel: {instant: 'true'}
+			})
+		);
+}
+
+// Once the service worker is registered set the initial state
+// Returns Rejected if not supported, true if subscribed, false if not subscribed
+export function init (fcmSwitch) {
+
+	if (!isLocalOrHTTPS) {
+		return Promise.reject();
+	}
+
+	// Are Notifications supported in the service worker?
+	if (!(window.ServiceWorkerRegistration) || !('showNotification' in window.ServiceWorkerRegistration.prototype)) {
+		return Promise.reject();
+	}
+
+	// Check if push messaging is supported
+	if (!('PushManager' in window)) {
+		return Promise.reject();
+	}
+
+	subscribeOptions = fcmSwitch ? {
+		userVisibleOnly: true,
+		applicationServerKey: urlB64ToUint8Array(fcmPublicKey)
+	} : {
+		userVisibleOnly: true
+	};
+
+	// We need the service worker registration to check for a subscription
+	return navigator.serviceWorker.ready.then(function (serviceWorkerRegistration) {
+		isServiceWorkerInitialised = true;
+		// Do we already have a push message subscription?
+		serviceWorkerRegistration.pushManager.getSubscription()
+			.then(function (subscription) {
+				// Enable any UI which subscribes / unsubscribes from
+				// push messages.
+				if (subscription) {
+					// We aren't subscribed to push, so set UI
+					// to allow the user to enable push
+					// Keep your server in sync with the latest subscriptionId
+					sendSubscriptionToServer(subscription);
+					return true;
+				} else {
+					return false;
+				}
+			});
+	});
+}
+
+// Returns true on success, or Rejected otherwise
+export function subscribe () {
+
+	return navigator.serviceWorker.ready.then(function (serviceWorkerRegistration) {
+		serviceWorkerRegistration.pushManager.subscribe(subscribeOptions)
+			.then(function (subscription) {
+				return sendSubscriptionToServer(subscription);
+			});
+	});
+}
+
+// Returns true on success, false if no subscription, or Rejected otherwise
+export function unsubscribe () {
+
+	return navigator.serviceWorker.ready.then(function (serviceWorkerRegistration) {
+		// To unsubscribe from push messaging, you need get the
+		// subscription object, which you can call unsubscribe() on.
+		serviceWorkerRegistration.pushManager.getSubscription().then(
+			function (subscription) {
+				// Check we have a subscription to unsubscribe
+				if (!subscription) {
+					return false;
+				}
+
+				// We have a subscription, so call unsubscribe on it
+				return subscription.unsubscribe()
+					.then(() => sendSubscriptionToServer(subscription, true));
+			});
+	});
+}
+
+export function offerInstantAlerts (conceptId) {
+	if (isServiceWorkerInitialised && Notification.permission !== 'denied') {
+		const overlay = instantAlertsConfirmation();
+		overlay.context.addEventListener('oOverlay.ready', () => {
+			const yesButton = overlay.context.querySelector('.js-instant-alerts-confirmation-yes');
+			yesButton.addEventListener('click', () => {
+				overlay.close();
+				subscribe();
+				enableInstantAlerts(conceptId);
+			});
+			const noButton = overlay.context.querySelector('.js-instant-alerts-confirmation-no');
+			noButton.addEventListener('click', () => {
+				overlay.close();
+			});
+		}, false);
+	}
+}

--- a/myft/ui/myft-buttons/do-form-submit.js
+++ b/myft/ui/myft-buttons/do-form-submit.js
@@ -2,6 +2,7 @@ import myFtClient from 'next-myft-client';
 import relationshipConfigs from '../lib/relationship-config';
 import getDataFromInputs from './get-data-from-inputs';
 import * as collections from '../../../components/collections';
+import {offerInstantAlerts} from '../lib/push-notifications';
 
 function formButtonIsDisabled (formEl) {
 	return formEl.querySelector('button').hasAttribute('disabled');
@@ -22,8 +23,7 @@ function getFormData (formEl) {
 	return getDataFromInputs(formInputs);
 }
 
-export default function (relationshipName, formEl) {
-
+export default function (relationshipName, formEl, pushNotifications) {
 	if (formButtonIsDisabled(formEl)) {
 		return;
 	} else {
@@ -58,6 +58,13 @@ export default function (relationshipName, formEl) {
 		}
 
 		return myFtClient[action](actorType, actorId, relationshipName, subjectType, subjectId, formData)
+			.then( () => {
+				if( pushNotifications ) {
+					if (action === 'add' && relationshipName === 'followed') {
+						offerInstantAlerts();
+					}
+				}
+			})
 			.catch( e => {
 				setTimeout(() => formEl.querySelector('button').removeAttribute('disabled'), 1000);
 				throw e;

--- a/myft/ui/myft-buttons/init.js
+++ b/myft/ui/myft-buttons/init.js
@@ -8,14 +8,15 @@ import Delegate from 'ftdomdelegate';
 import personaliseLinks from '../personalise-links';
 import doFormSubmit from './do-form-submit';
 import enhanceActionUrls from './enhance-action-urls';
+import {init as initPushNotifications} from '../lib/push-notifications';
 
 const delegate = new Delegate(document.body);
 let initialised;
 
-function getInteractionHandler (relationshipName) {
+function getInteractionHandler (flags, relationshipName) {
 	return (ev, formEl) => {
 		ev.preventDefault();
-		return doFormSubmit(relationshipName, formEl);
+		return doFormSubmit(relationshipName, formEl, flags.myftOfferInstantAlertNotifications);
 	};
 }
 
@@ -40,7 +41,7 @@ function anonEventListeners () {
 	});
 }
 
-function signedInEventListeners () {
+function signedInEventListeners (flags = {}) {
 	Object.keys(relationshipConfig).forEach(relationshipName => {
 		const uiSelector = relationshipConfig[relationshipName].uiSelector;
 		loadedRelationships.waitForRelationshipsToLoad(relationshipName)
@@ -70,7 +71,7 @@ function signedInEventListeners () {
 				});
 			});
 
-		delegate.on('submit', uiSelector, getInteractionHandler(relationshipName));
+		delegate.on('submit', uiSelector, getInteractionHandler(flags, relationshipName));
 	});
 }
 
@@ -86,7 +87,10 @@ export default function (opts) {
 		if (opts && opts.anonymous) {
 			anonEventListeners();
 		} else {
-			signedInEventListeners();
+			if( opts.flags && opts.flags.myftOfferInstantAlertNotifications ) {
+				initPushNotifications(opts.flags.fcmSwitch);
+			}
+			signedInEventListeners(opts.flags);
 			personaliseLinks();
 		}
 	}


### PR DESCRIPTION
Part of https://trello.com/c/duzjIVjX/3259-browser-notification-on-boarding

This copies the service worker code from `next-myft-page` into `n-myft-ui` so it can be shared across applications. 

It also adds a new UI component, offering the user Instant Alerts, and on the back of that, prompting them to enable Push Notifications.

![image](https://user-images.githubusercontent.com/8417658/55229579-58da4080-5215-11e9-9467-c53fd31fa6c9.png)

Enable by setting `myftOfferInstantAlertNotifications` in the flags object of the options passed to `n-myft-ui/init(...)` (This normally means just set the `myftOfferInstantAlertNotifications` flag.)


 🐿 v2.12.0