### PR TITLE
Remove xFollowButton flag from demo 🐿 v2.12.5

### DIFF
--- a/demos/app.js
+++ b/demos/app.js
@@ -39,8 +39,7 @@ app.get('/', (req, res) => {
 		layout: 'demo-layout',
 		flags: {
 			myFtApi: true,
-			myFtApiWrite: true,
-			xFollowButton: res.locals.flags.xFollowButton
+			myFtApiWrite: true
 		}
 	}, fixtures));
 });


### PR DESCRIPTION
It is a leftover.
`xFollowButton` flag was already deleted from the collections component by #264 

I have checked demo is working after removing it.