### PR TITLE
ACC-544 - major update to next-session-client from 2.x.x to 3.x.x

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,7 @@
     "n-notification": "^7.0.0",
     "n-ui-foundations": "^6.0.0",
     "next-myft-client": "^7.8.0",
-    "next-session-client": "^2.3.5",
+    "next-session-client": "^3.0.1",
     "o-editorial-typography": "^1.0.1",
     "o-errors": "^4.0.2",
     "o-forms": "^8.0.0",


### PR DESCRIPTION
Using version < 3.x.x is causing a conflict with an update to n-syndication that requires the later version 
NB: Requires changes from https://github.com/Financial-Times/next-myft-client/pull/156 to pass build