### PR TITLE
rename unread articles polling flag 🐿 v2.12.5

### DIFF
--- a/components/unread-articles-indicator/index.js
+++ b/components/unread-articles-indicator/index.js
@@ -19,7 +19,7 @@ export default async (options = {}) => {
 
 		const myftHeaderLink = document.querySelectorAll('.o-header__top-link--myft');
 		const uiOpts = Object.assign({onClick: uiOnClick, flags: {}}, options);
-		shouldPoll = uiOpts.flags.myftNewUnreadIndicatorPolling;
+		shouldPoll = uiOpts.flags.MyFT_UnreadArticlesIndicatorPolling;
 
 		await getNewArticlesSinceTime();
 


### PR DESCRIPTION
This PR renames the flag which activates the polling feature on the unread articles indicator.

This is being done so that outdated code (which caused traffic issues) is not activated when we turn on the feature