### PR TITLE
Update unread-articles when browser tab is selected

### DIFF
--- a/components/unread-articles-indicator/index.js
+++ b/components/unread-articles-indicator/index.js
@@ -49,6 +49,13 @@ export default (options = {}) => {
 							updater();
 						} else {
 							update(new Date());
+							document.addEventListener('visibilitychange', () => {
+								if (document.visibilityState === 'visible') {
+									getNewArticlesSinceTime().then(
+										update(new Date())
+									);
+								}
+							});
 						}
 					});
 			}


### PR DESCRIPTION
This was how it behaved before we did the periodic polling.

Re-adding this behaviour now that we have disabled polling.


 🐿 v2.12.4