### PR TITLE
Fix core experience

### DIFF
--- a/components/follow-button/follow-button.html
+++ b/components/follow-button/follow-button.html
@@ -11,9 +11,11 @@
 		{{else}}
 			{{#ifAll @root.csrfToken @root.cacheablePersonalisedUrl}}
 				{{#if setFollowButtonStateToSelected}}
-					action="/__myft/api/core/followed/concept/{{conceptId}}?method=delete"
+					action="/myft/remove/{{conceptId}}"
+					data-js-action="/__myft/api/core/followed/concept/{{conceptId}}?method=delete"
 				{{else}}
-					action="/__myft/api/core/followed/concept/{{conceptId}}?method=put"
+					action="/myft/add/{{conceptId}}"
+					data-js-action="/__myft/api/core/followed/concept/{{conceptId}}?method=put"
 				{{/if}}
 			{{else}}
 				{{#ifAll setFollowButtonStateToSelected @root.cacheablePersonalisedUrl}}

--- a/components/follow-button/follow-button.html
+++ b/components/follow-button/follow-button.html
@@ -9,22 +9,12 @@
 			action="/__myft/api/core/follow-plus-digest-email/{{conceptId}}?method=put"
 			data-myft-ui-variant="followPlusDigestEmail"
 		{{else}}
-			{{#ifAll @root.csrfToken @root.cacheablePersonalisedUrl}}
-				{{#if setFollowButtonStateToSelected}}
-					action="/myft/remove/{{conceptId}}"
-					data-js-action="/__myft/api/core/followed/concept/{{conceptId}}?method=delete"
-				{{else}}
-					action="/myft/add/{{conceptId}}"
-					data-js-action="/__myft/api/core/followed/concept/{{conceptId}}?method=put"
-				{{/if}}
+			{{#ifAll setFollowButtonStateToSelected @root.cacheablePersonalisedUrl}}
+				action="/myft/remove/{{conceptId}}"
+				data-js-action="/__myft/api/core/followed/concept/{{conceptId}}?method=delete"
 			{{else}}
-				{{#ifAll setFollowButtonStateToSelected @root.cacheablePersonalisedUrl}}
-					action="/myft/remove/{{conceptId}}"
-					data-js-action="/__myft/api/core/followed/concept/{{conceptId}}?method=delete"
-				{{else}}
-					action="/myft/add/{{conceptId}}"
-					data-js-action="/__myft/api/core/followed/concept/{{conceptId}}?method=put"
-				{{/ifAll}}
+				action="/myft/add/{{conceptId}}"
+				data-js-action="/__myft/api/core/followed/concept/{{conceptId}}?method=put"
 			{{/ifAll}}
 		{{/if}}>
 		{{> n-myft-ui/components/csrf-token/input}}


### PR DESCRIPTION
Puts the non-js `action` attribute back (1st commit), and simplifies the logic (2nd commit), since `csrfToken` has no effect on what action is selected.

Looks like the non-js `action` behaviour got added here https://github.com/Financial-Times/n-myft-ui/commit/1bc2e27
and removed here https://github.com/Financial-Times/n-myft-ui/pull/206

Trello: 
https://trello.com/c/swsWxJK2/3968-myft-follow-unfollow-button-core-experience-404s
