### PR TITLE
Make feed start time available as export

### DIFF
--- a/components/unread-articles-indicator/index.js
+++ b/components/unread-articles-indicator/index.js
@@ -1,3 +1,4 @@
+import {startOfDay} from 'date-fns';
 import * as storage from './storage';
 import * as ui from './ui';
 import update from './update';
@@ -6,10 +7,26 @@ import sessionClient from 'next-session-client';
 
 const REFRESH_INTERVAL = 1000; //  how often each window should whether an update is due. This is the max time that the tabs can be out of sync for.
 
+let initialFeedStartTime;
+
 const updater = () =>
 	update(new Date())
 		.then(() => window.setTimeout(updater, REFRESH_INTERVAL));
 
+// Used by next-myft-page to determine NEW tags on articles feed
+export const getNewArticlesSinceTime = () => {
+	if (initialFeedStartTime) {
+		return Promise.resolve(initialFeedStartTime);
+	}
+	if (!storage.isAvailable()) {
+		return Promise.resolve(startOfDay(new Date()));
+	}
+	return initialiseFeedStartTime(new Date())
+		.then( (startTime) => {
+			initialFeedStartTime = startTime;
+			return initialFeedStartTime;
+		});
+};
 
 export default (options = {}) => {
 	if (!storage.isAvailable()) {
@@ -18,7 +35,7 @@ export default (options = {}) => {
 	return sessionClient.uuid()
 		.then(({uuid}) => {
 			if (uuid) {
-				return initialiseFeedStartTime(new Date())
+				return getNewArticlesSinceTime(new Date())
 					.then(() => {
 						ui.createIndicators(document.querySelectorAll('.o-header__top-link--myft'),
 							Object.assign({

--- a/components/unread-articles-indicator/initialise-feed-start-time.js
+++ b/components/unread-articles-indicator/initialise-feed-start-time.js
@@ -55,4 +55,7 @@ const determineFeedStartTime = (now, previousFeedStartTime) => {
  */
 export default (now) =>
 	determineFeedStartTime(now, storage.getFeedStartTime())
-		.then(startTime => storage.setFeedStartTime(startTime));
+		.then(startTime => {
+			storage.setFeedStartTime(startTime);
+			return startTime;
+		});

--- a/test/unread-articles-indicator/index.spec.js
+++ b/test/unread-articles-indicator/index.spec.js
@@ -46,7 +46,7 @@ describe('unread stories indicator', () => {
 		describe('storage availability', () => {
 			it('should not do anything if storage is not available', () => {
 				isStorageAvailable = false;
-				unreadStoriesIndicator();
+				unreadStoriesIndicator.default();
 				expect(mockUi.createIndicators).to.not.have.been.called;
 				expect(mockUi.setCount).to.not.have.been.called;
 				expect(mockInitialiseFeedStartTime).to.not.have.been.called;
@@ -56,7 +56,7 @@ describe('unread stories indicator', () => {
 		describe('initialisation', () => {
 			beforeEach(() => {
 				isStorageAvailable = true;
-				return unreadStoriesIndicator();
+				return unreadStoriesIndicator.default();
 			});
 
 			it('should initialise feed start time', () => {


### PR DESCRIPTION
It's used by next-myft-page to add NEW labels to articles feed

 🐿 v2.12.4