### PR TITLE
Adds .default to the o-overlay require statement to resolve ES6/CJM e…

### DIFF
--- a/components/instant-alerts-confirmation/index.js
+++ b/components/instant-alerts-confirmation/index.js
@@ -1,4 +1,4 @@
-const Overlay = require('o-overlay');
+const Overlay = require('o-overlay').default;
 
 const buildOverlayContent = isBlocked => `
 <div class='instant-alerts-confirmation__info'>


### PR DESCRIPTION
…rrors 🐿 v2.12.0

Adds a missing .default to the oOverlay require statement in n-myft-ui to resolve an ES6/CJM interoperability error.

o-overlay is exported as a default so it will need to be imported using this syntax. https://github.com/Financial-Times/o-overlay/blob/master/main.js#L11

When running the myFT page on Page Kit, the current syntax causes a `TypeError: Overlay.getOverlays is not a function` error to thrown when triggering an instant alerts confirmation message https://github.com/Financial-Times/n-myft-ui/blob/master/components/instant-alerts-confirmation/index.js
