### PR TITLE
use inline-block instead of inline-flex to allow for text-indent 🐿 v2…

### DIFF
--- a/components/instant-alert/main.scss
+++ b/components/instant-alert/main.scss
@@ -5,6 +5,7 @@
 
 	.n-myft-ui__button {
 		@include buttonWithIcon(26, 24, oColorsByName('teal-40'), 'mail', 'mail', oColorsByName('white'));
+		display: inline-block;
 	}
 }
 


### PR DESCRIPTION
Text indend on alert buttons is not applied so button text is not hidden

Before
![Screen Shot 2019-12-17 at 12 46 57](https://user-images.githubusercontent.com/6670598/70996799-73b65300-20cb-11ea-851b-cabb320d962b.png)

After:

![Screen Shot 2019-12-17 at 12 47 12](https://user-images.githubusercontent.com/6670598/70996812-7a44ca80-20cb-11ea-8e26-35fb63389625.png)
