### PR TITLE
Add myft header logo tooltip

### DIFF
--- a/components/header-tooltip/index.js
+++ b/components/header-tooltip/index.js
@@ -1,0 +1,37 @@
+import Tooltip from 'o-tooltip';
+import myftClient from 'next-myft-client';
+
+const isMyftPage = window.location.pathname.startsWith('/myft');
+const externalReferrer = !document.referrer || (new URL(document.referrer)).host.endsWith('ft.com');
+const myftHeaderLogo = document.querySelector('.o-header__top-link--myft');
+const flagIsEnabled = window.FT && window.FT.flags && window.FT.flags.get('myFT_HeaderTooltip');
+
+export const init = () => {
+	if (!externalReferrer || isMyftPage || !myftHeaderLogo || !flagIsEnabled) {
+		return;
+	}
+
+	return myftClient.getAll('followed', 'concept')
+		.then(followedConcepts => {
+			if (followedConcepts.length) {
+				const concepts = followedConcepts
+					.sort((a, b) => b.lastPublished - a.lastPublished)
+					.map(({name}) => `<span style="no-wrap">${name}</span>`).slice(0, 3);
+				let content = 'Read the latest on ';
+
+				if (concepts.length === 3) {
+					content += `${concepts.shift()}, `;
+				}
+
+				content += concepts.join(' and ');
+				content += ' stories.';
+
+				new Tooltip(myftHeaderLogo, {
+					target: 'myft-header-tooltip',
+					content: content,
+					showOnConstruction: true,
+					position: 'below'
+				});
+			}
+		});
+};

--- a/components/header-tooltip/main.scss
+++ b/components/header-tooltip/main.scss
@@ -1,0 +1,12 @@
+.o-header__top-link--myft__container {
+	position: relative;
+
+	.o-tooltip {
+		white-space: normal;
+		text-align: left;
+		min-width: 200px;
+		@include oGridRespondTo('L') {
+			min-width: 250px;
+		}
+	}
+}

--- a/myft/main.scss
+++ b/myft/main.scss
@@ -11,6 +11,7 @@ $o-overlay-is-silent: false !default;
 
 @import './ui/myft-buttons/main';
 @import './ui/lists';
+@import "../components/header-tooltip/main";
 @import '../components/pin-button/main';
 @import '../components/instant-alert/main';
 @import '../components/instant-alerts-confirmation/main';

--- a/myft/ui/index.js
+++ b/myft/ui/index.js
@@ -2,10 +2,12 @@ import * as myFtButtons from './myft-buttons';
 import * as lists from './lists';
 import personaliseLinks from './personalise-links';
 import updateUi from './update-ui';
+import * as headerTooltip from '../../components/header-tooltip';
 
 function init (opts) {
 	myFtButtons.init(opts);
 	lists.init();
+	headerTooltip.init();
 }
 
 export {


### PR DESCRIPTION
# Add myft header logo tooltip

## What
Add myft header logo tooltip if:
- user has myFT_HeaderTooltip flag enabled
- user has navigated from a non FT domain
- user is not on a `/myft*` page
 🐿 v2.12.3
## Mobile
<img width="295" alt="Screenshot 2019-08-30 at 09 41 25" src="https://user-images.githubusercontent.com/11778762/64006514-68362080-cb0a-11e9-887f-d685da8a3ffd.png">

## Desktop
<img width="1415" alt="Screenshot 2019-08-30 at 09 41 40" src="https://user-images.githubusercontent.com/11778762/64006515-68362080-cb0a-11e9-9ac1-6e026753210c.png">
