### PR TITLE
Allow custom trackable value

### DIFF
--- a/components/collections/collections.html
+++ b/components/collections/collections.html
@@ -1,6 +1,6 @@
 <section
 	class="collection {{#if liteStyle}}collection--lite{{else}}collection--regular{{/if}}"
-	data-trackable="collection">
+	data-trackable="{{#if trackable}}{{trackable}}{{else}}collection{{/if}}">
 	<header class="collection__header {{#if liteStyle}}collection__header--lite{{else}}collection__header--regular{{/if}}">
 		<h2 class="collection__title {{#if liteStyle}}collection__title--lite{{else}}collection__title--regular{{/if}}">
 			{{title}}


### PR DESCRIPTION
This is so that we can track usages of the new industry recommendations collection.

 🐿 v2.12.4