### PR TITLE
UG-815: Add error reporting through Sentry

### DIFF
--- a/myft/ui/save-article-to-list-variant.js
+++ b/myft/ui/save-article-to-list-variant.js
@@ -3,36 +3,10 @@ import myFtClient from 'next-myft-client';
 import { uuid } from 'n-ui-foundations';
 import getToken from './lib/get-csrf-token';
 import oTooltip from 'o-tooltip';
-import oErrors from 'o-errors';
 
 const csrfToken = getToken();
 
 let lists;
-
-function initialiseErrorTracking () {
-	oErrors.init({
-		sentryEndpoint: 'https://d63d3b29fd374c3d95fa814a38c9bac9@o16684.ingest.sentry.io/79480',
-		transformError: function (data) {
-			const { context } = data;
-
-			if (context) {
-				const { extra = {} } = context;
-				const { info = {} } = extra;
-
-				if (info.component === 'professorLists') {
-					data.error.message = `[professorLists]: ${data.error.message}`;
-				}
-			}
-
-			return data;
-		},
-		filterError: function (data) {
-			const { error = { message: '' }, errormessage = '' } = data;
-
-			return errormessage.includes('[professorLists]') || error.message.includes('[professorLists]');
-		}
-	});
-}
 
 export default async function showSaveArticleToListVariant (name, contentId) {
 	try {
@@ -392,7 +366,6 @@ function triggerCreateListEvent (contentId) {
 }
 
 function handleError (error) {
-	initialiseErrorTracking();
 	document.body.dispatchEvent(new CustomEvent('oErrors.log', {
 		bubbles: true,
 		detail: {

--- a/myft/ui/save-article-to-list-variant.js
+++ b/myft/ui/save-article-to-list-variant.js
@@ -9,28 +9,30 @@ const csrfToken = getToken();
 
 let lists;
 
-oErrors.init({
-	sentryEndpoint: 'https://d63d3b29fd374c3d95fa814a38c9bac9@o16684.ingest.sentry.io/79480',
-	transformError: function (data) {
-		const { context } = data;
+function initialiseErrorTracking () {
+	oErrors.init({
+		sentryEndpoint: 'https://d63d3b29fd374c3d95fa814a38c9bac9@o16684.ingest.sentry.io/79480',
+		transformError: function (data) {
+			const { context } = data;
 
-		if (context) {
-			const { extra = {} } = context;
-			const { info = {} } = extra;
+			if (context) {
+				const { extra = {} } = context;
+				const { info = {} } = extra;
 
-			if (info.component === 'professorLists') {
-				data.error.message = `[professorLists]: ${data.error.message}`;
+				if (info.component === 'professorLists') {
+					data.error.message = `[professorLists]: ${data.error.message}`;
+				}
 			}
+
+			return data;
+		},
+		filterError: function (data) {
+			const { error = { message: '' }, errormessage = '' } = data;
+
+			return errormessage.includes('[professorLists]') || error.message.includes('[professorLists]');
 		}
-
-		return data;
-	},
-	filterError: function (data) {
-		const { error = { message: '' }, errormessage = '' } = data;
-
-		return errormessage.includes('[professorLists]') || error.message.includes('[professorLists]');
-	}
-});
+	});
+}
 
 export default async function showSaveArticleToListVariant (name, contentId) {
 	try {
@@ -390,6 +392,7 @@ function triggerCreateListEvent (contentId) {
 }
 
 function handleError (error) {
+	initialiseErrorTracking();
 	document.body.dispatchEvent(new CustomEvent('oErrors.log', {
 		bubbles: true,
 		detail: {

--- a/myft/ui/save-article-to-list-variant.js
+++ b/myft/ui/save-article-to-list-variant.js
@@ -3,12 +3,44 @@ import myFtClient from 'next-myft-client';
 import { uuid } from 'n-ui-foundations';
 import getToken from './lib/get-csrf-token';
 import oTooltip from 'o-tooltip';
+import oErrors from 'o-errors';
 
 const csrfToken = getToken();
 
 let lists;
 
-export default async function openSaveArticleToListVariant (name, contentId) {
+oErrors.init({
+	sentryEndpoint: 'https://d63d3b29fd374c3d95fa814a38c9bac9@o16684.ingest.sentry.io/79480',
+	transformError: function (data) {
+		const { context } = data;
+
+		if (context) {
+			const { extra = {} } = context;
+			const { info = {} } = extra;
+
+			if (info.component === 'professorLists') {
+				data.error.message = `[professorLists]: ${data.error.message}`;
+			}
+		}
+
+		return data;
+	},
+	filterError: function (data) {
+		const { error = { message: '' }, errormessage = '' } = data;
+
+		return errormessage.includes('[professorLists]') || error.message.includes('[professorLists]');
+	}
+});
+
+export default async function showSaveArticleToListVariant (name, contentId) {
+	try {
+		await openSaveArticleToListVariant (name, contentId);
+	} catch(error) {
+		handleError(error);
+	}
+}
+
+async function openSaveArticleToListVariant (name, contentId) {
 	function createList (list) {
 		if(!list) {
 			return;
@@ -82,18 +114,25 @@ export default async function openSaveArticleToListVariant (name, contentId) {
 	const realignListener = realignOverlay(window.scrollY);
 
 	function outsideClickHandler (e) {
-		const overlayContent = document.querySelector('.o-overlay__content');
-		if(!overlayContent || !overlayContent.contains(e.target)) {
-			createListOverlay.close();
+		try {
+			const overlayContent = document.querySelector('.o-overlay__content');
+			if(!overlayContent || !overlayContent.contains(e.target)) {
+				createListOverlay.close();
+			}
+		} catch(error) {
+			handleError(error);
 		}
 	}
 
 	function openFormHandler () {
-		const formElement = FormElement(createList);
-
-		const overlayContent = document.querySelector('.o-overlay__content');
-		overlayContent.insertAdjacentElement('beforeend', formElement);
-		formElement.elements[0].focus();
+		try {
+			const formElement = FormElement(createList);
+			const overlayContent = document.querySelector('.o-overlay__content');
+			overlayContent.insertAdjacentElement('beforeend', formElement);
+			formElement.elements[0].focus();
+		} catch(error) {
+			handleError(error);
+		}
 	}
 
 	createListOverlay.open();
@@ -159,14 +198,20 @@ function FormElement (createList) {
 
 	const formElement = stringToHTMLElement(formString);
 
-	formElement.querySelector('button[type="submit"]').addEventListener('click', (e) => {
-		e.preventDefault();
-		e.stopPropagation();
-		const inputListName = formElement.querySelector('input[name="list-name"]');
-		createList(inputListName.value);
-		inputListName.value = '';
-		formElement.remove();
-	});
+	function handleSubmit (event) {
+		try {
+			event.preventDefault();
+			event.stopPropagation();
+			const inputListName = formElement.querySelector('input[name="list-name"]');
+			createList(inputListName.value);
+			inputListName.value = '';
+			formElement.remove();
+		} catch(error) {
+			handleError(error);
+		}
+	}
+
+	formElement.querySelector('button[type="submit"]').addEventListener('click', handleSubmit);
 
 	return formElement;
 }
@@ -231,10 +276,12 @@ function ListCheckboxElement (addToList, removeFromList) {
 
 		const [ input ] = listCheckboxElement.children;
 
-		input.addEventListener('click', function (e) {
-			e.preventDefault();
-			return e.target.checked ? addToList(list) : removeFromList(list);
-		});
+		function handleCheck (event) {
+			event.preventDefault();
+			return event.target.checked ? addToList(list) : removeFromList(list);
+		}
+
+		input.addEventListener('click', handleCheck);
 
 		return listCheckboxElement;
 	};
@@ -242,26 +289,30 @@ function ListCheckboxElement (addToList, removeFromList) {
 
 function realignOverlay (originalScrollPosition) {
 	return function (target, currentScrollPosition) {
-		if(currentScrollPosition && Math.abs(currentScrollPosition - originalScrollPosition) < 120) {
-			return;
-		}
+		try {
+			if(currentScrollPosition && Math.abs(currentScrollPosition - originalScrollPosition) < 120) {
+				return;
+			}
 
-		originalScrollPosition = currentScrollPosition;
+			originalScrollPosition = currentScrollPosition;
 
-		target.style['min-width'] = '340px';
-		target.style['width'] = '100%';
-		target.style['margin-top'] = '-50px';
-		target.style['left'] = 0;
+			target.style['min-width'] = '340px';
+			target.style['width'] = '100%';
+			target.style['margin-top'] = '-50px';
+			target.style['left'] = 0;
 
-		if (isMobile()) {
-			target.style['position'] = 'absolute';
-			target.style['margin-left'] = 0;
-			target.style['margin-top'] = 0;
-			target.style['top'] = calculateLargerScreenHalf(target) === 'ABOVE' ? '-120px' : '50px';
-		} else {
-			target.style['position'] = 'absolute';
-			target.style['margin-left'] = '45px';
-			target.style['top'] = '220px';
+			if (isMobile()) {
+				target.style['position'] = 'absolute';
+				target.style['margin-left'] = 0;
+				target.style['margin-top'] = 0;
+				target.style['top'] = calculateLargerScreenHalf(target) === 'ABOVE' ? '-120px' : '50px';
+			} else {
+				target.style['position'] = 'absolute';
+				target.style['margin-left'] = '45px';
+				target.style['top'] = '220px';
+			}
+		} catch (error) {
+			handleError(error);
 		}
 	};
 }
@@ -335,5 +386,15 @@ function triggerCreateListEvent (contentId) {
 			article_id: contentId
 		},
 		bubbles: true
+	}));
+}
+
+function handleError (error) {
+	document.body.dispatchEvent(new CustomEvent('oErrors.log', {
+		bubbles: true,
+		detail: {
+			error,
+			info: { component: 'professorLists' },
+		}
 	}));
 }

--- a/secrets.js
+++ b/secrets.js
@@ -5,6 +5,7 @@ module.exports = {
 		'11df4800-391a-11ea-973b-4a52933561ab', // components/unread-articles-indicator/README.md:67
 		'190b4443-dc03-bd53-e79b-b4b6fbd04e64', // segment ID for subscribe URL
 		'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx', // regex for uuid generator
-		'a5676e20-5c92-47f3-a76c-11f9761121f5' // test/navigationAlphaTest.spec.js
+		'a5676e20-5c92-47f3-a76c-11f9761121f5', // test/navigationAlphaTest.spec.js
+		'https://d63d3b29fd374c3d95fa814a38c9bac9@o16684.ingest.sentry.io/79480', // Sentry URL myft/ui/save-article-to-list-variant:13
 	]
 };

--- a/secrets.js
+++ b/secrets.js
@@ -5,7 +5,6 @@ module.exports = {
 		'11df4800-391a-11ea-973b-4a52933561ab', // components/unread-articles-indicator/README.md:67
 		'190b4443-dc03-bd53-e79b-b4b6fbd04e64', // segment ID for subscribe URL
 		'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx', // regex for uuid generator
-		'a5676e20-5c92-47f3-a76c-11f9761121f5', // test/navigationAlphaTest.spec.js
-		'https://d63d3b29fd374c3d95fa814a38c9bac9@o16684.ingest.sentry.io/79480', // Sentry URL myft/ui/save-article-to-list-variant:13
+		'a5676e20-5c92-47f3-a76c-11f9761121f5' // test/navigationAlphaTest.spec.js
 	]
 };


### PR DESCRIPTION
## Description

Initialises `o-errors`on the save article variant to report errors to `next-article`'s Sentry project.
Adds `try/catch` structures to the `showSaveArticleToListVariant` function and all its components' event listeners. These structures catch the errors and enrich them with component property with value `professorLis`t. We'll use this property to create a custom alert for errors coming from the variant

## How to test this code

- Check out this branch locally and run: 
  - `npm link`
  - `bower link`
- Check out the branch `feature/UG-815-initialise-o-errors-for-professorlists` on `next-article` and run:
  - `npm link @financial-times/n-myft-ui`
  - `bower link n-myft-ui`
- Build and run `next-article`
  - `make build run`
- Go to FT Toggler and select the variant on the [professorLists flag](https://toggler.ft.com/#professorLists)
- Go to [myFT section](https://www.ft.com/myft/lists) and make sure you don't have any lists created. 
- Force an error on `openSaveArticleToListVariant` or on any of the event listeners. One way to force errors is to add a custom `throw new Error(message)` statement
- Go to [an article](https://local.ft.com:5050/content/aa9caaad-c19f-4451-b13b-e514b9c284a5), open the save article variant and trigger the error
- Inspect the Network tab on your Dev Tools and confirm that there are requests to Sentry endpoints
