### PR TITLE
Rewrite links to the alpha homepage

### DIFF
--- a/myft/ui/index.js
+++ b/myft/ui/index.js
@@ -3,11 +3,13 @@ import * as lists from './lists';
 import personaliseLinks from './personalise-links';
 import updateUi from './update-ui';
 import * as headerTooltip from '../../components/header-tooltip';
+import navigationAlphaTest from './navigationAlphaTest';
 
 function init (opts) {
 	myFtButtons.init(opts);
 	lists.init();
 	headerTooltip.init();
+	navigationAlphaTest(opts);
 }
 
 export {

--- a/myft/ui/lists.js
+++ b/myft/ui/lists.js
@@ -11,7 +11,7 @@ const delegate = new Delegate(document.body);
 const csrfToken = getToken();
 
 
-function openOverlay(html, { name = 'myft-ui', title = '&nbsp;', shaded = false }) {
+function openOverlay (html, { name = 'myft-ui', title = '&nbsp;', shaded = false }) {
 	// If an overlay already exists of the same name destroy it.
 	const overlays = Overlay.getOverlays();
 	const existingOverlay = overlays[name];
@@ -31,7 +31,7 @@ function openOverlay(html, { name = 'myft-ui', title = '&nbsp;', shaded = false 
 	});
 }
 
-function updateAfterAddToList(listId, contentId, wasAdded) {
+function updateAfterAddToList (listId, contentId, wasAdded) {
 
 	myFtUiButtonStates.setStateOfButton('contained', contentId, wasAdded);
 
@@ -54,7 +54,7 @@ function updateAfterAddToList(listId, contentId, wasAdded) {
 }
 
 
-function setUpSaveToExistingListListeners(overlay, contentId) {
+function setUpSaveToExistingListListeners (overlay, contentId) {
 
 	const saveToExistingListButton = overlay.content.querySelector('.js-save-to-existing-list');
 	const listSelect = overlay.content.querySelector('.js-list-select');
@@ -77,7 +77,7 @@ function setUpSaveToExistingListListeners(overlay, contentId) {
 	}
 }
 
-function setUpCreateListListeners(overlay, contentId) {
+function setUpCreateListListeners (overlay, contentId) {
 
 	const createListButton = overlay.content.querySelector('.js-create-list');
 	const nameInput = overlay.content.querySelector('.js-name');
@@ -121,7 +121,7 @@ function setUpCreateListListeners(overlay, contentId) {
 }
 
 
-function showListsOverlay(overlayTitle, formHtmlUrl, contentId) {
+function showListsOverlay (overlayTitle, formHtmlUrl, contentId) {
 	myFtClient.personaliseUrl(formHtmlUrl)
 		.then(url => fetch(url, {
 			credentials: 'same-origin'
@@ -149,19 +149,19 @@ function showListsOverlay(overlayTitle, formHtmlUrl, contentId) {
 
 }
 
-function showCopyToListOverlay(contentId, excludeList) {
+function showCopyToListOverlay (contentId, excludeList) {
 	showListsOverlay('Copy to list', `/myft/list?fragment=true&copy=true&contentId=${contentId}&excludeList=${excludeList}`, contentId);
 }
 
-function showCreateListOverlay() {
+function showCreateListOverlay () {
 	showListsOverlay('Create list', '/myft/list?fragment=true');
 }
 
-function showArticleSavedOverlay(contentId) {
+function showArticleSavedOverlay (contentId) {
 	showListsOverlay('Article saved', `/myft/list?fragment=true&fromArticleSaved=true&contentId=${contentId}`, contentId);
 }
 
-function handleArticleSaved(contentId) {
+function handleArticleSaved (contentId) {
 	return myFtClient.getAll('created', 'list')
 		.then(createdLists => createdLists.filter(list => !list.isRedirect))
 		.then(createdLists => {
@@ -171,7 +171,7 @@ function handleArticleSaved(contentId) {
 		});
 }
 
-function initialEventListeners() {
+function initialEventListeners () {
 
 	document.body.addEventListener('myft.user.saved.content.add', event => {
 		const contentId = event.detail.subject;
@@ -188,6 +188,6 @@ function initialEventListeners() {
 	});
 }
 
-export function init() {
+export function init () {
 	initialEventListeners();
 }

--- a/myft/ui/navigationAlphaTest.js
+++ b/myft/ui/navigationAlphaTest.js
@@ -1,0 +1,19 @@
+import { $$ as findElements } from 'n-ui-foundations';
+
+export default function (opts) {
+	if (opts && opts.flags && opts.flags.frontPageAlpha) {
+		const ft = 'www.ft.com/';
+		const relativeLinks = findElements('a[href="/"], a[href^="/?"]');
+		const absoluteLinks = findElements(
+			`a[href^="https://${ft}"], a[href^="http://${ft}"]`
+		);
+
+		const alphaFrontPageUrl =
+			'https://ft-next-alpha-front-page-eu.herokuapp.com/next-alpha-front-page';
+
+		[...relativeLinks, ...absoluteLinks].forEach(link => {
+			const url = new URL(link.href);
+			link.href = `${alphaFrontPageUrl}${url.search}`;
+		});
+	}
+}

--- a/secrets.js
+++ b/secrets.js
@@ -4,6 +4,7 @@ module.exports = {
 		'38d9c080-3301-11ea-9616-d1b31132c269', // components/unread-articles-indicator/README.md:3
 		'11df4800-391a-11ea-973b-4a52933561ab', // components/unread-articles-indicator/README.md:67
 		'190b4443-dc03-bd53-e79b-b4b6fbd04e64', // segment ID for subscribe URL
-		'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx' // regex for uuid generator
+		'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx', // regex for uuid generator
+		'a5676e20-5c92-47f3-a76c-11f9761121f5' // test/navigationAlphaTest.spc.js
 	]
 };

--- a/test/navigationAlphaTest.spec.js
+++ b/test/navigationAlphaTest.spec.js
@@ -1,0 +1,116 @@
+/* global expect */
+
+const navigationAlphaTest = require('../myft/ui/navigationAlphaTest');
+import { uuid } from 'n-ui-foundations';
+
+describe('navigationAlphaTest', () => {
+
+	const alphaFrontPageUrl = 'https://ft-next-alpha-front-page-eu.herokuapp.com/next-alpha-front-page';
+
+	const createAnchorElement = (href) => {
+		const anchor = document.createElement('a');
+		const linkText = document.createTextNode('linkText');
+		anchor.appendChild(linkText);
+		anchor.title = 'title';
+		anchor.href = href;
+		anchor.id = `alphaFrontPage-${uuid()}`;
+		document.body.appendChild(anchor);
+
+		return anchor;
+	};
+
+	const removeElements = (ids) => {
+		ids.forEach(id => {
+			const element = document.getElementById(id);
+			element.parentNode.removeChild(element);
+		});
+	};
+
+	const optsFactory = (includeFrontPageAlphaFlag = true) => {
+		return includeFrontPageAlphaFlag ?
+			{
+				flags:
+				{
+					frontPageAlpha: true
+				}
+			} :
+			{
+				flags : {}
+			};
+	};
+
+	const baseOverrideTest = (url, expectedUrl = alphaFrontPageUrl) => {
+		// Arrange
+		const anchor = createAnchorElement(url);
+
+		const opts = optsFactory();
+
+		// Act
+		navigationAlphaTest(opts);
+
+		// Assert
+		expect(document.getElementById(anchor.id).href).to.equal(expectedUrl);
+
+		// Clean-up
+		removeElements([anchor.id]);
+	};
+
+	it('Should override secure absolute links', () => {
+		baseOverrideTest('https://www.ft.com/content/a5676e20-5c92-47f3-a76c-11f9761121f5');
+	});
+
+	it('Should override insecure absolute links', () => {
+		baseOverrideTest('http://www.ft.com/content/a5676e20-5c92-47f3-a76c-11f9761121f5');
+	});
+
+	it('Should override relative links', () => {
+		baseOverrideTest('/');
+	});
+
+	it('Should override absolute links with search param', () => {
+		baseOverrideTest('https://www.ft.com/?edition=uk', `${alphaFrontPageUrl}?edition=uk`);
+	});
+
+	it('Should override all types of expected links', () => {
+		// Arrange
+		const relativeLink = createAnchorElement('/');
+		const absoluteSecureLink = createAnchorElement('https://www.ft.com/content/a5676e20-5c92-47f3-a76c-11f9761121f5');
+		const absoluteInsecureLink = createAnchorElement('http://www.ft.com/content/a5676e20-5c92-47f3-a76c-11f9761121f5');
+		const searchParamLink = createAnchorElement('https://www.ft.com/?edition=uk');
+
+		const opts = optsFactory();
+
+		// Act
+		navigationAlphaTest(opts);
+
+		// Assert
+		expect(document.getElementById(relativeLink.id).href).to.equal(alphaFrontPageUrl);
+		expect(document.getElementById(absoluteSecureLink.id).href).to.equal(alphaFrontPageUrl);
+		expect(document.getElementById(absoluteInsecureLink.id).href).to.equal(alphaFrontPageUrl);
+		expect(document.getElementById(searchParamLink.id).href).to.equal(`${alphaFrontPageUrl}?edition=uk`);
+
+		// Clean-up
+		removeElements([relativeLink.id, absoluteSecureLink.id, absoluteInsecureLink.id, searchParamLink.id]);
+	});
+
+	const baseShouldNotOverrideTest = (opts) => {
+		// Arrange
+		const anchor = createAnchorElement('/');
+		const initialHref = anchor.href;
+
+		// Act
+		navigationAlphaTest(opts);
+
+		// Assert
+		expect(document.getElementById(anchor.id).href).to.equal(initialHref);
+
+		// Clean-up
+		removeElements([anchor.id]);
+	};
+
+	it('Should override not override links if frontPageAlpha flag not set', () => {
+		const opts = optsFactory(false);
+
+		baseShouldNotOverrideTest(opts);
+	});
+});


### PR DESCRIPTION
As part of our navigation alpha test we want to rewrite front page links so users can use the alpha front page as part of their normal routine. We check for the `frontPageAlpha` flag to do this.

The flag is set using the cookie from a separate PR: https://github.com/Financial-Times/next-myft-page/pull/2312