### PR TITLE
fix: pin to date-fns version that do no use TS

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,7 @@
   ],
   "main": "main.js",
   "dependencies": {
-    "date-fns": "^2.7.0",
+    "date-fns": "2.16.1",
     "fetchres": "^1.7.2",
     "form-serialize": "^0.7.2",
     "js-cookie": "^2.2.0",


### PR DESCRIPTION
date-fns is migrating to TS, they are doing this progressively without transpiling the code