### PR TITLE
Restyle myFT unread articles indicator

### DIFF
--- a/components/unread-articles-indicator/main.scss
+++ b/components/unread-articles-indicator/main.scss
@@ -1,14 +1,44 @@
+$circle-radius-desktop: 17px;
+$circle-radius-mobile: 11px;
+
 .myft__indicator-container {
 	position: relative;
 }
 
 .myft__indicator {
+	padding: 0;
 	position: absolute;
-	top: 0;
-	right: -7px;
-	border-radius: 15px;
-	padding: 0 5px;
+	top: 16px;
+	right: -6px;
+
+	border: 1px solid oColorsGetPaletteColor('paper');
 	background-color: oColorsGetPaletteColor('claret');
 	color: oColorsGetPaletteColor('white');
-	@include oTypographySansBold(-1);
+
+	font-family: MetricWeb, sans-serif;
+	vertical-align: middle;
+	overflow: hidden;
+	text-align: center;
+
+	font-size: 9px;
+	line-height: $circle-radius-mobile;
+	border-radius: $circle-radius-mobile;
+	width: $circle-radius-mobile;
+	height: $circle-radius-mobile;
+	@include oGridRespondTo(M) {
+		right: -8px;
+		font-size: 11px;
+		line-height: $circle-radius-desktop;
+		border-radius: $circle-radius-desktop;
+		width: $circle-radius-desktop;
+		height: $circle-radius-desktop;
+		&.myft__indicator--single-digit {
+			// shows single digit counts slightly larger for more legibility
+			font-size: 13px;
+		}
+	}
+}
+
+.myft__indicator--hidden {
+	display: none;
 }

--- a/components/unread-articles-indicator/main.scss
+++ b/components/unread-articles-indicator/main.scss
@@ -8,7 +8,7 @@
 	right: -7px;
 	border-radius: 15px;
 	padding: 0 5px;
-	background-color: oColorsGetPaletteColor('teal');
+	background-color: oColorsGetPaletteColor('claret');
 	color: oColorsGetPaletteColor('white');
 	@include oTypographySansBold(-1);
 }

--- a/components/unread-articles-indicator/ui.js
+++ b/components/unread-articles-indicator/ui.js
@@ -5,6 +5,7 @@ class Indicator {
 
 		this.el = document.createElement('span');
 		this.el.classList.add('myft__indicator');
+		this.el.classList.add('myft__indicator--hidden');
 
 		container.appendChild(this.el);
 
@@ -14,7 +15,17 @@ class Indicator {
 	}
 
 	setCount (count) {
-		this.el.innerText = count > 0 ? count : '';
+		if( count < 1 ) {
+			this.el.classList.add('myft__indicator--hidden');
+		} else {
+			this.el.classList.remove('myft__indicator--hidden');
+			if( count < 10 ) {
+				this.el.classList.add('myft__indicator--single-digit');
+			} else {
+				this.el.classList.remove('myft__indicator--single-digit');
+			}
+			this.el.innerText = count > 0 && count < 200 ? count : '';
+		}
 	}
 }
 

--- a/test/unread-articles-indicator/ui.spec.js
+++ b/test/unread-articles-indicator/ui.spec.js
@@ -59,12 +59,12 @@ describe('unread stories indicator - ui', () => {
 				});
 			});
 
-			it('should clear the count when count is zero', () => {
+			it('should hide the indicator when count is zero', () => {
 				ui.setCount(0);
 				containers.forEach(container => {
 					const el = container.querySelector('.myft__indicator');
 
-					expect(el.innerText).to.equal('');
+					expect(el.classList.contains('myft__indicator--hidden')).to.equal(true);
 				});
 			});
 		});


### PR DESCRIPTION
Improvements to myFT Unread Articles Indicator

- Changes colour to claret
- Ensures it remains circular.
- Adjusts sizes of circle and text responsively.
- Uses smaller font for double digit numbers. 
- Limits length of text displayed by only showing numbers below 200
- Adds a border to contrast the dot with the myFT logo

Before:
![image](https://user-images.githubusercontent.com/8417658/64959218-921c7080-d888-11e9-9198-3bff04a5417e.png)

After:
![image](https://user-images.githubusercontent.com/8417658/64959776-c6446100-d889-11e9-9bde-96850ecd4e07.png)
![image](https://user-images.githubusercontent.com/8417658/64967836-1676ef80-d899-11e9-8c26-afd09a6cb002.png)

https://trello.com/c/JkXH2emN/3738-tidy-up-myft-indicator-styling-in-header

