### PR TITLE
UG-834 Create list variant tracking spec

### DIFF
--- a/myft/ui/save-article-to-list-variant.js
+++ b/myft/ui/save-article-to-list-variant.js
@@ -23,7 +23,7 @@ export default async function openSaveArticleToListVariant (name, contentId) {
 					overlayContent.insertAdjacentElement('afterbegin', listElement);
 					const announceListContainer = document.querySelector('.myft-ui-create-list-variant-announcement');
 					announceListContainer.textContent = `${list} created`;
-					triggerCreateListEvent(contentId)
+					triggerCreateListEvent(contentId);
 				});
 			});
 	}
@@ -39,6 +39,7 @@ export default async function openSaveArticleToListVariant (name, contentId) {
 			const listElement = ListsElement(lists, addToList, removeFromList);
 			const overlayContent = document.querySelector('.o-overlay__content');
 			overlayContent.insertAdjacentElement('afterbegin', listElement);
+			triggerAddToListEvent(contentId);
 		});
 	}
 
@@ -53,6 +54,7 @@ export default async function openSaveArticleToListVariant (name, contentId) {
 			const listElement = ListsElement(lists, addToList, removeFromList);
 			const overlayContent = document.querySelector('.o-overlay__content');
 			overlayContent.insertAdjacentElement('afterbegin', listElement);
+			triggerRemoveFromListEvent(contentId);
 		});
 	}
 
@@ -218,7 +220,7 @@ function ListCheckboxElement (addToList, removeFromList) {
 		<input type="checkbox" name="default" value="${list.name}" ${list.checked ? 'checked' : ''}>
 		<span class="o-forms-input__label">
 			<span class="o-normalise-visually-hidden">
-			${list.checked ? "Remove article from " : "Add article to " }
+			${list.checked ? 'Remove article from ' : 'Add article to ' }
 			</span>
 			${list.name}
 		</span>
@@ -288,7 +290,44 @@ async function getLists () {
 		});
 }
 
+function triggerAddToListEvent (contentId) {
+	return document.body.dispatchEvent(new CustomEvent('oTracking.event', {
+		detail: {
+			category: 'professorLists',
+			action: 'add-to-list',
+			article_id: contentId,
+			teamName: 'customer-products-us-growth',
+			amplitudeExploratory: true
+		},
+		bubbles: true
+	}));
+}
+
+function triggerRemoveFromListEvent (contentId) {
+	return document.body.dispatchEvent(new CustomEvent('oTracking.event', {
+		detail: {
+			category: 'professorLists',
+			action: 'remove-from-list',
+			article_id: contentId,
+			teamName: 'customer-products-us-growth',
+			amplitudeExploratory: true
+		},
+		bubbles: true
+	}));
+}
+
 function triggerCreateListEvent (contentId) {
+	document.body.dispatchEvent(new CustomEvent('oTracking.event', {
+		detail: {
+			category: 'professorLists',
+			action: 'create-list',
+			article_id: contentId,
+			teamName: 'customer-products-us-growth',
+			amplitudeExploratory: true
+		},
+		bubbles: true
+	}));
+
 	return document.body.dispatchEvent(new CustomEvent('oTracking.event', {
 		detail: {
 			category: 'myFT',

--- a/myft/ui/save-article-to-list-variant.js
+++ b/myft/ui/save-article-to-list-variant.js
@@ -23,6 +23,7 @@ export default async function openSaveArticleToListVariant (name, contentId) {
 					overlayContent.insertAdjacentElement('afterbegin', listElement);
 					const announceListContainer = document.querySelector('.myft-ui-create-list-variant-announcement');
 					announceListContainer.textContent = `${list} created`;
+					triggerCreateListEvent(contentId)
 				});
 			});
 	}
@@ -285,4 +286,15 @@ async function getLists () {
 		.then(lists => {
 			return lists.map(list => ({ name: list.name, uuid: list.uuid, checked: false }));
 		});
+}
+
+function triggerCreateListEvent (contentId) {
+	return document.body.dispatchEvent(new CustomEvent('oTracking.event', {
+		detail: {
+			category: 'myFT',
+			action: 'create-list-success',
+			article_id: contentId
+		},
+		bubbles: true
+	}));
 }


### PR DESCRIPTION
### Description

The save article overlay variant will use the same tracking events as the current experience apart from an event to track the new createList action. This change adds a function to trigger the `create-list-success` event and calls it after the list is created.

UPDATE: This PR is also adds new custom events for create list, add article to list and remove article from list actions on the save article variant. These events include the additional properties `amplitudeExploratory` and `teamName` to have them appear on Amplitude's exploratory space, and we'll use them to build a dashboard for this feature on Amplitude

### How to test this code?

- Check out this branch locally and run: 
  - `npm link`
  - `bower link`
- Check out `next-article` and run:
  - `npm link @financial-times/n-myft-ui`
  - `bower link n-myft-ui`
- Build and run `next-article`
  - `make build run`
- Go to FT Toggler and select the variant on the [professorLists flag](https://toggler.ft.com/#professorLists)
- Go to [myFT section](https://www.ft.com/myft/lists) and make sure you don't have any lists created. 
- Go to [an article](https://local.ft.com:5050/content/aa9caaad-c19f-4451-b13b-e514b9c284a5) and click on the `Save`  button on the Share Navigation bar
- Open the network tab and confirm that these events are triggered through their respective actions
  - Create a new list: `myFT:create-list-success`
  - Remove article from list: `myFT:unsave`
  - Add article to list: `myFT:add-to-list-success`
- Confirm that these events are triggered through their respective actions and they include the fields `amplitudeExploratory` and `teamName` on the payload's `context` property
  - Create a new list: `professorList:create-list`
  - Remove article from list: `professorList:remove-from-list`
  - Add article to list: `professorList:add-to-list`