### PR TITLE
Concept lists are supposed to have black links

### DIFF
--- a/components/concept-list/concept-list.html
+++ b/components/concept-list/concept-list.html
@@ -17,7 +17,7 @@
 					<a
 						href="{{relativeUrl}}"
 						data-trackable="{{#if conceptTrackable}}{{conceptTrackable}}{{else}}concept{{/if}}"
-						class="concept-list__concept n-content-tag n-content-tag--author n-content-tag--with-follow">
+						class="concept-list__concept">
 						{{prefLabel}}
 					</a>
 					{{> n-myft-ui/components/follow-button/follow-button

--- a/components/concept-list/main.scss
+++ b/components/concept-list/main.scss
@@ -13,8 +13,6 @@
 }
 
 .concept-list__list {
-	// TODO validate metrics
-	// @include oTypographyMargin($top: 7, $bottom: 10);
 	margin: oSpacingByName("s6") 0 oSpacingByName("m12");
 	padding: 0;
 }
@@ -25,24 +23,16 @@
 	list-style: none;
 	display: flex;
 	align-items: center;
-
-	.n-content-tag {
-		flex: 1;
-	}
-
-	.n-content-tag {
-		flex: 2;
-	}
 }
 
 .concept-list__concept {
 	word-break: keep-all;
-	// TODO replace
-	// @include oTypographyTopic;
-	@include oTypographySans(0);
-	margin: oSpacingByName("s1") 0;
+	@include oTypographySans(0, $weight: 'semibold');
+	margin: oSpacingByName("s1") oSpacingByName("s3") oSpacingByName("s1") 0;
 	text-decoration: none;
+	border: 0;
 	color: oColorsByName('black');
+	flex: 2;
 
 	&:hover {
 		color: oColorsMix(oColorsByName('black'), oColorsByName('paper'), 73);


### PR DESCRIPTION
Concept lists were using a load of `n-content-tag` classes which, as a
result of the origami change, were making links claret. It turns out we
only really needed the bold and some margin-right from those tags. So
rather than use them, directly style the links as we want them. 🐿 v2.12.5

| before | after |
|------- | ------|
| <img src="https://user-images.githubusercontent.com/35035/70992931-c2abba80-20c2-11ea-868c-94c745bae2db.png"> | <img src="https://user-images.githubusercontent.com/35035/70992946-ce977c80-20c2-11ea-973c-500216c94155.png"> |
