### PR TITLE
Fix instant alert prompting

### DIFF
--- a/myft/ui/lib/push-notifications.js
+++ b/myft/ui/lib/push-notifications.js
@@ -166,13 +166,13 @@ export function offerInstantAlerts (conceptId) {
 		overlay.context.addEventListener('oOverlay.ready', () => {
 			const yesButton = overlay.context.querySelector('.js-instant-alerts-confirmation-yes');
 			yesButton.addEventListener('click', () => {
-				overlay.close();
+				overlay.destroy();
 				subscribe();
 				enableInstantAlerts(conceptId);
 			});
 			const noButton = overlay.context.querySelector('.js-instant-alerts-confirmation-no');
 			noButton.addEventListener('click', () => {
-				overlay.close();
+				overlay.destroy();
 			});
 		}, false);
 	}

--- a/myft/ui/myft-buttons/do-form-submit.js
+++ b/myft/ui/myft-buttons/do-form-submit.js
@@ -61,7 +61,7 @@ export default function (relationshipName, formEl, pushNotifications) {
 			.then( () => {
 				if( pushNotifications ) {
 					if (action === 'add' && relationshipName === 'followed') {
-						offerInstantAlerts();
+						offerInstantAlerts(subjectId);
 					}
 				}
 			})


### PR DESCRIPTION
- It wasn't subscribing to instant alerts because a field was missing in the API request
- There was an error if the overlay opened a second time, because the overlay wasn't being completely destroyed on close.
