### PR TITLE
Avoid running engine check when this component is installed as a library

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "commit": "commit-wizard",
     "prepare": "npx snyk protect || npx snyk protect -d || true",
-    "preinstall": "npm_config_yes=true npx check-engine"
+    "preinstall": "[ \"$INIT_CWD\" != \"$PWD\" ] || npm_config_yes=true npx check-engine"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Description

`n-myft-ui` is running an engine check when being installed as a library. This could break the build of an app if they're on incompatible node versions, as it's currently happening on [next-article](https://app.circleci.com/pipelines/github/Financial-Times/next-article/7863/workflows/21c0fe9e-383f-4606-8e5a-88fecd0f4048/jobs/39261). This change avoids running that check if it's installed as a dependency.

### How to test this code?

- Check out branch `feature/bump-n-myft-ui` on `next-article`.
- Make sure you're running node version `12.22` and run `make install`. It should failed with `node version incorrect`
- Check out this branch on `n-myft-ui`.
- Make sure you're running node version `16` and run `npm link`.
- Run `npm link @financial-times/n-myft-ui` and it should install successfully install the package.