### PR TITLE
unread articles updates

### DIFF
--- a/components/unread-articles-indicator/constants.js
+++ b/components/unread-articles-indicator/constants.js
@@ -1,0 +1,4 @@
+const MINUTE = 60 * 1000;
+
+export const UPDATE_INTERVAL = 5 * MINUTE; // how often we should refresh the data from the server
+export const UPDATE_TIMEOUT = 10 * MINUTE; // how long before we assume an update finished without tidying up.

--- a/components/unread-articles-indicator/count-unread-articles.js
+++ b/components/unread-articles-indicator/count-unread-articles.js
@@ -23,6 +23,6 @@ async function fetchContentFromPersonalisedFeed (userId) {
 	const res = await fetch(`/__myft/api/onsite/feed/${userId}?${searchParams.toString()}`, {
 		credentials: 'include'
 	});
-	const {results = []} = res.statusCode === 401 ? {} : await fetchJson(res);
+	const {results = []} = await fetchJson(res);
 	return results;
 }

--- a/components/unread-articles-indicator/count-unread-articles.js
+++ b/components/unread-articles-indicator/count-unread-articles.js
@@ -1,71 +1,28 @@
-import sessionClient from 'next-session-client';
 import {json as fetchJson} from 'fetchres';
 import {isAfter, parseISO} from 'date-fns';
-import squashWhitespace from './lib/squash-whitespace';
 
