### PR TITLE
Revert "stop publishing to npm 🐿 v2.12.5"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,8 +115,12 @@ jobs:
     steps:
       - *attach_workspace
       - run:
-          name: Just informational
-          command: echo "This project is only published to bower not npm."
+          name: shared-helper / npm-store-auth-token
+          command: .circleci/shared-helpers/helper-npm-store-auth-token
+      - run: npx snyk monitor --org=customer-products --project-name=Financial-Times/n-myft-ui
+      - run:
+          name: shared-helper / npm-version-and-publish-public
+          command: .circleci/shared-helpers/helper-npm-version-and-publish-public
 
   deploy:
     <<: *container_config_node8


### PR DESCRIPTION
Publish package again in npm.

Last version published was `20.0.0-beta.1`

This is needed to be able to install `n-messaging-client` without bower. See https://github.com/Financial-Times/n-messaging-client/pull/360/files#diff-a64d264430c734e6d26c18106f896ebe60cf8f6922ac2072cf170cdb459629d3R25