### PR TITLE
Ensure the unread article indicator polling recovers

### DIFF
--- a/components/unread-articles-indicator/storage.js
+++ b/components/unread-articles-indicator/storage.js
@@ -33,12 +33,27 @@ export const isAvailable = () => {
 	}
 };
 
-export const setLastUpdate = (update) => window.localStorage.setItem(LAST_INDICATOR_UPDATE, JSON.stringify(Object.assign( {}, update, update && update.time && {time: update.time.toISOString()})) );
+export const setLastUpdate = (update) =>
+	window.localStorage.setItem(LAST_INDICATOR_UPDATE,
+		JSON.stringify(
+			Object.assign(
+				{},
+				update,
+				update && update.time && {time: update.time.toISOString()},
+				update && update.updateStarted && {updateStarted: update.updateStarted.toISOString()}
+			)
+		)
+	);
 
 export const getLastUpdate = () => {
 	try {
 		const update = JSON.parse(window.localStorage.getItem(LAST_INDICATOR_UPDATE));
-		return Object.assign({}, update, update && update.time && {time: new Date(update.time)});
+		return Object.assign(
+			{},
+			update,
+			update && update.time && {time: new Date(update.time)},
+			update && update.updateStarted && {updateStarted: new Date(update.updateStarted)}
+		);
 	} catch (e) {}
 };
 

--- a/components/unread-articles-indicator/update.js
+++ b/components/unread-articles-indicator/update.js
@@ -4,16 +4,24 @@ import * as ui from './ui';
 import * as tracking from './tracking';
 
 const UPDATE_INTERVAL = 1000 * 60 * 5; // how often to get an update from the server.
+const UPDATE_TIMEOUT = 1000 * 60 * 10; // how long before we assume an update finished without tidying up.
 
 export default function update (now) {
 	const lastUpdate = storage.getLastUpdate();
 
-	const readyToUpdate = !lastUpdate ||
-		!lastUpdate.inProgress && (!lastUpdate.time || now.getTime() - lastUpdate.time.getTime() > UPDATE_INTERVAL);
+	const readyToUpdate =
+		// Always update if there has never been an update before.
+		!lastUpdate || (
+			// Update if an update is overdue, and
+			(!lastUpdate.time || now.getTime() - lastUpdate.time.getTime() > UPDATE_INTERVAL) &&
+			// there is no update underway, or
+			// the update started so long ago that it must have failed or completed by now.
+			(!lastUpdate.updateStarted || now.getTime() - lastUpdate.updateStarted.getTime() > UPDATE_TIMEOUT)
+		);
 
 	if (readyToUpdate) {
 
-		storage.updateLastUpdate({inProgress: true});
+		storage.updateLastUpdate({updateStarted: now});
 
 		const startTime = storage.getFeedStartTime();
 
@@ -26,9 +34,9 @@ export default function update (now) {
 					tracking.onCountChange(count, startTime);
 				}
 
-				storage.setLastUpdate({time: now, count, inProgress: false});
+				storage.setLastUpdate({time: now, count, updateStarted: false});
 			})
