### PR TITLE
Fix to DAC_Status_message_only_temporary_Issue1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,6 @@ public/main.css
 public/main.css.map
 pa11y_screenCapture/
 .idea/
+.vscode/
 
 package-lock.json

--- a/myft/ui/myft-buttons/init.js
+++ b/myft/ui/myft-buttons/init.js
@@ -32,12 +32,12 @@ function anonEventListeners () {
 	['followed', 'saved'].forEach(action => {
 		delegate.on('submit', relationshipConfig[action].uiSelector, event => {
 			event.preventDefault();
-
 			nNotification.show({
 				content: messages[action],
 				trackable: 'myft-anon',
 				focusSelector: '.myft-ui-subscribe',
-				returnFocusSelector: document.activeElement
+				returnFocusSelector: document.activeElement,
+				duration: 0
 			});
 		});
 	});


### PR DESCRIPTION
Duration of notification now set to 0 so user is required to dismiss the notification as per the DAC recommendation.