-const fetchContentFromPersonalisedFeed = uuid => {
-	if (!uuid) {
-		return Promise.resolve([]);
-	}
-
-	const url = `/__myft/api/onsite/feed/${uuid}?originatingSignals=followed&from=-24h&source=myft-ui`;
-	const options = {credentials: 'include'};
-
-	return fetch(url, options)
-		.then(fetchJson)
-		.then(body => body.results);
-};
-
-// read state in articlesFromReadingHistory will be delayed by up to ~1 minute
-const fetchReadingHistory = uuid => {
-	if (!uuid) {
-		return Promise.resolve([]);
-	}
-
-	const gqlQuery = `
-		query newMyFTContentSince($uuid: String!) {
-			user(uuid: $uuid) {
-				articlesFromReadingHistory {
-					articles {
-						id
-					}
-				}
-			}
-		}
-		`;
-	const variables = {uuid};
-	const url = `https://next-api.ft.com/v2/query?query=${squashWhitespace(gqlQuery)}&variables=${JSON.stringify(variables)}&source=next-myft`;
-	const options = {credentials: 'include'};
-
-	return fetch(url, options)
-		.then(fetchJson)
-		.then(body => body.data)
-		.then(data => data.user.articlesFromReadingHistory ? data.user.articlesFromReadingHistory.articles : [])
-		.catch(() => []);
-};
-
-const removeReadArticles = (allArticles, readArticles) =>
-	allArticles.reduce((unreadArticles, article) => {
-		if (readArticles.find(readArticle => article.id === readArticle.id)) {
-			return unreadArticles;
-		}
-		return unreadArticles.concat(article);
-	},
-	[]);
-
-const getUnreadArticles = (uuid) =>
-	Promise.all([fetchContentFromPersonalisedFeed(uuid), fetchReadingHistory(uuid)])
-		.then(([userFeedLast24Hours, readingHistory]) => removeReadArticles(userFeedLast24Hours, readingHistory));
-
-const filterRecent = (articles, startTime) => {
+export default async (userId, startTime) => {
 	if (typeof startTime === 'string') startTime = parseISO(startTime);
-	return articles.filter(
-		article => isAfter(parseISO(article.contentTimeStamp), startTime)
-	);
+
+	const articles = await fetchContentFromPersonalisedFeed(userId);
+	const unreadArticlesSinceLastVisit = articles
+		.filter(({userCompletion = -1}) => userCompletion < 1) // only include unread articles
+		.filter(({contentTimeStamp}) => isAfter(parseISO(contentTimeStamp), startTime)); // only include articles published since last visit
+
+	return unreadArticlesSinceLastVisit.length;
 };
 
-export default (startTime) =>
-	sessionClient.uuid()
-		.then(({uuid}) => getUnreadArticles(uuid))
-		.then(articles => filterRecent(articles, startTime))
-		.then(newArticles => newArticles.length);
+async function fetchContentFromPersonalisedFeed (userId) {
+
+	const searchParams = new URLSearchParams({
+		originatingSignals: 'followed',
+		from: '-1d',
+		source: 'myft-ui'
+	});
+
+	const res = await fetch(`/__myft/api/onsite/feed/${userId}?${searchParams.toString()}`, {
+		credentials: 'include'
+	});
+	const {results = []} = res.statusCode === 401 ? {} : await fetchJson(res);
+	return results;
+}

--- a/components/unread-articles-indicator/update-count.js
+++ b/components/unread-articles-indicator/update-count.js
@@ -2,10 +2,7 @@ import {isAfter, parseISO} from 'date-fns';
 import * as storage from './storage';
 import countUnreadArticles from './count-unread-articles';
 import * as tracking from './tracking';
-import {
-	UPDATE_INTERVAL,
-	UPDATE_TIMEOUT
-} from './constants';
+import {UPDATE_INTERVAL, UPDATE_TIMEOUT} from './constants';
 
 
 function latest ( a, b ) {
@@ -18,34 +15,27 @@ function latest ( a, b ) {
 	return isAfter(parseISO(a),parseISO(b)) ? a : b;
 }
 
-export default function updateCount (userId, now) {
+export default async function updateCount (userId, now) {
 	const lastUpdate = storage.getLastUpdate();
 
-	const readyToUpdate =
-		// Always update if there has never been an update before.
-		!lastUpdate || (
-			// Update if an update is overdue, and
-			(!lastUpdate.time || now.getTime() - lastUpdate.time.getTime() > UPDATE_INTERVAL) &&
-			// there is no update underway, or
-			// the update started so long ago that it must have failed or completed by now.
-			(!lastUpdate.updateStarted || now.getTime() - lastUpdate.updateStarted.getTime() > UPDATE_TIMEOUT)
-		);
+	const isFirstUpdate = !lastUpdate; // Always update if there has never been an update before.
+	const noUpdateInProgress = !isFirstUpdate && (!lastUpdate.time || now.getTime() - lastUpdate.time.getTime() > UPDATE_INTERVAL);
+	const updateInProgressHasTimedOut = !isFirstUpdate && (!lastUpdate.updateStarted || now.getTime() - lastUpdate.updateStarted.getTime() > UPDATE_TIMEOUT);
 
-	if (readyToUpdate) {
+	if (isFirstUpdate || noUpdateInProgress && updateInProgressHasTimedOut) {
 
 		storage.updateLastUpdate({updateStarted: now});
 
 		const startTime = latest(storage.getFeedStartTime(), storage.getIndicatorDismissedTime());
-		return countUnreadArticles(userId, startTime)
-			.then((count) => {
-				if (!lastUpdate || count !== lastUpdate.count) {
-					tracking.onCountChange(count, startTime);
-				}
-				storage.setLastUpdate({time: now, count, updateStarted: false});
-			})
-			.catch(() => storage.updateLastUpdate({updateStarted: false}));
-
-	} else {
-		return Promise.resolve();
+		try {
+			const count = await countUnreadArticles(userId, startTime);
+			if (!lastUpdate || count !== lastUpdate.count) {
+				tracking.onCountChange(count, startTime);
+			}
+			storage.setLastUpdate({time: now, count, updateStarted: false});
+		} catch (error) {
+			storage.updateLastUpdate({updateStarted: false});
+			throw error;
+		}
 	}
 };

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -51,8 +51,12 @@ module.exports = function (karma) {
 						exclude: /node_modules\/(?!(@financial-times\/n-teaser|@financial-times\/n-display-metadata)\/).*/,
 						query: {
 							cacheDirectory: true,
-							presets: ['es2015'],
-							plugins: [['add-module-exports', { loose: true }], ['transform-es2015-classes', { loose: true }]]
+							presets: ['env'],
+							plugins: [
+								['transform-runtime'],
+								['add-module-exports', { loose: true }],
+								['transform-es2015-classes', { loose: true }]
+							]
 						}
 					},
 					// set 'this' scope to window

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "homepage": "https://github.com/Financial-Times/n-myft-ui#readme",
   "devDependencies": {
+    "@babel/plugin-transform-async-to-generator": "^7.7.0",
     "@financial-times/n-gage": "^3.11.2",
     "@financial-times/n-heroku-tools": "8.3.1",
     "@financial-times/n-internal-tool": "2.3.4",
@@ -33,6 +34,7 @@
     "babel-core": "^6.2.1",
     "babel-loader": "^6.2.4",
     "babel-plugin-add-module-exports": "^0.3.0",
+    "babel-plugin-transform-async-to-generator": "^6.24.1",
     "babel-plugin-transform-es2015-classes": "^6.8.0",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.5.2",
     "babel-plugin-transform-runtime": "^6.9.0",
@@ -83,10 +85,12 @@
     "snyk": "^1.216.5"
   },
   "dependencies": {
+    "babel-preset-env": "^1.7.0",
     "date-fns": "2.7.0",
     "form-serialize": "^0.7.2",
     "js-cookie": "^2.2.0",
-    "lodash": "^4.17.10"
+    "lodash": "^4.17.10",
+    "regenerator-runtime": "^0.13.3"
   },
   "x-dash": {
     "engine": {

--- a/test/unread-articles-indicator/index.spec.js
+++ b/test/unread-articles-indicator/index.spec.js
@@ -20,9 +20,11 @@ describe('unread stories indicator', () => {
 		mockStorage = {
 			getFeedStartTime: sinon.stub().returns(FEED_START_TIME),
 			setFeedStartTime: sinon.stub(),
+			getLastUpdate: sinon.stub().returns({count: 22}),
 			updateLastUpdate: sinon.stub(),
 			isAvailable: sinon.stub().callsFake(() => isStorageAvailable),
-			setIndicatorDismissedTime: sinon.stub()
+			setIndicatorDismissedTime: sinon.stub(),
+			addCountChangeListeners: sinon.stub()
 		};
 		mockUi = {
 			createIndicators: sinon.stub(),
@@ -38,7 +40,7 @@ describe('unread stories indicator', () => {
 			},
 			'./storage': mockStorage,
 			'./ui': mockUi,
-			'./update': mockUpdate,
+			'./update-count': mockUpdate,
 			'./initialise-feed-start-time': mockInitialiseFeedStartTime
 		});
 	});
@@ -67,6 +69,16 @@ describe('unread stories indicator', () => {
 			it('should create ui indicators', () => {
 				expect(mockUi.createIndicators).to.have.been.calledOnce;
 			});
+
+			it('should set the ui indicators initial count', () => {
+				expect(mockUi.setCount).to.have.been.calledOnce;
+				expect(mockUi.setCount).to.have.been.calledWith(22);
+			});
+
+			it('should set a listener for storage changes', () => {
+				expect(mockStorage.addCountChangeListeners).to.have.been.calledOnce;
+			});
+
 
 			it('should handle clicks', () => {
 				const args = mockUi.createIndicators.firstCall.args;

--- a/test/unread-articles-indicator/initialise-feed-start-time.spec.js
+++ b/test/unread-articles-indicator/initialise-feed-start-time.spec.js
@@ -18,6 +18,7 @@ const VISIT_TIME_TODAY = new Date('2018-03-05T14:00:00Z');
 const VISIT_TIME_YESTERDAY = new Date('2018-03-04T14:00:00Z');
 const FEED_TIME_TODAY = new Date('2018-03-05T12:00:00Z');
 const FEED_TIME_YESTERDAY = new Date('2018-03-04T12:00:00Z');
+const USER_ID = '00000000-0000-0000-0000-000000000000';
 
 const mockSetFeedStartTime = sinon.stub();
 
@@ -29,9 +30,6 @@ describe('initialiseFeedStartTime', () => {
 	const injector = require('inject-loader!../../components/unread-articles-indicator/initialise-feed-start-time');
 	const initialiseFeedStartTime = injector({
 		'date-fns': mockDateFns,
-		'next-session-client': {
-			uuid: sinon.stub().resolves({uuid: '00000000-0000-0000-0000-000000000000'})
-		},
 		'./device-session': () => ({ isNewSession: () => isNewSession }),
 		'./storage': {
 			setFeedStartTime: mockSetFeedStartTime,
@@ -43,7 +41,9 @@ describe('initialiseFeedStartTime', () => {
 	const expectStartTime = startTime => expect(mockSetFeedStartTime.firstCall.args[0].toISOString()).equal(startTime.toISOString());
 
 	before(() => {
-		fetchMock.get('begin:https://next-api.ft.com/v2/', ()=>({body: {data: {user: {lastSeenTimestamp: lastVisitTime.toISOString()}}}}));
+		fetchMock.get(`begin:/__myft/users/${USER_ID}/last-seen`, () => ({
+			lastSeen: lastVisitTime && lastVisitTime.toISOString()
+		}));
 	});
 	after(() => {
 		fetchMock.restore();
@@ -57,7 +57,7 @@ describe('initialiseFeedStartTime', () => {
 			before(() => {
 				mockSetFeedStartTime.resetHistory();
 				lastVisitTime = VISIT_TIME_TODAY;
-				return initialiseFeedStartTime(TIME_NOW);
+				return initialiseFeedStartTime(USER_ID, TIME_NOW);
 			});
 			it('sets start time to visit time', () => {
 				expectStartTime(VISIT_TIME_TODAY);
@@ -67,7 +67,7 @@ describe('initialiseFeedStartTime', () => {
 			before(() => {
 				mockSetFeedStartTime.resetHistory();
 				lastVisitTime = VISIT_TIME_YESTERDAY;
-				return initialiseFeedStartTime(TIME_NOW);
+				return initialiseFeedStartTime(USER_ID, TIME_NOW);
 			});
 			it('sets start time to start of today', () => {
 				expectStartTime(START_OF_TODAY);
@@ -77,7 +77,7 @@ describe('initialiseFeedStartTime', () => {
 			before(() => {
 				mockSetFeedStartTime.resetHistory();
 				lastVisitTime = undefined;
-				return initialiseFeedStartTime(TIME_NOW);
+				return initialiseFeedStartTime(USER_ID, TIME_NOW);
 			});
 			it('sets start time to start of today', () => {
 				expectStartTime(START_OF_TODAY);
@@ -92,7 +92,7 @@ describe('initialiseFeedStartTime', () => {
 			before(() => {
 				mockSetFeedStartTime.resetHistory();
 				lastVisitTime = VISIT_TIME_TODAY;
-				return initialiseFeedStartTime();
+				return initialiseFeedStartTime(USER_ID, );
 			});
 			it('sets start time to previous feed start time', () => {
 				expectStartTime(FEED_TIME_TODAY);
@@ -109,7 +109,7 @@ describe('initialiseFeedStartTime', () => {
 				before(() => {
 					mockSetFeedStartTime.resetHistory();
 					lastVisitTime = VISIT_TIME_TODAY;
-					return initialiseFeedStartTime(TIME_NOW);
+					return initialiseFeedStartTime(USER_ID, TIME_NOW);
 				});
 				it('sets start time to visit time', () => {
 					expectStartTime(VISIT_TIME_TODAY);
@@ -119,7 +119,7 @@ describe('initialiseFeedStartTime', () => {
 				before(() => {
 					mockSetFeedStartTime.resetHistory();
 					lastVisitTime = VISIT_TIME_YESTERDAY;
-					return initialiseFeedStartTime(TIME_NOW);
+					return initialiseFeedStartTime(USER_ID, TIME_NOW);
 				});
 				it('sets start time to start of today', () => {
 					expectStartTime(START_OF_TODAY);
@@ -129,7 +129,7 @@ describe('initialiseFeedStartTime', () => {
 				before(() => {
 					mockSetFeedStartTime.resetHistory();
 					lastVisitTime = undefined;
-					return initialiseFeedStartTime(TIME_NOW);
+					return initialiseFeedStartTime(USER_ID, TIME_NOW);
 				});
 				it('sets start time to start of today', () => {
 					expectStartTime(START_OF_TODAY);
@@ -145,7 +145,7 @@ describe('initialiseFeedStartTime', () => {
 			before(() => {
 				mockSetFeedStartTime.resetHistory();
 				lastVisitTime = VISIT_TIME_TODAY;
-				return initialiseFeedStartTime(TIME_NOW);
+				return initialiseFeedStartTime(USER_ID, TIME_NOW);
 			});
 			it('sets start time to visit time', () => {
 				expectStartTime(VISIT_TIME_TODAY);
@@ -155,7 +155,7 @@ describe('initialiseFeedStartTime', () => {
 			before(() => {
 				mockSetFeedStartTime.resetHistory();
 				lastVisitTime = VISIT_TIME_YESTERDAY;
-				return initialiseFeedStartTime(TIME_NOW);
+				return initialiseFeedStartTime(USER_ID, TIME_NOW);
 			});
 			it('sets start time to start of today', () => {
 				expectStartTime(START_OF_TODAY);
@@ -165,7 +165,7 @@ describe('initialiseFeedStartTime', () => {
 			before(() => {
 				mockSetFeedStartTime.resetHistory();
 				lastVisitTime = undefined;
-				return initialiseFeedStartTime(TIME_NOW);
+				return initialiseFeedStartTime(USER_ID, TIME_NOW);
 			});
 			it('sets start time to start of today', () => {
 				expectStartTime(START_OF_TODAY);

--- a/test/unread-articles-indicator/update-count.spec.js
+++ b/test/unread-articles-indicator/update-count.spec.js
@@ -108,11 +108,16 @@ describe('update function', () => {
 	});
 
 	context('when an update fails', () => {
-		before( () => {
+		let err;
+		before( async () => {
 			resetMocks();
-			mocks.countUnreadArticles.rejects('boom');
+			mocks.countUnreadArticles.rejects(new Error('boom'));
 			mockStorage.lastUpdate = undefined;
-			return updateCount(USER_ID, MOCK_NOW);
+			try {
+				await updateCount(USER_ID, MOCK_NOW);
+			} catch(e) {
+				err = e;
+			}
 		} );
 
 		after( () => {
@@ -125,6 +130,10 @@ describe('update function', () => {
 
 		it('doesn\'t block further updates', () => {
 			expect(mockStorage.lastUpdate.updateStarted).equal(false);
+		});
+
+		it('should throw an error', () => {
+			expect(err.message).to.equal('boom');
 		});
 	});
 


### PR DESCRIPTION
Apologies for the big first commit

- removes dependency on next-api
- switches to using async/await
- pass userId around rather than fetching multiple times
- listen for changes made by other tabs via `'storage'` events
- cancel polling on error