### PR TITLE
Update to ES6 module imports (myFT Digest Promo issue)

### DIFF
--- a/components/digest-promo/index.js
+++ b/components/digest-promo/index.js
@@ -101,4 +101,4 @@ function init () {
 	});
 };
 
-module.exports = { init };
+export { init };

--- a/components/digest-promo/index.js
+++ b/components/digest-promo/index.js
@@ -1,7 +1,7 @@
-const myFtClient = require('next-myft-client').default;
-const buttons = require('../../myft-common');
-const getToken = require('../../myft/ui/lib/get-csrf-token').default;
-const superstore = require('superstore-sync');
+import myFtClient from 'next-myft-client';
+import buttons from '../../myft-common';
+import getToken from '../../myft/ui/lib/get-csrf-token';
+import superstore from 'superstore-sync';
 const STORAGE_KEY = 'n-myft-digest-promo-seen';
 
 const CLASSES = {


### PR DESCRIPTION
A js error is currently thrown on the fastFT stream (possibly other places) when the myftdigestpromo flag is enabled - it appears to be caused by the myFTClient module not importing correctly - this PR swaps the requires for ES module imports, which appears to fix the issue