### PR TITLE
Modify focus outline colour for myFT collection--regular

### DIFF
--- a/components/collections/main.scss
+++ b/components/collections/main.scss
@@ -1,3 +1,61 @@
+@mixin focusOutlineColor($focus-color) {
+	// Apply :focus styles as a fallback
+	// These styles will be applied to all browsers that don't use the polyfill, this includes browsers which support the feature natively.
+	body:not(.js-focus-visible) &,
+	html:not(.js-focus-visible) & {
+		// Standardise focus styles.
+		:focus {
+			outline: 2px solid $focus-color;
+		}
+
+		input:focus,
+		textarea:focus,
+		select:focus {
+			box-shadow: 0 0 0 1px $focus-color;
+		}
+	}
+
+	// When the focus-visible polyfill is applied `.js-focus-visible` is added to the html dom node
+	// (the body node in v4 of the 3rd party polyfill)
+
+	// stylelint-disable-next-line selector-no-qualifying-type
+	body.js-focus-visible &, // stylelint-disable-next-line selector-no-qualifying-type
+	html.js-focus-visible & {
+		// Standardise focus styles.
+		// stylelint-disable-next-line selector-no-qualifying-type
+		.focus-visible {
+			outline: 2px solid $focus-color;
+		}
+		// stylelint-disable-next-line selector-no-qualifying-type
+		input.focus-visible, // stylelint-disable-next-line selector-no-qualifying-type
+		textarea.focus-visible,
+		select.focus-visible {
+			box-shadow: 0 0 0 1px $focus-color;
+		}
+	}
+
+
+	// Styles given :focus-visible support. Extra selectors needed to match
+	// previous `:focus` selector specificity.
+	body:not(.js-focus-visible) & :focus-visible,
+	html:not(.js-focus-visible) & :focus-visible,
+	:focus-visible {
+		outline: 2px solid $focus-color;
+	}
+
+	body:not(.js-focus-visible) & input:focus-visible,
+	html:not(.js-focus-visible) & input:focus-visible,
+	body:not(.js-focus-visible) & textarea:focus-visible,
+	html:not(.js-focus-visible) & textarea:focus-visible,
+	body:not(.js-focus-visible) & select:focus-visible,
+	html:not(.js-focus-visible) & select:focus-visible,
+	input:focus-visible,
+	textarea:focus-visible,
+	select:focus-visible {
+		box-shadow: 0 0 0 1px $focus-color;
+	}
+}
+
 .collection {
 	display: flex;
 	flex: 1 1 auto;
@@ -12,7 +70,7 @@
 
 .collection--regular {
 	background: oColorsByName('claret-70');
-
+	@include focusOutlineColor($focus-color: black);
 	@include oGridRespondTo(M) {
 		height: 100%;
 	}


### PR DESCRIPTION
This fix is a part of DAC July 2021.
The focus outline didn't have enough contrast with the background colour(claret-70). It has to be over 3:1.

|Before|After|
|----|----|
|![Screenshot 2021-08-10 at 15 22 37](https://user-images.githubusercontent.com/21194161/128884414-ba724f36-3367-4dd3-a7d4-2d70c923b75c.png)|![Screenshot 2021-08-10 at 15 26 40](https://user-images.githubusercontent.com/21194161/128884909-7d936718-1863-4098-8fa2-cb9a5dd4b9dd.png)|
| Focus outline colour: **#807973** | Focus outline colour: #**000000**|
| Contrast ratio: **1.58**:1 | Contrast ratio: **3.09**:1|
|![Screenshot 2021-08-10 at 15 23 25](https://user-images.githubusercontent.com/21194161/128884469-46f846e7-6788-4baf-a62a-cb5e2c3257e8.png)|![Screenshot 2021-08-10 at 15 28 20](https://user-images.githubusercontent.com/21194161/128885210-41304ac1-39e6-4019-8ce4-891324887c49.png)|
