### PR TITLE
Improve accessibility by including context in the saved state of save for later

### DIFF
--- a/components/save-for-later/save-for-later.html
+++ b/components/save-for-later/save-for-later.html
@@ -34,8 +34,8 @@
 		{{/if}}
 		data-content-id="{{contentId}}" {{! duplicated here for tracking}}
 		{{#if isSaved}}
-			aria-label="Saved to myFT"
-			title="Saved to myFT"
+			aria-label="{{#if title}}{{title}} is{{/if}} Saved to myFT"
+			title="{{#if title}}{{title}} is{{/if}} Saved to myFT"
 		{{else}}
 			aria-label="{{#if title}}Save {{title}} to myFT for later{{else}}Save this article to myFT for later{{/if}}"
 			title="{{#if title}}Save {{title}} to myFT for later{{else}}Save this article to myFT for later{{/if}}"

--- a/components/save-for-later/save-for-later.html
+++ b/components/save-for-later/save-for-later.html
@@ -10,6 +10,7 @@
 		class="{{#if saveButtonWithIcon}}n-myft-ui__save-button-with-icon{{else}}n-myft-ui__button{{#variant}} n-myft-ui__button--{{this}}{{/variant}}{{/if}}"
 		data-trackable="{{#if trackableId}}{{trackableId}}{{else}}save-for-later{{/if}}"
 		{{#if isSaved}}
+			{{!-- The value of alternate label needs to be the opposite of label / the current saved state. This allows the client side JS to toggle the labels on state changes --}}
 			data-alternate-label="{{#if title}}Save {{title}} to myFT for later{{else}}Save this article to myFT for later{{/if}}"
 			aria-pressed="true"
 		{{else}}

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/Financial-Times/n-myft-ui#readme",
   "devDependencies": {
-    "@financial-times/n-gage": "^3.0.0-beta.26",
+    "@financial-times/n-gage": "^3.7.1",
     "@financial-times/n-heroku-tools": "^6.19.0",
     "@financial-times/n-internal-tool": "^1.2.3",
     "@financial-times/n-webpack": "^3.0.2",


### PR DESCRIPTION
This will now include the title of the article in the aria-label and title attributes. This will help screen reader users to understand what articles they have already saved when navigating via the buttons.