### PR TITLE
remove npm dependencies in favour of bower dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,9 @@ run:
 	cp -rf $(shell cat _test-server/template-copy-list.txt) bower_components/n-ui
 	node _test-server/app
 
+prevent-npm-dependencies:
+	@node scripts/prevent-npm-deps.js
+
 # copy project files into bower components so that we can reference component partials
 # in the same way that apps that use the components do
 demo-build:
@@ -38,6 +41,7 @@ a11y: demo-build
 	@$(DONE)
 
 test:
+	make prevent-npm-dependencies
 	make verify
 	make test-unit
 	make test-build

--- a/bower.json
+++ b/bower.json
@@ -26,7 +26,8 @@
     "next-session-client": "^2.3.4",
     "fetchres": "^1.7.2",
     "o-tooltip": "^3.5.0",
-    "js-cookie": "^2.2.0"
+    "js-cookie": "^2.2.0",
+    "form-serialize": "^0.7.2"
   },
   "resolutions": {
     "ftdomdelegate": "^3.0.0"

--- a/components/unread-articles-indicator/count-unread-articles.js
+++ b/components/unread-articles-indicator/count-unread-articles.js
@@ -1,5 +1,6 @@
 import {json as fetchJson} from 'fetchres';
-import {isAfter, parseISO} from 'date-fns';
+import isAfter from 'date-fns/src/isAfter';
+import parseISO from 'date-fns/src/parseISO';
 
 export default async (userId, startTime) => {
 	if (typeof startTime === 'string') startTime = parseISO(startTime);

--- a/components/unread-articles-indicator/device-session.js
+++ b/components/unread-articles-indicator/device-session.js
@@ -1,4 +1,6 @@
-import { isAfter, addMinutes, parseISO} from 'date-fns';
+import addMinutes from 'date-fns/src/addMinutes';
+import isAfter from 'date-fns/src/isAfter';
+import parseISO from 'date-fns/src/parseISO';
 import * as storage from './storage';
 const SESSION_THRESHOLD_MINUTES = 30;
 

--- a/components/unread-articles-indicator/index.js
+++ b/components/unread-articles-indicator/index.js
@@ -1,4 +1,4 @@
-import {startOfDay} from 'date-fns';
+import startOfDay from 'date-fns/src/startOfDay';
 import * as storage from './storage';
 import * as ui from './ui';
 import updateCount from './update-count';

--- a/components/unread-articles-indicator/initialise-feed-start-time.js
+++ b/components/unread-articles-indicator/initialise-feed-start-time.js
@@ -1,4 +1,5 @@
-import {isToday, startOfDay} from 'date-fns';
+import isToday from 'date-fns/src/isToday';
+import startOfDay from 'date-fns/src/startOfDay';
 import DeviceSession from './device-session';
 import * as storage from './storage';
 import {json as fetchJson} from 'fetchres';

--- a/components/unread-articles-indicator/storage.js
+++ b/components/unread-articles-indicator/storage.js
@@ -1,4 +1,4 @@
-import { isValid } from 'date-fns';
+import isValid from 'date-fns/src/isValid';
 
 const DEVICE_SESSION_EXPIRY = 'deviceSessionExpiry';
 const FEED_START_TIME = 'newArticlesSinceTime';

--- a/components/unread-articles-indicator/update-count.js
+++ b/components/unread-articles-indicator/update-count.js
@@ -1,4 +1,5 @@
-import {isAfter, parseISO} from 'date-fns';
+import isAfter from 'date-fns/src/isAfter';
+import parseISO from 'date-fns/src/parseISO';
 import * as storage from './storage';
 import countUnreadArticles from './count-unread-articles';
 import * as tracking from './tracking';

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/Financial-Times/n-myft-ui#readme",
   "devDependencies": {
-    "@financial-times/n-gage": "^3.11.2",
+    "@financial-times/n-gage": "^3.12.0",
     "@financial-times/n-heroku-tools": "8.3.1",
     "@financial-times/n-internal-tool": "2.3.4",
     "@financial-times/n-webpack": "^3.0.2",
@@ -37,6 +37,7 @@
     "babel-plugin-transform-es2015-classes": "^6.8.0",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.5.2",
     "babel-plugin-transform-runtime": "^6.9.0",
+    "babel-preset-env": "^1.7.0",
     "babel-preset-es2015": "^6.6.0",
     "babel-runtime": "^6.9.2",
     "bower": "^1.8.8",
@@ -77,19 +78,12 @@
     "npm-prepublish": "^1.2.1",
     "pa11y-ci": "^2.1.1",
     "postcss-loader": "^0.9.1",
+    "regenerator-runtime": "^0.13.3",
     "sass-loader": "^3.2.0",
     "semver": "6.3.0",
     "sinon": "^7.1.0",
     "sinon-chai": "^3.2.0",
-    "snyk": "^1.216.5",
-    "babel-preset-env": "^1.7.0",
-    "regenerator-runtime": "^0.13.3"
-  },
-  "dependencies": {
-    "date-fns": "2.7.0",
-    "form-serialize": "^0.7.2",
-    "js-cookie": "^2.2.0",
-    "lodash": "^4.17.10"
+    "snyk": "^1.216.5"
   },
   "x-dash": {
     "engine": {

--- a/scripts/prevent-npm-deps.js
+++ b/scripts/prevent-npm-deps.js
@@ -1,0 +1,8 @@
+'use strict';
+
+const {dependencies = {}} = require('../package');
+
+if (Object.keys(dependencies).length > 0) {
+	global.console.error('NPM dependencies included in bower only js project, please remove');
+	process.exit(1);
+}

--- a/test/unread-articles-indicator/count-unread-articles.spec.js
+++ b/test/unread-articles-indicator/count-unread-articles.spec.js
@@ -1,7 +1,8 @@
 /* global expect */
 
 import fetchMock from 'fetch-mock';
-import * as dateFns from 'date-fns';
+import isAfter from 'date-fns/src/isAfter';
+import parseISO from 'date-fns/src/parseISO';
 
 const START_TIME = new Date('2018-06-05T06:48:26.635Z');
 const userId = '00000000-0000-0000-0000-000000000000';
@@ -55,7 +56,8 @@ describe('count-unread-articles', () => {
 
 	const injector = require('inject-loader!../../components/unread-articles-indicator/count-unread-articles');
 	const countUnreadArticles = injector({
-		'date-fns': dateFns
+		'date-fns/src/isAfter': isAfter,
+		'date-fns/src/parseISO': parseISO
 	});
 
 	beforeEach(() => {

--- a/test/unread-articles-indicator/device-session.spec.js
+++ b/test/unread-articles-indicator/device-session.spec.js
@@ -1,6 +1,8 @@
 /* global expect */
 import sinon from 'sinon';
-import * as dateFns from 'date-fns';
+import addMinutes from 'date-fns/src/addMinutes';
+import isAfter from 'date-fns/src/isAfter';
+import parseISO from 'date-fns/src/parseISO';
 
 const expiryTimestamp = '2018-06-14T12:00:00.000Z';
 const timestampBeforeExpiry = '2018-06-14T11:40:00.000Z';
@@ -21,7 +23,9 @@ describe('DeviceSession', () => {
 
 	const subjectInjector = require('inject-loader!../../components/unread-articles-indicator/device-session');
 	const DeviceSession = subjectInjector({
-		'date-fns': dateFns,
+		'date-fns/src/addMinutes': addMinutes,
+		'date-fns/src/isAfter': isAfter,
+		'date-fns/src/parseISO': parseISO,
 		'./storage': mockStorage
 	});
 
@@ -47,7 +51,7 @@ describe('DeviceSession', () => {
 		});
 
 		it('should call storage.setDeviceSessionExpiry with correct timestamp', () => {
-			const correctTimestamp = dateFns.addMinutes(dateFns.parseISO(timeNow), SESSION_THRESHOLD_MINUTES);
+			const correctTimestamp = addMinutes(parseISO(timeNow), SESSION_THRESHOLD_MINUTES);
 
 			expect(mockStorage.setDeviceSessionExpiry).to.have.been.calledOnce;
 			expect(mockStorage.setDeviceSessionExpiry).to.have.been.calledWith(correctTimestamp);
@@ -58,7 +62,7 @@ describe('DeviceSession', () => {
 
 		it('should return true if the user visits for the first time (initially no value in localStorage)', () => {
 			const timeNow = '2018-06-14T08:00:00.000Z';
-			const newExpiryTimestamp = dateFns.addMinutes(dateFns.parseISO(timeNow), SESSION_THRESHOLD_MINUTES);
+			const newExpiryTimestamp = addMinutes(parseISO(timeNow), SESSION_THRESHOLD_MINUTES);
 
 			clock = sinon.useFakeTimers(new Date(timeNow));
 			deviceSessionExpiry = undefined;
@@ -70,7 +74,7 @@ describe('DeviceSession', () => {
 
 		it('should return true if the user returns after session (initial value in localStorage is in the past)', () => {
 			const timeNow = timestampAfterExpiry;
-			const newExpiryTimestamp = dateFns.addMinutes(dateFns.parseISO(timeNow), SESSION_THRESHOLD_MINUTES);
+			const newExpiryTimestamp = addMinutes(parseISO(timeNow), SESSION_THRESHOLD_MINUTES);
 
 			clock = sinon.useFakeTimers(new Date(timeNow));
 			deviceSessionExpiry = expiryTimestamp;
@@ -82,7 +86,7 @@ describe('DeviceSession', () => {
 
 		it('should return false if the user returns within session (initial value in localStorage is in the future)', () => {
 			const timeNow = timestampBeforeExpiry;
-			const newExpiryTimestamp = dateFns.addMinutes(dateFns.parseISO(timeNow), SESSION_THRESHOLD_MINUTES);
+			const newExpiryTimestamp = addMinutes(parseISO(timeNow), SESSION_THRESHOLD_MINUTES);
 
 			clock = sinon.useFakeTimers(new Date(timeNow));
 			deviceSessionExpiry = expiryTimestamp;

--- a/test/unread-articles-indicator/initialise-feed-start-time.spec.js
+++ b/test/unread-articles-indicator/initialise-feed-start-time.spec.js
@@ -29,7 +29,8 @@ describe('initialiseFeedStartTime', () => {
 	let lastVisitTime;
 	const injector = require('inject-loader!../../components/unread-articles-indicator/initialise-feed-start-time');
 	const initialiseFeedStartTime = injector({
-		'date-fns': mockDateFns,
+		'date-fns/src/isToday': mockDateFns.isToday,
+		'date-fns/src/startOfDay': mockDateFns.startOfDay,
 		'./device-session': () => ({ isNewSession: () => isNewSession }),
 		'./storage': {
 			setFeedStartTime: mockSetFeedStartTime,


### PR DESCRIPTION
## What
- removes npm dependencies
- adds bower dependencies
- updates `date-fns` references to resolve to bower `date-fns` dependency
- adds pre-test script to prevent addition of npm dependencies
- removes unused lodash dependency

## Why
This library is consumed as a bower dependency (so that its own bower dependencies are downloaded along side it). As a result it's npm dependencies won't be resolved properly by n-ui. This has caused deployment problems.