### PR TITLE
Add tracking for clicking on favicon browser tabs

### DIFF
--- a/components/unread-articles-indicator/index.js
+++ b/components/unread-articles-indicator/index.js
@@ -61,6 +61,10 @@ export default (options = {}) => {
 		},
 		options));
 
+	document.addEventListener('visibilitychange',
+		() => tracking.onVisibilityChange(ui.getState()),
+		false);
+
 	return getNewArticlesSinceTime()
 		.then(newArticlesSinceTime => showUnreadArticlesCount(newArticlesSinceTime, true))
 		.then(() => {

--- a/components/unread-articles-indicator/tracking.js
+++ b/components/unread-articles-indicator/tracking.js
@@ -7,6 +7,19 @@ function dispatchEvent (detail) {
 	document.body.dispatchEvent(event);
 }
 
+export function onVisibilityChange (state) {
+	document.body.dispatchEvent(new CustomEvent('oTracking.event',
+		{
+			detail: {
+				action: `browser-tab-${document.hidden?'hidden':'visible'}`,
+				category: 'myFT',
+				faviconHasDot: state.faviconHasDot,
+				numberInTitle: state.numberInTitle
+			},
+			bubbles: true
+		}));
+}
+
 export const countShown = (count, newArticlesSinceTime) => dispatchEvent({
 	category: 'unread-articles-indicator',
 	action: 'render',

--- a/components/unread-articles-indicator/ui.js
+++ b/components/unread-articles-indicator/ui.js
@@ -23,10 +23,12 @@ class Favicon {
 		this.faviconLinks =
 			Array.from(document.querySelectorAll('head link[rel=icon]'))
 				.concat(Array.from(document.querySelectorAll('head link[rel=apple-touch-icon]')));
+		this.showDot = false;
 	}
 
 	setCount (count) {
-		const newImage = count > 0 ? 'brand-ft-logo-square-coloured-dot' : 'brand-ft-logo-square-coloured-no-dot';
+		this.showDot = count > 0;
+		const newImage = this.showDot ? 'brand-ft-logo-square-coloured-dot' : 'brand-ft-logo-square-coloured-no-dot';
 		this.faviconLinks.forEach(link => {
 			link.href = link.href.replace(/brand-ft-logo-square-coloured(-dot|-no-dot)?/, newImage);
 		});
@@ -36,9 +38,11 @@ class Favicon {
 class Title {
 	constructor () {
 		this.originalTitle = document.title;
+		this.count = 0;
 	}
 
 	setCount (count) {
+		this.count = count;
 		document.title = count > 0 ? `(${count}) ${this.originalTitle}` : this.originalTitle;
 	}
 }
@@ -64,3 +68,8 @@ export const setCount = count => {
 		title.setCount(count);
 	}
 };
+
+export const getState = () => ({
+	faviconHasDot: favicon ? favicon.showDot : false,
+	numberInTitle: title ? title.count : 0
+});

--- a/test/unread-articles-indicator/index.spec.js
+++ b/test/unread-articles-indicator/index.spec.js
@@ -36,11 +36,13 @@ describe('unread stories indicator', () => {
 			isAvailable: sinon.stub().callsFake(() => isStorageAvailable)
 		};
 		mockTracking = {
-			countShown: sinon.stub()
+			countShown: sinon.stub(),
+			onVisibilityChange: sinon.stub()
 		};
 		mockUi = {
 			createIndicators: sinon.stub(),
-			setCount: sinon.stub()
+			setCount: sinon.stub(),
+			getState: sinon.stub(),
 		};
 		mockFetchNewArticles = sinon.stub().returns(Promise.resolve(NEW_ARTICLES));
 		unreadStoriesIndicator = require('inject-loader!../../components/unread-articles-indicator')({


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8417658/64851175-c553cb00-d60e-11e9-8893-7c94b3714419.png)

New events : `browser-tab-visible`, `browser-tab-hidden`, with fields `faviconHasDot` and `numberInTitle`.

https://trello.com/c/DDxQgb3f/3739-myft-favicon-a-b-test

 🐿 v2.12.4