-			.catch(() => storage.updateLastUpdate({inProgress: false}));
+			.catch(() => storage.updateLastUpdate({updateStarted: false}));
 
 	} else {
 		ui.setCount(lastUpdate ? lastUpdate.count : 0);

--- a/test/unread-articles-indicator/storage.spec.js
+++ b/test/unread-articles-indicator/storage.spec.js
@@ -128,15 +128,33 @@ describe('storage', () => {
 
 	describe('getLastUpdate', () => {
 		beforeEach(() => {
-			mockStorage.myFTIndicatorUpdate = JSON.stringify({foo:1, time: now.toISOString()});
+			mockStorage.myFTIndicatorUpdate = JSON.stringify({foo:1, time: now.toISOString(), updateStarted: now.toISOString()});
 		});
 
 		it('converts time from ISOString to Date', () => {
 			expect(storage.getLastUpdate().time).to.be.a('Date');
 		});
 
-		it('gives the right Date', () => {
+		it('converts updateStarted from ISOString to Date', () => {
+			expect(storage.getLastUpdate().updateStarted).to.be.a('Date');
+		});
+
+		it('gives the right time', () => {
 			expect(storage.getLastUpdate().time.getTime()).to.be.equal(now.getTime());
+		});
+
+		it('gives the right updateStarted', () => {
+			expect(storage.getLastUpdate().updateStarted.getTime()).to.be.equal(now.getTime());
+		});
+	});
+
+	describe('getLastUpdate when updateStarted is false', () => {
+		beforeEach(() => {
+			mockStorage.myFTIndicatorUpdate = JSON.stringify({foo:1, time: now.toISOString(), updateStarted: false});
+		});
+
+		it('gives the right updateStarted', () => {
+			expect(storage.getLastUpdate().updateStarted).equal(false);
 		});
 	});
 
@@ -154,6 +172,31 @@ describe('storage', () => {
 
 			it('leaves other properties unchanged', () => {
 				expect(JSON.parse(mockStorage.myFTIndicatorUpdate).foo).to.equal(3);
+			});
+		});
+		describe('when updating updateStarted with a Date', () =>{
+			const date = new Date(2018, 5, 1, 11, 30, 0);
+			beforeEach(() => {
+				mockStorage.myFTIndicatorUpdate = JSON.stringify({foo: 3, updateStarted: now.toISOString()});
+				storage.updateLastUpdate({updateStarted: date});
+			});
+
+			it('converts updateStarted from Date to ISOString', () => {
+				expect(JSON.parse(mockStorage.myFTIndicatorUpdate).updateStarted).to.equal(date.toISOString());
+			});
+
+			it('leaves other properties unchanged', () => {
+				expect(JSON.parse(mockStorage.myFTIndicatorUpdate).foo).to.equal(3);
+			});
+		});
+		describe('when updating updateStarted with false', () =>{
+			beforeEach(() => {
+				mockStorage.myFTIndicatorUpdate = JSON.stringify({foo: 3, updateStarted: now.toISOString()});
+				storage.updateLastUpdate({updateStarted: false});
+			});
+
+			it('sets updateStarted to false', () => {
+				expect(JSON.parse(mockStorage.myFTIndicatorUpdate).updateStarted).to.equal(false);
 			});
 		});
 		describe('when updating other properties', () =>{

--- a/test/unread-articles-indicator/update.spec.js
+++ b/test/unread-articles-indicator/update.spec.js
@@ -55,7 +55,7 @@ describe('update function', () => {
 		});
 
 		it('marked an update as in progress', () => {
-			expect(mockStorage._setLastUpdate.firstCall.args[0].inProgress).equal(true);
+			expect(mockStorage._setLastUpdate.firstCall.args[0].updateStarted.toISOString()).equal(MOCK_NOW.toISOString());
 		});
 
 		it('updates the local storage', () => {
@@ -85,11 +85,11 @@ describe('update function', () => {
 		});
 
 		it('marked an update as in progress', () => {
-			expect(mockStorage._setLastUpdate.firstCall.args[0].inProgress).equal(true);
+			expect(mockStorage._setLastUpdate.firstCall.args[0].updateStarted.toISOString()).equal(MOCK_NOW.toISOString());
 		});
 
 		it('doesn\'t block further updates', () => {
-			expect(mockStorage.lastUpdate.inProgress).equal(false);
+			expect(mockStorage.lastUpdate.updateStarted).equal(false);
 		});
 	});
 
@@ -131,7 +131,7 @@ describe('update function', () => {
 		});
 
 		it('marks the update as in progress', () => {
-			expect(mockStorage._setLastUpdate.firstCall.args[0].inProgress).equal(true);
+			expect(mockStorage._setLastUpdate.firstCall.args[0].updateStarted.toISOString()).equal(MOCK_NOW.toISOString());
 		});
 
 		it('doesn\'t update the ui', () => {
@@ -139,14 +139,14 @@ describe('update function', () => {
 		});
 
 		it('doesn\'t block further updates', () => {
-			expect(mockStorage.lastUpdate.inProgress).equal(false);
+			expect(mockStorage.lastUpdate.updateStarted).equal(false);
 		});
 	});
 
 	context('when an update is due but already happening', () => {
 		before( function () {
 			resetMocks();
-			mockStorage.lastUpdate = {time: MOCK_OVERDUE_REFRESH_TIME, count: MOCK_PREVIOUS_COUNT, inProgress: true};
+			mockStorage.lastUpdate = {time: MOCK_OVERDUE_REFRESH_TIME, count: MOCK_PREVIOUS_COUNT, updateStarted: MOCK_OVERDUE_REFRESH_TIME};
 			return update(MOCK_NOW);
 		} );
 


### PR DESCRIPTION
Testing this in the absence of a network connection revealed a bug where the update would get stuck as "inProgress" forever, even after the browser has closed.

This change ensures the app can recover, by assuming that any update taking longer than 10 minutes must have completed by now.

 🐿 v2.12.4