### PR TITLE
Add two variants for wording of Add to myFT button

### DIFF
--- a/components/collections/collections.html
+++ b/components/collections/collections.html
@@ -63,22 +63,38 @@
 				{{~/concepts~}}"
 			/>
 			<button
-				type="submit"
-				aria-label="Add all topics in the {{title}} collection to my F T"
-				aria-pressed="false"
-				class="collection-follow-all__button {{#if liteStyle}}collection-follow-all__button--lite{{else}}collection-follow-all__button--regular{{/if}}"
-				data-alternate-label="Remove all topics in the {{title}} collection from my F T"
-				data-alternate-text="Added"
-				data-trackable="follow all"
-				data-concept-id="
-					{{~#concepts~}}
-						{{conceptId}}
-						{{~#unless @last~}}
-							,
-						{{~/unless~}}
-					{{~/concepts~}}"
-				title="Add all topics in the {{title}} collection to my F T">
-				Add all to myFT
+					type="submit"
+					aria-pressed="false"
+					class="collection-follow-all__button {{#if liteStyle}}collection-follow-all__button--lite{{else}}collection-follow-all__button--regular{{/if}}"
+					data-trackable="follow all"
+					data-concept-id="
+						{{~#concepts~}}
+							{{conceptId}}
+							{{~#unless @last~}}
+								,
+							{{~/unless~}}
+						{{~/concepts~}}"
+				{{#ifEquals @root.flags.followmyFTABTest 'Variant1' }}
+					aria-label="Add all topics in the {{title}} collection to feed"
+					data-alternate-label="Remove all topics in the {{title}} collection from feed"
+					data-alternate-text="Added to feed"
+					title="Add all topics in the {{title}} collection to feed">
+					Add all to feed
+				{{else}}
+					{{#ifEquals @root.flags.followmyFTABTest 'Variant2' }}
+						aria-label="Follow all topics in the {{title}} collection"
+						data-alternate-label="Unfollow all topics in the {{title}} collection"
+						data-alternate-text="Following"
+						title="Follow all topics in the {{title}} collection">
+						Follow all
+					{{else}}
+						aria-label="Add all topics in the {{title}} collection to my F T"
+						data-alternate-label="Remove all topics in the {{title}} collection from my F T"
+						data-alternate-text="Added"
+						title="Add all topics in the {{title}} collection to my F T">
+						Add all to myFT
+					{{/ifEquals}}
+				{{/ifEquals}}
 			</button>
 		</form>
 	</div>

--- a/components/follow-button/follow-button.html
+++ b/components/follow-button/follow-button.html
@@ -34,33 +34,95 @@
 		></div>
 		<button
 			{{#ifAll setFollowButtonStateToSelected @root.cacheablePersonalisedUrl}}
-				aria-label="Remove {{name}} from myFT"
-				title="Remove {{name}} from myFT"
-				data-alternate-label="Add {{name}} to myFT"
-				aria-pressed="true"
-				{{#if alternateText}}
-					data-alternate-text="{{alternateText}}"
-				{{else}}
-					{{#if buttonText}}
-						data-alternate-text="{{buttonText}}"
+				{{#ifEquals @root.flags.followmyFTABTest 'Variant1' }}
+					aria-label="Remove {{name}} from feed"
+					title="Remove {{name}} from feed"
+					data-alternate-label="Add {{name}} to feed"
+					aria-pressed="true"
+					{{#if alternateText}}
+						data-alternate-text="{{alternateText}}"
 					{{else}}
-						data-alternate-text="Add to myFT"
+						{{#if buttonText}}
+							data-alternate-text="{{buttonText}}"
+						{{else}}
+							data-alternate-text="Add to feed"
+						{{/if}}
 					{{/if}}
-				{{/if}}
+				{{else}}
+					{{#ifEquals @root.flags.followmyFTABTest 'Variant2'}}
+						aria-label="Unfollow {{name}}"
+						title="Unfollow {{name}}"
+						data-alternate-label="Follow {{name}}"
+						aria-pressed="true"
+						{{#if alternateText}}
+							data-alternate-text="{{alternateText}}"
+						{{else}}
+							{{#if buttonText}}
+								data-alternate-text="{{buttonText}}"
+							{{else}}
+								data-alternate-text="Unfollowed"
+							{{/if}}
+						{{/if}}
+					{{else}}
+						aria-label="Remove {{name}} from myFT"
+						title="Remove {{name}} from myFT"
+						data-alternate-label="Add {{name}} to myFT"
+						aria-pressed="true"
+						{{#if alternateText}}
+							data-alternate-text="{{alternateText}}"
+						{{else}}
+							{{#if buttonText}}
+								data-alternate-text="{{buttonText}}"
+							{{else}}
+								data-alternate-text="Add to myFT"
+							{{/if}}
+						{{/if}}
+					{{/ifEquals}}
+				{{/ifEquals}}
 			{{else}}
-				aria-label="Add {{name}} to myFT"
-				title="Add {{name}} to myFT"
-				data-alternate-label="Remove {{name}} from myFT"
 				aria-pressed="false"
-				{{#if alternateText}}
-					data-alternate-text="{{alternateText}}"
-				{{else}}
-					{{#if buttonText}}
-						data-alternate-text="{{buttonText}}"
+				{{#ifEquals @root.flags.followmyFTABTest 'Variant1' }}
+					aria-label="Add {{name}} to feed"
+					title="Add {{name}} to feed"
+					data-alternate-label="Remove {{name}} from feed"
+					{{#if alternateText}}
+						data-alternate-text="{{alternateText}}"
 					{{else}}
-						data-alternate-text="Added"
+						{{#if buttonText}}
+							data-alternate-text="{{buttonText}}"
+						{{else}}
+							data-alternate-text="Added to feed"
+						{{/if}}
 					{{/if}}
-				{{/if}}
+				{{else}}
+					{{#ifEquals @root.flags.followmyFTABTest 'Variant2' }}
+						aria-label="Follow {{name}}"
+						title="Follow {{name}}"
+						data-alternate-label="Unfollow {{name}}"
+						{{#if alternateText}}
+							data-alternate-text="{{alternateText}}"
+						{{else}}
+							{{#if buttonText}}
+								data-alternate-text="{{buttonText}}"
+							{{else}}
+								data-alternate-text="Following"
+							{{/if}}
+						{{/if}}
+					{{else}}
+						aria-label="Add {{name}} to myFT"
+						title="Add {{name}} to myFT"
+						data-alternate-label="Remove {{name}} from myFT"
+						{{#if alternateText}}
+							data-alternate-text="{{alternateText}}"
+						{{else}}
+							{{#if buttonText}}
+								data-alternate-text="{{buttonText}}"
+							{{else}}
+								data-alternate-text="Added"
+							{{/if}}
+						{{/if}}
+					{{/ifEquals}}
+				{{/ifEquals}}
 			{{/ifAll}}
 			class="{{extraButtonClasses}}
 				n-myft-follow-button
@@ -74,11 +136,27 @@
 			{{~#if buttonText~}}
 				{{buttonText}}
 			{{~else~}}
-				{{~#ifAll setFollowButtonStateToSelected @root.cacheablePersonalisedUrl~}}
-					Added
-				{{~else~}}
-					Add to myFT
-				{{~/ifAll~}}
+				{{~#ifEquals @root.flags.followmyFTABTest 'Variant1'~}}
+					{{~#ifAll setFollowButtonStateToSelected @root.cacheablePersonalisedUrl~}}
+						Added to feed
+					{{~else~}}
+						Add to feed
+					{{~/ifAll~}}
+				{{~/ifEquals~}}
+				{{~#ifEquals @root.flags.followmyFTABTest 'Variant2'~}}
+					{{~#ifAll setFollowButtonStateToSelected @root.cacheablePersonalisedUrl~}}
+						Following
+					{{~else~}}
+						Follow
+					{{~/ifAll~}}
+				{{~/ifEquals~}}
+				{{~#ifEquals @root.flags.followmyFTABTest false ~}}
+					{{~#ifAll setFollowButtonStateToSelected @root.cacheablePersonalisedUrl~}}
+						Added
+					{{~else~}}
+						Add to myFT
+					{{~/ifAll~}}
+				{{~/ifEquals~}}
 			{{~/if~}}
 		</button>
 	</form>


### PR DESCRIPTION
This adds two variants for the wording of the Add to myFT button, behind the `followmyFTABTest` flag.

**Control** 

![Screenshot 2019-09-17 at 15 51 57](https://user-images.githubusercontent.com/8225167/65053152-691cde00-d963-11e9-9477-e560ebc46e9d.png)

**Variant 1**

![Screenshot 2019-09-17 at 15 51 37](https://user-images.githubusercontent.com/8225167/65053163-6cb06500-d963-11e9-89fe-56b7264dde54.png)

**Variant 2**

![Screenshot 2019-09-17 at 15 50 01](https://user-images.githubusercontent.com/8225167/65053807-76869800-d964-11e9-9e36-ac5f5bf74479.png)

**Note:** I did not update the pop up as it seemed outside the scope of the card but the wording will be a bit inconsistent with the variants.

![Screenshot 2019-09-17 at 15 56 55](https://user-images.githubusercontent.com/8225167/65053479-ecd6ca80-d963-11e9-9c9f-af85f5eaf209.png)

https://trello.com/c/Z8MFkTI1/3753-myft-debranding-prepare-a-b-test