### PR TITLE
Show extra sentence in popup if notifications are blocked

### DIFF
--- a/components/instant-alerts-confirmation/index.js
+++ b/components/instant-alerts-confirmation/index.js
@@ -1,7 +1,11 @@
 const Overlay = require('o-overlay');
 
-const overlayContent = `
-<div class='instant-alerts-confirmation__text'>Would you like to receive instant alerts?</div>
+const buildOverlayContent = isBlocked => `
+<div class='instant-alerts-confirmation__info'>
+	<div class='instant-alerts-confirmation-info__icon'></div>
+	<div class='instant-alerts-confirmation-info__text'>Would you like to receive instant alerts?</div>
+</div>
+${isBlocked ? '<div class=\'instant-alerts-confirmation-info__subtext\'>You will need to unblock notifications to receive them on this device.</div>' : ''}
 <div class='instant-alerts-confirmation__buttons'>
 	<button
 			class="o-buttons instant-alerts-confirmation__button js-instant-alerts-confirmation-no"
@@ -22,14 +26,14 @@ const overlayContent = `
 </div>
 `;
 
-module.exports = () => {
+module.exports = (isBlocked) => {
 	const overlay = new Overlay('instant-alerts-confirmation', {
 		heading: {
 			title: 'You have added this topic to <abbr title="myFT" class="myft-ui__icon"></abbr>',
 			shaded: false
 		},
 		modal: true,
-		html: overlayContent
+		html: buildOverlayContent(isBlocked)
 	});
 
 	overlay.open();

--- a/components/instant-alerts-confirmation/main.scss
+++ b/components/instant-alerts-confirmation/main.scss
@@ -43,13 +43,20 @@
 	margin-top: 30px;
 	.n-myft-ui__button {
 		margin-left: 10px;
+		margin-bottom: 10px;
 	}
 }
 
-.instant-alerts-confirmation__text:before {
+.instant-alerts-confirmation__info {
+	display: flex;
+	align-items: center;
+}
+
+.instant-alerts-confirmation-info__icon {
 	@include oIconsGetIcon('notifications', getColor('claret'), 42, $iconset-version: 1);
-	content: '';
-	display: inline-block;
-	vertical-align: middle;
-	margin-left: -10px;
+}
+
+.instant-alerts-confirmation-info__subtext {
+	margin-top: 20px;
+	@include oTypographySans($scale: 0);
 }

--- a/myft/ui/lib/push-notifications.js
+++ b/myft/ui/lib/push-notifications.js
@@ -161,8 +161,8 @@ export function unsubscribe () {
 }
 
 export function offerInstantAlerts (conceptId) {
-	if (isServiceWorkerInitialised && Notification.permission !== 'denied') {
-		const overlay = instantAlertsConfirmation();
+	if (isServiceWorkerInitialised) {
+		const overlay = instantAlertsConfirmation(Notification.permission === 'denied');
 		overlay.context.addEventListener('oOverlay.ready', () => {
 			const yesButton = overlay.context.querySelector('.js-instant-alerts-confirmation-yes');
 			yesButton.addEventListener('click', () => {


### PR DESCRIPTION
If the user has previously blocked push notifications from us, an extra sentence is shown in the message box that appears when following a topic

![image](https://user-images.githubusercontent.com/8417658/55566166-0d330580-56f3-11e9-8edf-613370393a39.png)

This PR also improves the layout of that message box on small screens.

 🐿 v2.12.0