### PR TITLE
change instant alerts popup text 🐿 v2.12.5

### DIFF
--- a/components/instant-alerts-confirmation/index.js
+++ b/components/instant-alerts-confirmation/index.js
@@ -3,7 +3,7 @@ const Overlay = require('o-overlay');
 const buildOverlayContent = isBlocked => `
 <div class='instant-alerts-confirmation__info'>
 	<div class='instant-alerts-confirmation-info__icon'></div>
-	<div class='instant-alerts-confirmation-info__text'>Would you like to receive instant alerts?</div>
+	<div class='instant-alerts-confirmation-info__text'>Would you like to receive instant alerts on this device?</div>
 </div>
 ${isBlocked ? '<div class=\'instant-alerts-confirmation-info__subtext\'>Unblock notifications to receive them on this device.</div>' : ''}
 <div class='instant-alerts-confirmation__buttons'>

--- a/components/instant-alerts-confirmation/main.scss
+++ b/components/instant-alerts-confirmation/main.scss
@@ -54,6 +54,10 @@
 
 .instant-alerts-confirmation-info__icon {
 	@include oIconsGetIcon('notifications', getColor('claret'), 42, $iconset-version: 1);
+	margin-left: -8px;
+	@include oGridRespondTo(M) {
+		margin-left: -12px;
+	}
 }
 
 .instant-alerts-confirmation-info__subtext {


### PR DESCRIPTION
add the words ` on this device` to the end of the instant alerts popup