### PR TITLE
Apply focus outline depends on theme colour

### DIFF
--- a/mixins/lozenge/_themes.scss
+++ b/mixins/lozenge/_themes.scss
@@ -4,28 +4,32 @@ $myft-lozenge-themes: (
 		text: oColorsByName('white'),
 		highlight: oColorsByName('claret-50'),
 		pressed-highlight: rgba(oColorsByName('black'), 0.05),
-		disabled: rgba(oColorsByName('black'), 0.5)
+		disabled: rgba(oColorsByName('black'), 0.5),
+		focus-outline: oColorsByUsecase('focus', 'outline', $fallback: null)
 	),
 	inverse: (
 		background: oColorsByName('white'),
 		text: oColorsByName('claret'),
 		highlight: rgba(white, 0.8),
 		pressed-highlight: rgba(white, 0.2),
-		disabled: rgba(oColorsByName('white'), 0.5)
+		disabled: rgba(oColorsByName('white'), 0.5),
+		focus-outline: oColorsByName('white')
 	),
 	opinion: (
 		background: oColorsByName('oxford-40'),
 		text: oColorsByName('white'),
 		highlight: oColorsByName('oxford-30'),
 		pressed-highlight: rgba(oColorsByName('oxford-40'), 0.2),
-		disabled: rgba(oColorsByName('black'), 0.5)
+		disabled: rgba(oColorsByName('black'), 0.5),
+		focus-outline: oColorsByUsecase('focus', 'outline', $fallback: null)
 	),
 	monochrome: (
 		background: oColorsByName('white'),
 		text: oColorsByName('black'),
 		highlight: oColorsByName('white-80'),
 		pressed-highlight: rgba(oColorsByName('white'), 0.2),
-		disabled: rgba(oColorsByName('white'), 0.5)
+		disabled: rgba(oColorsByName('white'), 0.5),
+		focus-outline: oColorsByName('white')
 	)
 );
 

--- a/mixins/lozenge/main.scss
+++ b/mixins/lozenge/main.scss
@@ -1,6 +1,54 @@
 @import './themes';
 @import './toggle-icon';
 
+@mixin focusOutlineColor($focus-color) {
+	// Apply :focus styles as a fallback
+	// These styles will be applied to all browsers that don't use the polyfill, this includes browsers which support the feature natively.
+	body:not(.js-focus-visible) &,
+	html:not(.js-focus-visible) & {
+		// Standardise focus styles.
+		&:focus {
+			outline: 2px solid $focus-color;
+		}
+	}
+
+	// When the focus-visible polyfill is applied `.js-focus-visible` is added to the html dom node
+	// (the body node in v4 of the 3rd party polyfill)
+
+	// stylelint-disable-next-line selector-no-qualifying-type
+	body.js-focus-visible &, // stylelint-disable-next-line selector-no-qualifying-type
+	html.js-focus-visible & {
+		// Standardise focus styles.
+		// stylelint-disable-next-line selector-no-qualifying-type
+		&.focus-visible {
+			outline: 2px solid $focus-color;
+		}
+		// Disable browser default focus style.
+		// stylelint-disable-next-line selector-no-qualifying-type
+		&:focus:not(.focus-visible) {
+			outline: 0;
+		}
+	}
+
+	// These styles will be ignored by browsers which do not recognise the :focus-visible selector (as per the third bullet point in https://www.w3.org/TR/selectors-3/#Conformance)
+	// If a browser supports :focus-visible we unset the :focus styles that were applied above
+	// (within the html:not(.js-focus-visible) block).
+	&:focus-visible,
+	body:not(.js-focus-visible) &:focus,
+	html:not(.js-focus-visible) &:focus {
+		outline: unset;
+	}
+
+	// Styles given :focus-visible support. Extra selectors needed to match
+	// previous `:focus` selector specificity.
+	body:not(.js-focus-visible) &:focus-visible,
+	html:not(.js-focus-visible) &:focus-visible,
+	&:focus-visible {
+		outline: 2px solid $focus-color;
+	}
+}
+
+
 @mixin myftLozengeTheme($theme: standard, $with-toggle-icon: false) {
 	@if $with-toggle-icon != false {
 		@include myftToggleIcon($theme);
@@ -10,6 +58,8 @@
 		background-color: transparent;
 		border: 1px solid getThemeColor(background);
 		color: getThemeColor(background);
+
+		@include focusOutlineColor(getThemeColor(focus-outline));
 
 		&:hover,
 		&:focus {
@@ -57,8 +107,4 @@
 	text-overflow: ellipsis;
 	transition: border-color, background-color 0.5s ease;
 	white-space: nowrap;
-
-	&:focus {
-		outline: 2px solid oColorsByName('teal-90');
-	}
 }


### PR DESCRIPTION
## Description

When background is dark colour (claret, oxford, teal...), there is not enough contrast between background and focus outline colour.

![image-20210715-121204](https://user-images.githubusercontent.com/21194161/129552165-388d053e-d166-48da-b438-c83467bd90ef.png)
Colour ratio:
Foreground: #807973
Background: #990F3D
The contrast ratio is: 2:1 (**It should be over 3:1**)

This issue was reported by DAC 2021 summer doc. ([Jira ticket](https://financialtimes.atlassian.net/browse/CON-1096))

To fix this issue, applying white outline instead of grey outline(which is provided by o-nomalise).
📝   I'm going to apply the same change to x-follow-button as well ([the PR](https://github.com/Financial-Times/x-dash/pull/609)).

## Screenshots

This fixes the focus outline with follow buttons on ft.com/myft/explore/ and on next-front-page's onboarding slice. They are pointed in the DAC doc.

**The focus outline with follow buttons on ft.com/myft/explore/**

|Before|After|
|---|---|
|![Screenshot 2021-08-10 at 15 22 37](https://user-images.githubusercontent.com/21194161/129576371-0f95089f-afe4-44f0-aeaa-6b0c1dfb2e03.png)|![Screenshot 2021-08-16 at 14 23 22](https://user-images.githubusercontent.com/21194161/129576387-49fb2302-0be2-4d7d-8c63-59f57082c5e1.png)|

**The focus outline with follow buttons on next-front-page's onboarding slice**
|Before|After|
|---|---|
|![Screenshot 2021-08-16 at 14 42 44](https://user-images.githubusercontent.com/21194161/129576424-76c00ef3-a477-496c-811c-7856a0df2b80.png)|![Screenshot 2021-08-16 at 14 45 27](https://user-images.githubusercontent.com/21194161/129576481-250aebd6-2813-4205-8a5d-6baa9e8efa5e.png)|