### PR TITLE
Bump o-forms to receive new o-loading

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,7 @@
     "n-notification": "^6.0.3",
     "next-myft-client": "^7.0.0",
     "o-overlay": "^2.6.2",
-    "o-forms": "^5.0.0",
+    "o-forms": "^6.0.0",
     "o-errors": "^3.5.2",
     "next-session-client": "^2.3.4",
     "fetchres": "^1.7.2",


### PR DESCRIPTION
This allows n-myft-ui dependencies to upgrade to the new o-loading.

I discovered this while trying to update `o-video` for `next-video-page` to fix this issue https://trello.com/c/j5FOVudH/876-videos-are-playing-slowly-on-ftcom.

Because the new version of `o-video` requires version 3 of `o-loading` this could not be updated without first updating `o-forms` to a version that supports version 3 of `o-loading`.

As this version of `o-forms` only bumps `o-loading` which this component does not use there are no changes needed for this bump.



 🐿 v2.12.3