### PR TITLE
Fix unread articles indicator displays incorrect number on cross device

### DIFF
--- a/components/unread-articles-indicator/README.md
+++ b/components/unread-articles-indicator/README.md
@@ -1,0 +1,21 @@
+# n-myft-ui/unread-articles-indicator
+
+![unread article indicator](https://user-images.githubusercontent.com/21194161/72087965-38d9c080-3301-11ea-9616-d1b31132c269.png)
+
+## How the unread articles number is gotten
+
+:one: Determine the time(`feedStartTime`) which is the user's last active time (the process is explained below)
+
+:two: Determine the time(`startTime`) to be used to count unread articles for the current visit. It is `feedStartTime` or `myFTIndicatorDismissedAt`&ast;, whichever comes later.
+
+:three: Fetch myft feed articles for the user
+
+:four: Count the articles published after the timestamp(`startTime`)
+
+---
+&ast; `myFTIndicatorDismissedAt` is stored in `window.localStorage` when user visits myFT feed page, and then the unread aricle indicator is cleared to `0`.
+
+---
+![unread article count](https://user-images.githubusercontent.com/21194161/72248809-f0b3ea00-35ef-11ea-899f-0ac0abba6ba6.png)
+
+To keep the number consistent on **cross devices**, it fetches the last 'active' time for a user via a Volt Procedure called UserInfo.

--- a/components/unread-articles-indicator/count-unread-articles.js
+++ b/components/unread-articles-indicator/count-unread-articles.js
@@ -1,10 +1,7 @@
 import {json as fetchJson} from 'fetchres';
-import isAfter from 'date-fns/src/isAfter';
-import parseISO from 'date-fns/src/parseISO';
+import {isAfter, parseISO} from './date-fns';
 
 export default async (userId, startTime) => {
-	if (typeof startTime === 'string') startTime = parseISO(startTime);
-
 	const articles = await fetchContentFromPersonalisedFeed(userId);
 	const unreadArticlesSinceLastVisit = articles
 		.filter(({userCompletion = -1}) => userCompletion < 1) // only include unread articles

--- a/components/unread-articles-indicator/date-fns.js
+++ b/components/unread-articles-indicator/date-fns.js
@@ -1,0 +1,32 @@
+// date-fns from v2 doesn't accept String arguments anymore.
+// the detail => https://github.com/date-fns/date-fns/blob/master/CHANGELOG.md#200---2019-08-20
+// By adding validation for dates before their functions allows us to know it when unexpected value passed.
+
+import isTodayOriginal from 'date-fns/src/isToday';
+import isAfterOriginal from 'date-fns/src/isAfter';
+import addMinutesOriginal from 'date-fns/src/addMinutes';
+import startOfDayOriginal from 'date-fns/src/startOfDay';
+import isValidOriginal from 'date-fns/src/isValid';
+import parseISO from 'date-fns/src/parseISO';
+
+const isValid = (date) => {
+	if (!isValidOriginal(date)) {
+		console.error('Invalid date passed', [date]); //eslint-disable-line
+	}
+	return date;
+};
+
+const isToday = (date) => isTodayOriginal(isValid(date));
+const isAfter = (date, dateToCompare) => isAfterOriginal(isValid(date), isValid(dateToCompare));
+const addMinutes = (date, amount) => addMinutesOriginal(isValid(date), amount);
+const startOfDay = (date) => startOfDayOriginal(isValid(date));
+
+
+export {
+	isToday,
+	isAfter,
+	addMinutes,
+	startOfDay,
+	isValid,
+	parseISO,
+};

--- a/components/unread-articles-indicator/device-session.js
+++ b/components/unread-articles-indicator/device-session.js
@@ -1,6 +1,5 @@
 import addMinutes from 'date-fns/src/addMinutes';
 import isAfter from 'date-fns/src/isAfter';
-import parseISO from 'date-fns/src/parseISO';
 import * as storage from './storage';
 const SESSION_THRESHOLD_MINUTES = 30;
 
@@ -14,7 +13,7 @@ export default class DeviceSession {
 
 	isNewSession () {
 		if (this.expiry) {
-			return isAfter(new Date(), parseISO(this.expiry));
+			return isAfter(new Date(), this.expiry);
 		} else {
 			return true;
 		}

--- a/components/unread-articles-indicator/device-session.js
+++ b/components/unread-articles-indicator/device-session.js
@@ -1,5 +1,4 @@
-import addMinutes from 'date-fns/src/addMinutes';
-import isAfter from 'date-fns/src/isAfter';
+import {isAfter, addMinutes} from './date-fns';
 import * as storage from './storage';
 const SESSION_THRESHOLD_MINUTES = 30;
 

--- a/components/unread-articles-indicator/index.js
+++ b/components/unread-articles-indicator/index.js
@@ -1,4 +1,4 @@
-import startOfDay from 'date-fns/src/startOfDay';
+import {startOfDay} from './date-fns';
 import * as storage from './storage';
 import * as ui from './ui';
 import updateCount from './update-count';

--- a/components/unread-articles-indicator/initialise-feed-start-time.js
+++ b/components/unread-articles-indicator/initialise-feed-start-time.js
@@ -1,5 +1,4 @@
-import isToday from 'date-fns/src/isToday';
-import startOfDay from 'date-fns/src/startOfDay';
+import {isToday, startOfDay} from './date-fns';
 import DeviceSession from './device-session';
 import * as storage from './storage';
 import {json as fetchJson} from 'fetchres';

--- a/components/unread-articles-indicator/storage.js
+++ b/components/unread-articles-indicator/storage.js
@@ -1,4 +1,4 @@
-import isValid from 'date-fns/src/isValid';
+import {isValid} from './date-fns';
 
 const DEVICE_SESSION_EXPIRY = 'deviceSessionExpiry';
 const FEED_START_TIME = 'newArticlesSinceTime';

--- a/components/unread-articles-indicator/update-count.js
+++ b/components/unread-articles-indicator/update-count.js
@@ -1,5 +1,4 @@
 import isAfter from 'date-fns/src/isAfter';
-import parseISO from 'date-fns/src/parseISO';
 import * as storage from './storage';
 import countUnreadArticles from './count-unread-articles';
 import * as tracking from './tracking';
@@ -9,7 +8,7 @@ import {UPDATE_INTERVAL, UPDATE_TIMEOUT} from './constants';
 function latest (a, b) {
 	if (!a) return b;
 	if (!b) return a;
-	return isAfter(parseISO(a), parseISO(b)) ? a : b;
+	return isAfter(a, b) ? a : b;
 }
 
 export default async function updateCount (userId, now) {

--- a/components/unread-articles-indicator/update-count.js
+++ b/components/unread-articles-indicator/update-count.js
@@ -1,4 +1,4 @@
-import isAfter from 'date-fns/src/isAfter';
+import {isAfter} from './date-fns';
 import * as storage from './storage';
 import countUnreadArticles from './count-unread-articles';
 import * as tracking from './tracking';

--- a/secrets.js
+++ b/secrets.js
@@ -1,6 +1,8 @@
 module.exports = {
 	whitelist: [
 		'3a499586-b2e0-11e4-a058-00144feab7de',
+		'38d9c080-3301-11ea-9616-d1b31132c269', // components/unread-articles-indicator/README.md:3
+		'f0b3ea00-35ef-11ea-899f-0ac0abba6ba6', // components/unread-articles-indicator/README.md:19
 		'190b4443-dc03-bd53-e79b-b4b6fbd04e64', // segment ID for subscribe URL
 		'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx' // regex for uuid generator
 	]

--- a/test/unread-articles-indicator/count-unread-articles.spec.js
+++ b/test/unread-articles-indicator/count-unread-articles.spec.js
@@ -1,8 +1,6 @@
 /* global expect */
 
 import fetchMock from 'fetch-mock';
-import isAfter from 'date-fns/src/isAfter';
-import parseISO from 'date-fns/src/parseISO';
 
 const START_TIME = new Date('2018-06-05T06:48:26.635Z');
 const userId = '00000000-0000-0000-0000-000000000000';
@@ -54,11 +52,7 @@ const mockPersonalisedFeedData = {
 describe('count-unread-articles', () => {
 	let count;
 
-	const injector = require('inject-loader!../../components/unread-articles-indicator/count-unread-articles');
-	const countUnreadArticles = injector({
-		'date-fns/src/isAfter': isAfter,
-		'date-fns/src/parseISO': parseISO
-	});
+	const countUnreadArticles = require('../../components/unread-articles-indicator/count-unread-articles');
 
 	beforeEach(() => {
 		count = null;

--- a/test/unread-articles-indicator/device-session.spec.js
+++ b/test/unread-articles-indicator/device-session.spec.js
@@ -1,7 +1,6 @@
 /* global expect */
 import sinon from 'sinon';
 import addMinutes from 'date-fns/src/addMinutes';
-import isAfter from 'date-fns/src/isAfter';
 import parseISO from 'date-fns/src/parseISO';
 
 const expiryTimestamp = parseISO('2018-06-14T12:00:00.000Z');
@@ -23,8 +22,6 @@ describe('DeviceSession', () => {
 
 	const subjectInjector = require('inject-loader!../../components/unread-articles-indicator/device-session');
 	const DeviceSession = subjectInjector({
-		'date-fns/src/addMinutes': addMinutes,
-		'date-fns/src/isAfter': isAfter,
 		'./storage': mockStorage
 	});
 

--- a/test/unread-articles-indicator/device-session.spec.js
+++ b/test/unread-articles-indicator/device-session.spec.js
@@ -4,7 +4,7 @@ import addMinutes from 'date-fns/src/addMinutes';
 import isAfter from 'date-fns/src/isAfter';
 import parseISO from 'date-fns/src/parseISO';
 
-const expiryTimestamp = '2018-06-14T12:00:00.000Z';
+const expiryTimestamp = parseISO('2018-06-14T12:00:00.000Z');
 const timestampBeforeExpiry = '2018-06-14T11:40:00.000Z';
 const timestampAfterExpiry = '2018-06-14T12:10:00.000Z';
 
@@ -25,7 +25,6 @@ describe('DeviceSession', () => {
 	const DeviceSession = subjectInjector({
 		'date-fns/src/addMinutes': addMinutes,
 		'date-fns/src/isAfter': isAfter,
-		'date-fns/src/parseISO': parseISO,
 		'./storage': mockStorage
 	});
 

--- a/test/unread-articles-indicator/initialise-feed-start-time.spec.js
+++ b/test/unread-articles-indicator/initialise-feed-start-time.spec.js
@@ -29,8 +29,10 @@ describe('initialiseFeedStartTime', () => {
 	let lastVisitTime;
 	const injector = require('inject-loader!../../components/unread-articles-indicator/initialise-feed-start-time');
 	const initialiseFeedStartTime = injector({
-		'date-fns/src/isToday': mockDateFns.isToday,
-		'date-fns/src/startOfDay': mockDateFns.startOfDay,
+		'./date-fns': {
+			isToday: mockDateFns.isToday,
+			startOfDay: mockDateFns.startOfDay
+		},
 		'./device-session': () => ({ isNewSession: () => isNewSession }),
 		'./storage': {
 			setFeedStartTime: mockSetFeedStartTime,


### PR DESCRIPTION
This PR includes
- **Fix `isNewSession` function never returns `true`**
When isNewSession never returns true, it always get the user's last visit timestamp from window.localStorage and never fetches it from VoltDB.

- **Fix `startTime` in `updateCount` function is set incorrect time**
The startTime to count unread articles should have been set user's last visit time or indicator dismissed time, whichever comes later.
However it's always set indicator dismissed time.

-----

### The cause of the two issues above is the same
When it gets dates from storage, it returns dates (`Tue Aug 19 1975 23:15:30 GMT+0100`) which parsed from ISO string(`1975-08-19T22:15:30.000Z`), however, these functions try to parse dates again as an ISO string.

```js
parseISO("Tue Aug 19 1975 23:15:30 GMT+0100");
// returns Invalid Date
```
`isAfter` function doesn't throw an error when it's passed `Invalid Date`, it just returns `false`.


These bugs maybe started after [this commit](https://github.com/Financial-Times/n-myft-ui/commit/68692da6bd9bb4f1966404fd97c885cd1a3dc685)

🐿 v2.12.5