### PR TITLE
Adding github settings.yml

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,14 @@
+_extends: github-apps-config-next
+
+branches:
+  - name: master
+    protection:
+      required_pull_request_reviews: null
+      required_status_checks:
+        strict: true
+        contexts:
+          - "ci/circleci: build"
+      enforce_admins: true
+      restrictions:
+        users: []
+        teams: []


### PR DESCRIPTION
This lets us centrally define access permissions to our repositories
and other sensible defaults where approrpriate. You can see the
defaults in the [github-apps-config-next][defaults] repo. For full
configuration options check out the [probot settings repo][probot].

[defaults]: https://github.com/Financial-Times/github-apps-config-next/blob/master/.github/settings.yml
[probot]: https://github.com/probot/settings

🤖 This PR was opened automatically.