### PR TITLE
UG-812: Implement create list and save article overlay variant

### DIFF
--- a/components/save-for-later/save-for-later.html
+++ b/components/save-for-later/save-for-later.html
@@ -3,7 +3,8 @@
 	data-content-id="{{contentId}}"
 	data-myft-ui="saved"
 	action="/myft/save/{{contentId}}"
-	data-js-action="/__myft/api/core/saved/content/{{contentId}}?method=put">
+	data-js-action="/__myft/api/core/saved/content/{{contentId}}?method=put"
+	{{#ifEquals @root.flags.professorLists 'variant'}}data-myft-ui-variant="createListAndSaveArticleVariant"{{/ifEquals}}>
 	{{> n-myft-ui/components/csrf-token/input}}
 	<div
 		class="n-myft-ui__announcement o-normalise-visually-hidden"

--- a/myft/main.scss
+++ b/myft/main.scss
@@ -173,3 +173,148 @@ $spacing-unit: 20px;
 	}
 
 }
+
+.share-nav {
+	&.data-overlap-initialised {
+		.o-overlay {
+			transition: opacity 0.15s ease-in;
+			opacity: 0;
+			z-index: -1;
+		}
+	}
+
+	.myft-ui-create-list-variant {
+		border-radius: 10px;
+		border: 1px solid oColorsByName('black-5');
+		background: oColorsByName('white-80');
+
+		.o-overlay__heading {
+			border-radius: 10px 10px 0 0;
+			background: oColorsByName('white-60');
+			@include oTypographySans($scale: 2);
+			color: oColorsByName('black-80');
+		}
+
+		.o-overlay__content {
+			@include oTypographySans($scale: 0);
+			color: oColorsByName('black-80');
+			padding: 0;
+		}
+
+		.o-overlay__title {
+			margin: 8px 14px 0 8px;
+		}
+
+		&-container {
+			display: block;
+			width: 340px;
+			top: 115.5px;
+			left: 50px;
+		}
+
+		&-add {
+			border: 0;
+			background: none;
+			@include oTypographySans($scale: 1, $weight: 'semibold');
+			color: oColorsByName('black-80');
+
+			padding-left: 0;
+			margin-left: -8px;
+
+			&:hover {
+				text-decoration: underline;
+			}
+
+			&::before {
+				content: '';
+				@include oIconsContent(
+					'plus',
+					oColorsByName('black-80'),
+					28,
+					$iconset-version: 1
+				);
+				vertical-align: middle;
+				margin-top: -2px;
+			}
+		}
+
+		&-add-description {
+			margin: 4px 0;
+		}
+
+		&-heading {
+			&::before {
+				content: '';
+				@include oIconsContent(
+					'tick',
+					oColorsByName('teal'),
+					32,
+					$iconset-version: 1
+				);
+				vertical-align: middle;
+				margin-top: -2px;
+			}
+		}
+
+		&-footer {
+			border-top: 1px solid oColorsByName('black-5');
+			padding: 16px;
+		}
+
+		&-icon {
+			&::before {
+				content: "";
+				display: inline-block;
+				background-repeat: no-repeat;
+				background-size: contain;
+				background-position: 50%;
+				background-color: transparent;
+				background-image: url(https://www.ft.com/__origami/service/image/v2/images/raw/ftlogo-v1:brand-myft?source=next-article);
+				width: 42px;
+				height: 42px;
+				vertical-align: middle;
+				margin-top: -2px;
+			}
+
+			&-visually-hidden {
+				clip: rect(0 0 0 0);
+				clip-path: inset(50%);
+				height: 1px;
+				overflow: hidden;
+				position: absolute;
+				white-space: nowrap;
+				width: 1px;
+			}
+		}
+
+		&-form {
+			display: flex;
+			width: calc(100% - 32px);
+			justify-content: space-between;
+			height: 40px;
+			gap: 8px;
+			padding: 0 16px 16px;
+
+			& > * {
+				flex: 1 1 auto;
+			}
+
+			.o-forms-input {
+				margin-top: 0;
+			}
+		}
+
+		&-lists {
+			padding: 16px 16px 0;
+			@include oTypographySans($scale: 1);
+			&-text {
+				@include oTypographySans($weight: 'semibold');
+				color: oColorsByName('black-80');
+				margin-bottom: 16px;
+			}
+			&-container {
+				margin-top: 0;
+			}
+		}
+	}
+}

--- a/myft/ui/lists.js
+++ b/myft/ui/lists.js
@@ -195,7 +195,7 @@ function initialEventListeners () {
 		// otherwise it will show the classic overlay
 		const createListVariant = event.currentTarget.querySelector('[data-myft-ui-variant="createListAndSaveArticleVariant"]');
 		if (createListVariant) {
-			return openCreateListAndAddArticleOverlay(userid, contentId);
+			return openCreateListAndAddArticleOverlay(contentId);
 		}
 
 		handleArticleSaved(contentId);

--- a/myft/ui/lists.js
+++ b/myft/ui/lists.js
@@ -187,7 +187,6 @@ function openCreateListAndAddArticleOverlay (contentId) {
 function initialEventListeners () {
 
 	document.body.addEventListener('myft.user.saved.content.add', event => {
-		const userid = event.detail.actorId;
 		const contentId = event.detail.subject;
 
 		// Checks if the createListAndSaveArticle variant is active

--- a/myft/ui/lists.js
+++ b/myft/ui/lists.js
@@ -190,7 +190,7 @@ function initialEventListeners () {
 		const contentId = event.detail.subject;
 
 		// Checks if the createListAndSaveArticle variant is active
-		// and will show the variant overlay if there the user has no lists,
+		// and will show the variant overlay if the user has no lists,
 		// otherwise it will show the classic overlay
 		const createListVariant = event.currentTarget.querySelector('[data-myft-ui-variant="createListAndSaveArticleVariant"]');
 		if (createListVariant) {

--- a/myft/ui/save-article-to-list-variant.js
+++ b/myft/ui/save-article-to-list-variant.js
@@ -194,7 +194,7 @@ function ListsElement (lists, addToList, removeFromList) {
 	const listCheckboxElement = ListCheckboxElement(addToList, removeFromList);
 
 	const listsTemplate = `
-	<div class="myft-ui-create-list-variant-lists o-forms-field o-forms-field--optional" role="group" aria-labelledby="checkbox-group-title" aria-describedby="checkbox-group-info">
+	<div class="myft-ui-create-list-variant-lists o-forms-field o-forms-field--optional" role="group">
 		<span class="myft-ui-create-list-variant-lists-text">Add to a list</span>
 		<span class="myft-ui-create-list-variant-lists-container o-forms-input o-forms-input--checkbox">
 		</span>

--- a/myft/ui/save-article-to-list-variant.js
+++ b/myft/ui/save-article-to-list-variant.js
@@ -17,7 +17,7 @@ export default async function openSaveArticleToListVariant (name, contentId) {
 		myFtClient.add('user', null, 'created', 'list', uuid(), { name: list,	token: csrfToken })
 			.then(detail => {
 				myFtClient.add('list', detail.subject, 'contained', 'content', contentId, { token: csrfToken }).then((createdList) => {
-					lists.push({ name: list, subject: createdList.actorId, checked: true });
+					lists.push({ name: list, uuid: createdList.actorId, checked: true });
 					const listElement = ListsElement(lists, addToList, removeFromList);
 					const overlayContent = document.querySelector('.o-overlay__content');
 					overlayContent.insertAdjacentElement('afterbegin', listElement);
@@ -30,7 +30,7 @@ export default async function openSaveArticleToListVariant (name, contentId) {
 			return;
 		}
 
-		myFtClient.add('list', list.subject, 'contained', 'content', contentId, { token: csrfToken }).then(() => {
+		myFtClient.add('list', list.uuid, 'contained', 'content', contentId, { token: csrfToken }).then(() => {
 			const indexToUpdate = lists.indexOf(list);
 			lists[indexToUpdate] = { ...lists[indexToUpdate], checked: true };
 			const listElement = ListsElement(lists, addToList, removeFromList);
@@ -44,7 +44,7 @@ export default async function openSaveArticleToListVariant (name, contentId) {
 			return;
 		}
 
-		myFtClient.remove('list', list.subject, 'contained', 'content', contentId, { token: csrfToken }).then(() => {
+		myFtClient.remove('list', list.uuid, 'contained', 'content', contentId, { token: csrfToken }).then(() => {
 			const indexToUpdate = lists.indexOf(list);
 			lists[indexToUpdate] = { ...lists[indexToUpdate], checked: false };
 			const listElement = ListsElement(lists, addToList, removeFromList);
@@ -273,6 +273,6 @@ function calculateLargerScreenHalf (target) {
 
 async function getLists () {
 	return myFtClient.getAll('created', 'list').then(lists => {
-		return lists.map(list => ({ name: list.name, subject: list.uuid, checked: false }));
+		return lists.map(list => ({ name: list.name, uuid: list.uuid, checked: false }));
 	});
 }

--- a/myft/ui/save-article-to-list-variant.js
+++ b/myft/ui/save-article-to-list-variant.js
@@ -280,7 +280,9 @@ function calculateLargerScreenHalf (target) {
 }
 
 async function getLists () {
-	return myFtClient.getAll('created', 'list').then(lists => {
-		return lists.map(list => ({ name: list.name, uuid: list.uuid, checked: false }));
-	});
+	return myFtClient.getAll('created', 'list')
+		.then(lists => lists.filter(list => !list.isRedirect))
+		.then(lists => {
+			return lists.map(list => ({ name: list.name, uuid: list.uuid, checked: false }));
+		});
 }

--- a/myft/ui/save-article-to-list-variant.js
+++ b/myft/ui/save-article-to-list-variant.js
@@ -139,10 +139,10 @@ function stringToHTMLElement (string) {
 
 function FormElement (createList) {
 	const formString = `
-	<form class='myft-ui-create-list-variant-form'>
+	<form class="myft-ui-create-list-variant-form">
 		<label class="o-forms-field">
 			<span class="o-forms-input o-forms-input--text">
-					<input type="text" name="list-name">
+				<input type="text" name="list-name" aria-label="List name">
 			</span>
 		</label>
 		<button class="o-buttons o-buttons--secondary" type="submit">

--- a/myft/ui/save-article-to-list-variant.js
+++ b/myft/ui/save-article-to-list-variant.js
@@ -1,0 +1,278 @@
+import Overlay from 'o-overlay';
+import myFtClient from 'next-myft-client';
+import { uuid } from 'n-ui-foundations';
+import getToken from './lib/get-csrf-token';
+import oTooltip from 'o-tooltip';
+
+const csrfToken = getToken();
+
+let lists;
+
+export default async function openSaveArticleToListVariant (name, contentId) {
+	function createList (list) {
+		if(!list) {
+			return;
+		}
+
+		myFtClient.add('user', null, 'created', 'list', uuid(), { name: list,	token: csrfToken })
+			.then(detail => {
+				myFtClient.add('list', detail.subject, 'contained', 'content', contentId, { token: csrfToken }).then((createdList) => {
+					lists.push({ name: list, subject: createdList.subject, checked: true });
+					const listElement = ListsElement(lists, addToList, removeFromList);
+					const overlayContent = document.querySelector('.o-overlay__content');
+					overlayContent.insertAdjacentElement('afterbegin', listElement);
+				});
+			});
+	}
+
+	function addToList (list) {
+		if(!list) {
+			return;
+		}
+
+		myFtClient.add('list', list.subject, 'contained', 'content', contentId, { token: csrfToken }).then(() => {
+			const indexToUpdate = lists.indexOf(list);
+			lists[indexToUpdate] = { ...lists[indexToUpdate], checked: true };
+			const listElement = ListsElement(lists, addToList, removeFromList);
+			const overlayContent = document.querySelector('.o-overlay__content');
+			overlayContent.insertAdjacentElement('afterbegin', listElement);
+		});
+	}
+
+	function removeFromList (list) {
+		if(!list) {
+			return;
+		}
+
+		myFtClient.remove('list', list.subject, 'contained', 'content', contentId, { token: csrfToken }).then(() => {
+			const indexToUpdate = lists.indexOf(list);
+			lists[indexToUpdate] = { ...lists[indexToUpdate], checked: false };
+			const listElement = ListsElement(lists, addToList, removeFromList);
+			const overlayContent = document.querySelector('.o-overlay__content');
+			overlayContent.insertAdjacentElement('afterbegin', listElement);
+		});
+	}
+
+	if (!lists) {
+		lists = await getLists(contentId);
+	}
+
+	const overlays = Overlay.getOverlays();
+	const existingOverlay = overlays[name];
+	if (existingOverlay) {
+		existingOverlay.destroy();
+	}
+
+	const contentElement = ContentElement();
+	const headingElement = HeadingElement();
+
+	const createListOverlay = new Overlay(name, {
+		html: contentElement,
+		heading: { title: headingElement.outerHTML },
+		modal: false,
+		parentnode: isMobile() ? '.o-share--horizontal' : '.o-share--vertical',
+		class: 'myft-ui-create-list-variant',
+	});
+
+	const realignListener = realignOverlay(window.scrollY);
+
+	function outsideClickHandler (e) {
+		const overlayContent = document.querySelector('.o-overlay__content');
+		if(!overlayContent || !overlayContent.contains(e.target)) {
+			createListOverlay.close();
+		}
+	}
+
+	function openFormHandler () {
+		const formElement = FormElement(createList);
+
+		const overlayContent = document.querySelector('.o-overlay__content');
+		overlayContent.insertAdjacentElement('beforeend', formElement);
+	}
+
+	createListOverlay.open();
+	createListOverlay.wrapper.addEventListener('oOverlay.ready', (data) => {
+		realignListener(data.currentTarget);
+
+		if (lists && lists.length) {
+			const listElement = ListsElement(lists, addToList, removeFromList);
+			const overlayContent = document.querySelector('.o-overlay__content');
+			overlayContent.insertAdjacentElement('afterbegin', listElement);
+		}
+
+		contentElement.addEventListener('click', openFormHandler);
+
+		document.querySelector('.article-content').addEventListener('click', outsideClickHandler);
+	});
+
+	createListOverlay.wrapper.addEventListener('oOverlay.destroy', () => {
+		const tooltipTemplate = document.createElement('div');
+		const opts = {
+			target: 'o-header-top-link-myft',
+			content: 'Go to saved articles in myFT to find your lists',
+			showOnConstruction: true,
+			closeAfter: 5,
+			position: 'below'
+		};
+
+		new oTooltip(tooltipTemplate, opts);
+
+		contentElement.removeEventListener('click', openFormHandler);
+
+		document.querySelector('.article-content').removeEventListener('click', outsideClickHandler);
+	});
+
+	window.addEventListener('scroll', function () {
+		realignListener(createListOverlay.wrapper, window.scrollY);
+	});
+
+	window.addEventListener('oViewport.resize', () => {
+		realignListener(createListOverlay.wrapper);
+	});
+}
+
+function stringToHTMLElement (string) {
+	const template = document.createElement('template');
+	template.innerHTML = string.trim();
+	return template.content.firstChild;
+}
+
+function FormElement (createList) {
+	const formString = `
+	<form class='myft-ui-create-list-variant-form'>
+		<label class="o-forms-field">
+			<span class="o-forms-input o-forms-input--text">
+					<input type="text" name="list-name">
+			</span>
+		</label>
+		<button class="o-buttons o-buttons--secondary" type="submit">
+			Save
+		</button>
+	</form>
+	`;
+
+	const formElement = stringToHTMLElement(formString);
+
+	formElement.querySelector('button[type="submit"]').addEventListener('click', (e) => {
+		e.preventDefault();
+		e.stopPropagation();
+		const inputListName = formElement.querySelector('input[name="list-name"]');
+		createList(inputListName.value);
+		inputListName.value = '';
+		formElement.remove();
+	});
+
+	return formElement;
+}
+
+function ContentElement () {
+	let content = `
+		<div class="myft-ui-create-list-variant-footer">
+			<button class="myft-ui-create-list-variant-add">Add to a new list</button>
+			${!lists.length ? '<p class="myft-ui-create-list-variant-add-description">Lists are a simple way to curate your content</p>' : ''}
+		</div>
+	`;
+
+	return stringToHTMLElement(content);
+}
+
+function HeadingElement () {
+	const heading = `
+		<span class="myft-ui-create-list-variant-heading">Added to <a href="https://www.ft.com/myft/saved-articles">saved articles</a> in <span class="myft-ui-create-list-variant-icon"><span class="myft-ui-create-list-variant-icon-visually-hidden">my ft</span></span></span>
+		`;
+
+	return stringToHTMLElement(heading);
+}
+
+function ListsElement (lists, addToList, removeFromList) {
+	const currentList = document.querySelector('.myft-ui-create-list-variant-lists');
+	if (currentList) {
+		currentList.remove();
+	}
+
+	const listCheckboxElement = ListCheckboxElement(addToList, removeFromList);
+
+	const listsTemplate = `
+	<div class="myft-ui-create-list-variant-lists o-forms-field o-forms-field--optional" role="group" aria-labelledby="checkbox-group-title" aria-describedby="checkbox-group-info">
+		<span class="myft-ui-create-list-variant-lists-text">Add to a list</span>
+		<span class="myft-ui-create-list-variant-lists-container o-forms-input o-forms-input--checkbox">
+		</span>
+	</div>
+	`;
+	const listsElement = stringToHTMLElement(listsTemplate);
+
+	const listsElementContainer = listsElement.querySelector('.myft-ui-create-list-variant-lists-container');
+
+	lists.map(list => listsElementContainer.insertAdjacentElement('beforeend', listCheckboxElement(list)));
+
+	return listsElement;
+}
+
+function ListCheckboxElement (addToList, removeFromList) {
+	return function (list) {
+		const listCheckbox = `<label>
+		<input type="checkbox" name="default" value="${list.name}" ${list.checked ? 'checked' : ''}>
+		<span class="o-forms-input__label">${list.name}</span>
+	</label>
+	`;
+
+		const listCheckboxElement = stringToHTMLElement(listCheckbox);
+
+		const [ input ] = listCheckboxElement.children;
+
+		input.addEventListener('click', function (e) {
+			e.preventDefault();
+			return e.target.checked ? addToList(list) : removeFromList(list);
+		});
+
+		return listCheckboxElement;
+	};
+}
+
+function realignOverlay (originalScrollPosition) {
+	return function (target, currentScrollPosition) {
+		if(currentScrollPosition && Math.abs(currentScrollPosition - originalScrollPosition) < 120) {
+			return;
+		}
+
+		originalScrollPosition = currentScrollPosition;
+
+		target.style['min-width'] = '340px';
+		target.style['width'] = '100%';
+		target.style['margin-top'] = '-50px';
+		target.style['left'] = 0;
+
+		if (isMobile()) {
+			target.style['position'] = 'absolute';
+			target.style['margin-left'] = 0;
+			target.style['margin-top'] = 0;
+			target.style['top'] = calculateLargerScreenHalf(target) === 'ABOVE' ? '-120px' : '50px';
+		} else {
+			target.style['position'] = 'absolute';
+			target.style['margin-left'] = '45px';
+			target.style['top'] = '220px';
+		}
+	};
+}
+
+function isMobile () {
+	const vw = Math.max(document.documentElement.clientWidth || 0, window.innerWidth || 0);
+
+	return vw <= 980;
+}
+
+function calculateLargerScreenHalf (target) {
+	const vh = Math.min(document.documentElement.clientHeight || 0, window.innerHeight || 0);
+
+	const targetBox = target.getBoundingClientRect();
+	const spaceAbove = targetBox.top;
+	const spaceBelow = vh - targetBox.bottom;
+
+	return spaceBelow < spaceAbove ? 'ABOVE' : 'BELOW';
+}
+
+async function getLists () {
+	return myFtClient.getAll('created', 'list').then(lists => {
+		return lists.map(list => ({ name: list.name, subject: list.uuid, checked: false }));
+	});
+}

--- a/myft/ui/save-article-to-list-variant.js
+++ b/myft/ui/save-article-to-list-variant.js
@@ -213,7 +213,12 @@ function ListCheckboxElement (addToList, removeFromList) {
 	return function (list) {
 		const listCheckbox = `<label>
 		<input type="checkbox" name="default" value="${list.name}" ${list.checked ? 'checked' : ''}>
-		<span class="o-forms-input__label">${list.name}</span>
+		<span class="o-forms-input__label">
+			<span class="o-normalise-visually-hidden">
+			${list.checked ? "Remove article from " : "Add article to " }
+			</span>
+			${list.name}
+		</span>
 	</label>
 	`;
 

--- a/myft/ui/save-article-to-list-variant.js
+++ b/myft/ui/save-article-to-list-variant.js
@@ -179,7 +179,7 @@ function ContentElement () {
 
 function HeadingElement () {
 	const heading = `
-		<span class="myft-ui-create-list-variant-heading">Added to <a href="https://www.ft.com/myft/saved-articles">saved articles</a> in <span class="myft-ui-create-list-variant-icon"><span class="myft-ui-create-list-variant-icon-visually-hidden">my ft</span></span></span>
+		<span class="myft-ui-create-list-variant-heading">Added to <a href="https://www.ft.com/myft/saved-articles">saved articles</a> in <span class="myft-ui-create-list-variant-icon"><span class="myft-ui-create-list-variant-icon-visually-hidden">my FT</span></span></span>
 		`;
 
 	return stringToHTMLElement(heading);

--- a/myft/ui/save-article-to-list-variant.js
+++ b/myft/ui/save-article-to-list-variant.js
@@ -88,6 +88,7 @@ export default async function openSaveArticleToListVariant (name, contentId) {
 
 		const overlayContent = document.querySelector('.o-overlay__content');
 		overlayContent.insertAdjacentElement('beforeend', formElement);
+		formElement.elements[0].focus();
 	}
 
 	createListOverlay.open();

--- a/myft/ui/save-article-to-list-variant.js
+++ b/myft/ui/save-article-to-list-variant.js
@@ -21,6 +21,8 @@ export default async function openSaveArticleToListVariant (name, contentId) {
 					const listElement = ListsElement(lists, addToList, removeFromList);
 					const overlayContent = document.querySelector('.o-overlay__content');
 					overlayContent.insertAdjacentElement('afterbegin', listElement);
+					const announceListContainer = document.querySelector('.myft-ui-create-list-variant-announcement');
+					announceListContainer.textContent = `${list} created`;
 				});
 			});
 	}

--- a/myft/ui/save-article-to-list-variant.js
+++ b/myft/ui/save-article-to-list-variant.js
@@ -17,7 +17,7 @@ export default async function openSaveArticleToListVariant (name, contentId) {
 		myFtClient.add('user', null, 'created', 'list', uuid(), { name: list,	token: csrfToken })
 			.then(detail => {
 				myFtClient.add('list', detail.subject, 'contained', 'content', contentId, { token: csrfToken }).then((createdList) => {
-					lists.push({ name: list, subject: createdList.subject, checked: true });
+					lists.push({ name: list, subject: createdList.actorId, checked: true });
 					const listElement = ListsElement(lists, addToList, removeFromList);
 					const overlayContent = document.querySelector('.o-overlay__content');
 					overlayContent.insertAdjacentElement('afterbegin', listElement);


### PR DESCRIPTION
### Description
 This PRs implements the "Create list and save article overlay" variant that will be shown on [this US Growth test](https://www.figma.com/file/nNlBgqIg0aXAOrYLrxPmSg/Professors-Lists?node-id=500%3A28355)

Its main changes consist of:

- Adding a data property  `data-myft-ui-variant=createListAndSaveArticleVariant` to the save for later button that will determine if the test is active based on the value of the professorLists flag.
- Adding a check for that data property in the `myft.user.saved.content.add` event listener, and displays the new overlay variant if the user has no lists.
- Implement the overlay variant using `o-overlay` and implement methods to: position the overlay next to the `SaveForLater` component, reposition the overlay on resize or scroll (mobile only) handle the interactions to create a new list and add/remove the article to lists.

### Screenshots

![Screenshot 2022-04-13 at 10 31 00](https://user-images.githubusercontent.com/1705375/163147351-e6c205f5-d971-4aa1-a0a2-817db016eee8.png)
![Screenshot 2022-04-13 at 10 31 20](https://user-images.githubusercontent.com/1705375/163147363-93dca78e-0a77-433e-ad52-55ab9cdfd1df.png)

### How to test this code?

- Check out this branch locally and run: 
  - `npm link`
  - `bower link`
- Check out `next-article` and run:
  - `npm link @financial-times/n-myft-ui`
  - `bower link n-myft-ui`
- Build and run `next-article`
  - `make build run`
- Go to FT Toggler and select the variant on the [professorLists flag](https://toggler.ft.com/#professorLists)
- Go to [myFT section](https://www.ft.com/myft/lists) and make sure you don't have any lists created. 
- Go to [an article](https://local.ft.com:5050/content/aa9caaad-c19f-4451-b13b-e514b9c284a5) and click on the `Save`  button on the Share Navigation bar
- Confirm that you can: create a new list, add the article to the list and remove the article from the list. These changes must be reflected on your [myFT lists page](https://www.ft.com/myft/lists/)
- Test it on the following article types
  - [x] Normal articles ([Local](https://local.ft.com:5050/content/395650fa-5b9c-11e5-a28b-50226830d644) | [Live](https://www.ft.com/content/395650fa-5b9c-11e5-a28b-50226830d644) | `395650fa-5b9c-11e5-a28b-50226830d644`)
  - [x] Articles with toppers ([Local](https://local.ft.com:5050/content/fe291f16-4aa6-11e7-a3f4-c742b9791d43) | [Live](https://www.ft.com/content/fe291f16-4aa6-11e7-a3f4-c742b9791d43) | `fe291f16-4aa6-11e7-a3f4-c742b9791d43`)
  - [x] Package Intro page
([Local](https://local.ft.com:5050/content/de4d756c-04be-11e7-ace0-1ce02ef0def9) | [Live](https://www.ft.com/content/de4d756c-04be-11e7-ace0-1ce02ef0def9) | `de4d756c-04be-11e7-ace0-1ce02ef0def9`)
  - [x] Package article page ([Local](https://local.ft.com:5050/content/bb1d8246-75e1-11e7-a3e8-60495fe6ca71) | [Live](https://www.ft.com/content/bb1d8246-75e1-11e7-a3e8-60495fe6ca71) | `bb1d8246-75e1-11e7-a3e8-60495fe6ca71`)
  - [x] Kitchen Sink Components ([Local](https://local.ft.com:5050/content/146da558-4dee-11e3-8fa5-00144feabdc0) | [Live](https://www.ft.com/content/146da558-4dee-11e3-8fa5-00144feabdc0) | `146da558-4dee-11e3-8fa5-00144feabdc0`)