### PR TITLE
Change URLs which get overriden

### DIFF
--- a/myft/ui/navigationAlphaTest.js
+++ b/myft/ui/navigationAlphaTest.js
@@ -8,9 +8,19 @@ export default function (opts) {
 	) {
 		const ft = 'www.ft.com';
 		const relativeLinks = findElements('a[href="/"], a[href^="/?"]');
-		const absoluteLinks = findElements(
-			`a[href="https://${ft}"], a[href="http://${ft}"], a[href="https://${ft}/"], a[href="http://${ft}/"], a[href^="https://${ft}/?"], a[href^="http://${ft}/?"], a[href^="https://${ft}?"]`
-		);
+
+		const cssSelectors = [
+			`a[href="https://${ft}"]`,
+			`a[href="http://${ft}"]`,
+			`a[href="https://${ft}/"]`,
+			`a[href="http://${ft}/"]`,
+			`a[href^="https://${ft}/?"]`,
+			`a[href^="http://${ft}/?"]`,
+			`a[href^="https://${ft}?"]`,
+			`a[href^="http://${ft}?"]`
+		].join(',');
+
+		const absoluteLinks = findElements(cssSelectors);
 
 		const alphaFrontPageUrl =
 			'https://ft-next-alpha-front-page-eu.herokuapp.com/next-alpha-front-page';

--- a/myft/ui/navigationAlphaTest.js
+++ b/myft/ui/navigationAlphaTest.js
@@ -6,10 +6,10 @@ export default function (opts) {
 		opts.flags &&
 		((opts.flags.get && opts.flags.get('frontPageAlpha')) || opts.flags.frontPageAlpha)
 	) {
-		const ft = 'www.ft.com/';
+		const ft = 'www.ft.com';
 		const relativeLinks = findElements('a[href="/"], a[href^="/?"]');
 		const absoluteLinks = findElements(
-			`a[href^="https://${ft}"], a[href^="http://${ft}"]`
+			`a[href="https://${ft}/"], a[href="http://${ft}/"], a[href^="https://${ft}/?"], a[href^="http://${ft}/?"]`
 		);
 
 		const alphaFrontPageUrl =

--- a/myft/ui/navigationAlphaTest.js
+++ b/myft/ui/navigationAlphaTest.js
@@ -9,7 +9,7 @@ export default function (opts) {
 		const ft = 'www.ft.com';
 		const relativeLinks = findElements('a[href="/"], a[href^="/?"]');
 		const absoluteLinks = findElements(
-			`a[href="https://${ft}"], a[href="http://${ft}"], a[href="https://${ft}/"], a[href="http://${ft}/"], a[href^="https://${ft}/?"], a[href^="http://${ft}/?"]`
+			`a[href="https://${ft}"], a[href="http://${ft}"], a[href="https://${ft}/"], a[href="http://${ft}/"], a[href^="https://${ft}/?"], a[href^="http://${ft}/?"], a[href^="https://${ft}?"]`
 		);
 
 		const alphaFrontPageUrl =

--- a/myft/ui/navigationAlphaTest.js
+++ b/myft/ui/navigationAlphaTest.js
@@ -9,7 +9,7 @@ export default function (opts) {
 		const ft = 'www.ft.com';
 		const relativeLinks = findElements('a[href="/"], a[href^="/?"]');
 		const absoluteLinks = findElements(
-			`a[href="https://${ft}/"], a[href="http://${ft}/"], a[href^="https://${ft}/?"], a[href^="http://${ft}/?"]`
+			`a[href="https://${ft}"], a[href="http://${ft}"], a[href="https://${ft}/"], a[href="http://${ft}/"], a[href^="https://${ft}/?"], a[href^="http://${ft}/?"]`
 		);
 
 		const alphaFrontPageUrl =

--- a/test/navigationAlphaTest.spec.js
+++ b/test/navigationAlphaTest.spec.js
@@ -93,6 +93,8 @@ describe('navigationAlphaTest', () => {
 	it('Should override absolute links with search param', () => {
 		baseOverrideTest('https://www.ft.com/?edition=uk', `${alphaFrontPageUrl}?edition=uk`);
 		baseOverrideTest('https://www.ft.com?edition=uk', `${alphaFrontPageUrl}?edition=uk`);
+		baseOverrideTest('http://www.ft.com/?edition=uk', `${alphaFrontPageUrl}?edition=uk`);
+		baseOverrideTest('http://www.ft.com?edition=uk', `${alphaFrontPageUrl}?edition=uk`);
 	});
 
 	const baseOverrideAllLinksTest = (opts) => {

--- a/test/navigationAlphaTest.spec.js
+++ b/test/navigationAlphaTest.spec.js
@@ -71,12 +71,14 @@ describe('navigationAlphaTest', () => {
 		removeElements([anchor.id]);
 	};
 
-	it('Should override secure absolute links', () => {
+	it('Should override secure absolute links to the FT homepage', () => {
 		baseOverrideTest('https://www.ft.com/');
+		baseOverrideTest('https://www.ft.com');
 	});
 
-	it('Should override insecure absolute links', () => {
+	it('Should override insecure absolute links to the FT homepage', () => {
 		baseOverrideTest('http://www.ft.com/');
+		baseOverrideTest('http://www.ft.com');
 	});
 
 	it('Should not override links to FT pages', () => {

--- a/test/navigationAlphaTest.spec.js
+++ b/test/navigationAlphaTest.spec.js
@@ -72,11 +72,16 @@ describe('navigationAlphaTest', () => {
 	};
 
 	it('Should override secure absolute links', () => {
-		baseOverrideTest('https://www.ft.com/content/a5676e20-5c92-47f3-a76c-11f9761121f5');
+		baseOverrideTest('https://www.ft.com/');
 	});
 
 	it('Should override insecure absolute links', () => {
-		baseOverrideTest('http://www.ft.com/content/a5676e20-5c92-47f3-a76c-11f9761121f5');
+		baseOverrideTest('http://www.ft.com/');
+	});
+
+	it('Should not override links to FT pages', () => {
+		baseOverrideTest('http://www.ft.com/myaccount', 'http://www.ft.com/myaccount');
+		baseOverrideTest('https://www.ft.com/tour/myft','https://www.ft.com/tour/myft');
 	});
 
 	it('Should override relative links', () => {
@@ -90,8 +95,8 @@ describe('navigationAlphaTest', () => {
 	const baseOverrideAllLinksTest = (opts) => {
 		// Arrange
 		const relativeLink = createAnchorElement('/');
-		const absoluteSecureLink = createAnchorElement('https://www.ft.com/content/a5676e20-5c92-47f3-a76c-11f9761121f5');
-		const absoluteInsecureLink = createAnchorElement('http://www.ft.com/content/a5676e20-5c92-47f3-a76c-11f9761121f5');
+		const absoluteSecureLink = createAnchorElement('https://www.ft.com/');
+		const absoluteInsecureLink = createAnchorElement('http://www.ft.com/');
 		const searchParamLink = createAnchorElement('https://www.ft.com/?edition=uk');
 
 		// Act

--- a/test/navigationAlphaTest.spec.js
+++ b/test/navigationAlphaTest.spec.js
@@ -92,6 +92,7 @@ describe('navigationAlphaTest', () => {
 
 	it('Should override absolute links with search param', () => {
 		baseOverrideTest('https://www.ft.com/?edition=uk', `${alphaFrontPageUrl}?edition=uk`);
+		baseOverrideTest('https://www.ft.com?edition=uk', `${alphaFrontPageUrl}?edition=uk`);
 	});
 
 	const baseOverrideAllLinksTest = (opts) => {


### PR DESCRIPTION
This PR changes the URLs which are overridden to point to the Alpha front page URL.

Note that these overrides are only applied if the user has opted-in to the frontPageAlpha feature (this is triggered via navigating to /myft/alpha-front-page?switch=on)