### PR TITLE
Add support for alternate way that frontPageAlpha flag is set

### DIFF
--- a/myft/ui/navigationAlphaTest.js
+++ b/myft/ui/navigationAlphaTest.js
@@ -4,7 +4,7 @@ export default function (opts) {
 	if (
 		opts &&
 		opts.flags &&
-		(opts.flags.get && opts.flags.get('frontPageAlpha') || opts.flags.frontPageAlpha)
+		((opts.flags.get && opts.flags.get('frontPageAlpha')) || opts.flags.frontPageAlpha)
 	) {
 		const ft = 'www.ft.com/';
 		const relativeLinks = findElements('a[href="/"], a[href^="/?"]');

--- a/myft/ui/navigationAlphaTest.js
+++ b/myft/ui/navigationAlphaTest.js
@@ -1,7 +1,11 @@
 import { $$ as findElements } from 'n-ui-foundations';
 
 export default function (opts) {
-	if (opts && opts.flags && opts.flags.get('frontPageAlpha')) {
+	if (
+		opts &&
+		opts.flags &&
+		(opts.flags.get && opts.flags.get('frontPageAlpha') || opts.flags.frontPageAlpha)
+	) {
 		const ft = 'www.ft.com/';
 		const relativeLinks = findElements('a[href="/"], a[href^="/?"]');
 		const absoluteLinks = findElements(
@@ -11,7 +15,7 @@ export default function (opts) {
 		const alphaFrontPageUrl =
 			'https://ft-next-alpha-front-page-eu.herokuapp.com/next-alpha-front-page';
 
-		[...relativeLinks, ...absoluteLinks].forEach(link => {
+		[...relativeLinks, ...absoluteLinks].forEach((link) => {
 			const url = new URL(link.href);
 			link.href = `${alphaFrontPageUrl}${url.search}`;
 		});

--- a/test/navigationAlphaTest.spec.js
+++ b/test/navigationAlphaTest.spec.js
@@ -26,19 +26,32 @@ describe('navigationAlphaTest', () => {
 		});
 	};
 
-	const optsFactory = (includeFrontPageAlphaFlag = true) => {
+	const optsFactory = (includeFrontPageAlphaFlag = true, accessViaFlags = true) => {
+		if (accessViaFlags) {
+			return includeFrontPageAlphaFlag ?
+				{
+					flags:
+						{
+							get: () => { return 'on'; }
+						}
+				} :
+				{
+					flags :
+						{
+							get: () => { return undefined; }
+						}
+				};
+		}
+
 		return includeFrontPageAlphaFlag ?
 			{
 				flags:
-				{
-					get: () => { return 'on'; }
-				}
+					{
+						frontPageAlpha : true
+					}
 			} :
 			{
-				flags :
-				{
-					get: () => { return undefined; }
-				}
+				flags : {}
 			};
 	};
 
@@ -74,14 +87,12 @@ describe('navigationAlphaTest', () => {
 		baseOverrideTest('https://www.ft.com/?edition=uk', `${alphaFrontPageUrl}?edition=uk`);
 	});
 
-	it('Should override all types of expected links', () => {
+	const baseOverrideAllLinksTest = (opts) => {
 		// Arrange
 		const relativeLink = createAnchorElement('/');
 		const absoluteSecureLink = createAnchorElement('https://www.ft.com/content/a5676e20-5c92-47f3-a76c-11f9761121f5');
 		const absoluteInsecureLink = createAnchorElement('http://www.ft.com/content/a5676e20-5c92-47f3-a76c-11f9761121f5');
 		const searchParamLink = createAnchorElement('https://www.ft.com/?edition=uk');
-
-		const opts = optsFactory();
 
 		// Act
 		navigationAlphaTest(opts);
@@ -94,6 +105,18 @@ describe('navigationAlphaTest', () => {
 
 		// Clean-up
 		removeElements([relativeLink.id, absoluteSecureLink.id, absoluteInsecureLink.id, searchParamLink.id]);
+		;};
+
+	it('Should override all types of expected links', () => {
+		const opts = optsFactory();
+
+		baseOverrideAllLinksTest(opts);
+	});
+
+	it('Should override all types of expected links when accessing flag through property', () => {
+		const opts = optsFactory(true, false);
+
+		baseOverrideAllLinksTest(opts);
 	});
 
 	const baseShouldNotOverrideTest = (opts) => {


### PR DESCRIPTION
This PR modifies the code so that the frontPageAlpha flag can either be read from a flags object or directly from a flags property.