### PR TITLE
Track appearances of instant alerts message box

### DIFF
--- a/myft/ui/lib/push-notifications.js
+++ b/myft/ui/lib/push-notifications.js
@@ -162,6 +162,16 @@ export function unsubscribe () {
 
 export function offerInstantAlerts (conceptId) {
 	if (isServiceWorkerInitialised) {
+
+		document.body.dispatchEvent(new CustomEvent('oTracking.event', {
+			detail: {
+				category: 'myFT',
+				action: 'offer-instant-alerts',
+				permission: Notification.permission
+			},
+			bubbles: true
+		}));
+
 		const overlay = instantAlertsConfirmation(Notification.permission === 'denied');
 		overlay.context.addEventListener('oOverlay.ready', () => {
 			const yesButton = overlay.context.querySelector('.js-instant-alerts-confirmation-yes');


### PR DESCRIPTION
Adds tracking event `offer-instant-alerts` that fires when the message box is shown. It has a field called `permission` which reflects whether or not the user has push notifications blocked.

https://trello.com/c/lV8PhYrz/3490-track-push-notifications

 🐿 v2.12.0