### PR TITLE
fix: CPORM-16 - Npm migration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,6 @@ run:
 	cp -rf $(shell cat _test-server/template-copy-list.txt) bower_components/n-ui
 	node _test-server/app
 
-prevent-npm-dependencies:
-	@node scripts/prevent-npm-deps.js
-
 # copy project files into bower components so that we can reference component partials
 # in the same way that apps that use the components do
 demo-build:
@@ -41,7 +38,6 @@ a11y: demo-build
 	@$(DONE)
 
 test:
-	make prevent-npm-dependencies
 	make verify
 	make test-unit
 	make test-build

--- a/bower.json
+++ b/bower.json
@@ -19,18 +19,6 @@
     "date-fns": "2.16.1",
     "fetchres": "^1.7.2",
     "form-serialize": "^0.7.2",
-    "js-cookie": "^2.2.0",
-    "n-notification": "^7.0.0",
-    "n-ui-foundations": "^6.0.0",
-    "next-myft-client": "^7.8.0",
-    "next-session-client": "^3.0.1",
-    "o-editorial-typography": "^1.0.1",
-    "o-errors": "^4.0.2",
-    "o-forms": "^8.0.0",
-    "o-grid": "^5.0.0",
-    "o-normalise": "^2.0.1",
-    "o-overlay": "^3.0.0",
-    "o-spacing": "^2.0.0",
-    "o-tooltip": "^4.0.0"
+    "js-cookie": "^2.2.0"
   }
 }

--- a/components/button/main.scss
+++ b/components/button/main.scss
@@ -1,4 +1,4 @@
-@import 'o-buttons/main';
+@import '@financial-times/o-buttons/main';
 
 .n-myft-ui__button {
 	@include oButtonsContent($opts: (

--- a/components/instant-alert/index.js
+++ b/components/instant-alert/index.js
@@ -1,4 +1,4 @@
-import * as nNotification from 'n-notification/main';
+import * as nNotification from '@financial-times/notification/main';
 import Delegate from 'ftdomdelegate';
 import myftClient from 'next-myft-client';
 import { $, $$ } from 'n-ui-foundations/main';

--- a/components/pin-button/index.js
+++ b/components/pin-button/index.js
@@ -1,7 +1,7 @@
 import Delegate from 'ftdomdelegate';
 import myftApiClient from 'next-myft-client';
 import serialize from 'form-serialize';
-import Tooltip from 'o-tooltip';
+import Tooltip from '@financial-times/o-tooltip';
 
 const delegate = new Delegate(document.body);
 

--- a/myft/main.scss
+++ b/myft/main.scss
@@ -1,15 +1,15 @@
-@import 'o-normalise/main';
-@import 'o-colors/main';
-@import 'o-grid/main';
-@import 'o-icons/main';
-@import 'o-buttons/main';
-@import 'o-editorial-typography/main';
-@import 'o-forms/main';
-@import 'o-overlay/main';
-@import 'o-spacing/main';
+@import '@financial-times/o-normalise/main';
+@import '@financial-times/o-colors/main';
+@import '@financial-times/o-grid/main';
+@import '@financial-times/o-icons/main';
+@import '@financial-times/o-buttons/main';
+@import '@financial-times/o-editorial-typography/main';
+@import '@financial-times/o-forms/main';
+@import '@financial-times/o-overlay/main';
+@import '@financial-times/o-spacing/main';
 
 $n-notification-is-silent: false !default;
-@import 'n-notification/main';
+@import '@financial-times/n-notification/main';
 
 @import './ui/myft-buttons/main';
 @import './ui/lists';

--- a/myft/ui/lists.js
+++ b/myft/ui/lists.js
@@ -1,11 +1,11 @@
 import myFtClient from 'next-myft-client';
 import Delegate from 'ftdomdelegate';
-import Overlay from 'o-overlay';
+import Overlay from '@financial-times/o-overlay';
 import * as myFtUiButtonStates from './lib/button-states';
-import nNotification from 'n-notification';
+import nNotification from '@financial-times/n-notification';
 import { uuid } from 'n-ui-foundations';
 import getToken from './lib/get-csrf-token';
-import oForms from 'o-forms';
+import oForms from '@financial-times/o-forms';
 import openSaveArticleToListVariant from './save-article-to-list-variant';
 
 const delegate = new Delegate(document.body);

--- a/myft/ui/myft-buttons/init.js
+++ b/myft/ui/myft-buttons/init.js
@@ -3,7 +3,7 @@ import * as tracking from '../lib/tracking';
 import * as loadedRelationships from '../lib/loaded-relationships';
 import relationshipConfig from '../lib/relationship-config';
 import setTokens from '../lib/set-tokens';
-import nNotification from 'n-notification';
+import nNotification from '@financial-times/n-notification';
 import Delegate from 'ftdomdelegate';
 import personaliseLinks from '../personalise-links';
 import doFormSubmit from './do-form-submit';

--- a/myft/ui/save-article-to-list-variant.js
+++ b/myft/ui/save-article-to-list-variant.js
@@ -1,4 +1,4 @@
-import Overlay from 'o-overlay';
+import Overlay from '@financial-times/o-overlay';
 import myFtClient from 'next-myft-client';
 import { uuid } from 'n-ui-foundations';
 import getToken from './lib/get-csrf-token';

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,11 @@
       "version": "0.0.0",
       "hasInstallScript": true,
       "license": "ISC",
+      "dependencies": {
+        "ftdomdelegate": "^4.0.6",
+        "next-myft-client": "^9.0.0",
+        "next-session-client": "^4.0.0"
+      },
       "devDependencies": {
         "@financial-times/dotcom-build-base": "^7.0.0",
         "@financial-times/dotcom-build-bower-resolve": "^2.6.2",
@@ -81,6 +86,21 @@
       "engines": {
         "node": "14.x || 16.x",
         "npm": "7.x || 8.x"
+      },
+      "peerDependencies": {
+        "@financial-times/n-notification": "^8.2.2",
+        "@financial-times/o-buttons": "^7.5.0",
+        "@financial-times/o-colors": "^6.4.2",
+        "@financial-times/o-editorial-typography": "^2.3.2",
+        "@financial-times/o-errors": "^5.2.2",
+        "@financial-times/o-forms": "^9.4.0",
+        "@financial-times/o-grid": "^6.1.5",
+        "@financial-times/o-icons": "^7.3.0",
+        "@financial-times/o-normalise": "^3.2.2",
+        "@financial-times/o-overlay": "^4.2.4",
+        "@financial-times/o-spacing": "^3.2.1",
+        "@financial-times/o-tooltip": "^5.2.2",
+        "n-ui-foundations": "^9.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2870,6 +2890,24 @@
         "eslint-plugin-no-only-tests": ">=2.0.0"
       }
     },
+    "node_modules/@financial-times/fticons": {
+      "version": "1.23.1",
+      "resolved": "https://registry.npmjs.org/@financial-times/fticons/-/fticons-1.23.1.tgz",
+      "integrity": "sha512-pBcOFpblNAUVl38Vez+WHpYlRC/gYkk30ANFiDWN7tUjKFsa2AbEMSJ2JBZsGEMvupPMBWKA/zsVqb29FmGnxA==",
+      "peer": true
+    },
+    "node_modules/@financial-times/math": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/math/-/math-1.1.0.tgz",
+      "integrity": "sha512-de62A+grddYjBzOf5NogvRou2othrHThVxPKf4hWjEvTTMTisPDvVfc7jiVm3OvH7FyGImwrpPJN/u30NzeLmQ==",
+      "peer": true,
+      "engines": {
+        "npm": "^7 || ^8"
+      },
+      "peerDependencies": {
+        "mathsass": "0.10.1"
+      }
+    },
     "node_modules/@financial-times/n-express": {
       "version": "23.0.2",
       "resolved": "https://registry.npmjs.org/@financial-times/n-express/-/n-express-23.0.2.tgz",
@@ -3161,6 +3199,19 @@
         "node": "12.x"
       }
     },
+    "node_modules/@financial-times/n-notification": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-notification/-/n-notification-8.2.2.tgz",
+      "integrity": "sha512-PJrWD/YW/Hf7xqnoqALMMr/RDTy9fX0CG3k3ZHHyf/ihkrXMmjqZGvjw3tZqIJQhrqaTQ7A3By0heKSRTga8JQ==",
+      "peer": true,
+      "engines": {
+        "npm": "^7 || ^8"
+      },
+      "peerDependencies": {
+        "@financial-times/o-colors": "^6.1.1",
+        "@financial-times/o-typography": "^7.0.3"
+      }
+    },
     "node_modules/@financial-times/n-pa11y-config": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@financial-times/n-pa11y-config/-/n-pa11y-config-1.0.0.tgz",
@@ -3199,6 +3250,278 @@
       "engines": {
         "node": "12.x",
         "npm": "7.x || 8.x"
+      }
+    },
+    "node_modules/@financial-times/o-brand": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-brand/-/o-brand-4.2.1.tgz",
+      "integrity": "sha512-tdDa8JFnHIEYrn4h3mG5j7FI7qZx4S7ywFjzNGTDOxEm6jp0xEpc8laAzSI8QfIhjedGmM26/AkSG3LBJ7/8XQ==",
+      "peer": true,
+      "engines": {
+        "npm": "^7 || ^8"
+      }
+    },
+    "node_modules/@financial-times/o-buttons": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-buttons/-/o-buttons-7.5.0.tgz",
+      "integrity": "sha512-5LcYNytGKrZat5mDgV5W3bhmazI87m3oq5IB630xRQoJUBLPeu5MvWTzH0sTm8t19F+tcgEMSD1G5iRqsS4nzw==",
+      "peer": true,
+      "engines": {
+        "npm": "^7 || ^8"
+      },
+      "peerDependencies": {
+        "@financial-times/o-brand": "^4.1.0",
+        "@financial-times/o-colors": "^6.0.1",
+        "@financial-times/o-icons": "^7.0.0",
+        "@financial-times/o-normalise": "^3.2.0",
+        "@financial-times/o-typography": "^7.0.1"
+      }
+    },
+    "node_modules/@financial-times/o-colors": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-colors/-/o-colors-6.4.2.tgz",
+      "integrity": "sha512-M9I652qnTL6nDARt/3S2cbmJsiM34ag+1kfHtt37xMf2ZsXA/M7c0s+fYO2UWJ308+eWSa1aA8P5Dl13jndmzQ==",
+      "peer": true,
+      "engines": {
+        "npm": "^7 || ^8"
+      },
+      "peerDependencies": {
+        "@financial-times/math": "^1.0.0",
+        "@financial-times/o-brand": "^4.0.1"
+      }
+    },
+    "node_modules/@financial-times/o-editorial-typography": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-editorial-typography/-/o-editorial-typography-2.3.2.tgz",
+      "integrity": "sha512-KrOGq7rbSTEFVKaEEdy6jSaZInb4JyzhjaN4xfDPws1f+AYoiHcZA+146uR5qnlZW85SD3scPueQZ1vfBTU+cw==",
+      "peer": true,
+      "engines": {
+        "npm": "^7 || ^8"
+      },
+      "peerDependencies": {
+        "@financial-times/o-colors": "^6.0.1",
+        "@financial-times/o-fonts": "^5.0.0",
+        "@financial-times/o-spacing": "^3.0.0",
+        "@financial-times/o-typography": "^7.0.1"
+      }
+    },
+    "node_modules/@financial-times/o-errors": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-errors/-/o-errors-5.2.2.tgz",
+      "integrity": "sha512-27GaGSp6Wb3O66n1zPj4wIL1p8akutIMPttkZ2cq0K0SZcQ2rgb7MtfQ/E6YvMDCUapcCeAwAZ+HMkHEYef4+A==",
+      "peer": true,
+      "dependencies": {
+        "raven-js": "^3.27.2"
+      },
+      "engines": {
+        "npm": "^7 || ^8"
+      }
+    },
+    "node_modules/@financial-times/o-fonts": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-fonts/-/o-fonts-5.3.3.tgz",
+      "integrity": "sha512-Sxw09RmtFlWrDs8pZcSf+aSnTaW5bL+bhkrXWYsUwlssf5TkI37PHAGeCzSNDcqJ2QSQrHcA4HsaAP2BI6kULw==",
+      "peer": true,
+      "engines": {
+        "npm": "^7 || ^8"
+      },
+      "peerDependencies": {
+        "@financial-times/o-brand": "^4.1.0"
+      }
+    },
+    "node_modules/@financial-times/o-forms": {
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-forms/-/o-forms-9.4.0.tgz",
+      "integrity": "sha512-35aUkEhC4La3wABkqB4QNZwctR+UrFyU0SoSFZH3EA9pCxp20x9CYpYdr8E2106ArK0Uab+jJc8snAw5ukew+A==",
+      "peer": true,
+      "engines": {
+        "npm": "^7 || ^8"
+      },
+      "peerDependencies": {
+        "@financial-times/math": "^1.0.0",
+        "@financial-times/o-brand": "^4.1.0",
+        "@financial-times/o-buttons": "^7.2.0",
+        "@financial-times/o-colors": "^6.0.1",
+        "@financial-times/o-grid": "^6.0.0",
+        "@financial-times/o-icons": "^7.0.0",
+        "@financial-times/o-loading": "^5.0.0",
+        "@financial-times/o-normalise": "^3.2.0",
+        "@financial-times/o-spacing": "^3.0.0",
+        "@financial-times/o-typography": "^7.0.1"
+      }
+    },
+    "node_modules/@financial-times/o-grid": {
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-grid/-/o-grid-6.1.5.tgz",
+      "integrity": "sha512-wjotgIlrkx0YvR96MD6FwB0tKuX4NyDiiz8FXlBGhsB/Csn1qDecsDQuhQ8XesBdbJI1LG1zrnOGrP/WQncCqg==",
+      "peer": true,
+      "engines": {
+        "npm": "^7 || ^8"
+      },
+      "peerDependencies": {
+        "@financial-times/math": "^1.0.0",
+        "@financial-times/sass-mq": "^5.0.2"
+      }
+    },
+    "node_modules/@financial-times/o-icons": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-icons/-/o-icons-7.3.0.tgz",
+      "integrity": "sha512-JXrv87DW4gQtXw880wFSfnFpeOoBlB7AddSQPN1jUIU03058CEKCGST9ZSdbvgDq1bHrcGH9geSrifczhAf8kw==",
+      "peer": true,
+      "engines": {
+        "npm": "^7 || ^8"
+      },
+      "peerDependencies": {
+        "@financial-times/fticons": "^1.23.1"
+      }
+    },
+    "node_modules/@financial-times/o-loading": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-loading/-/o-loading-5.2.1.tgz",
+      "integrity": "sha512-63wLZuONKI1tygnq3xUxm1zYsLllBFhyQ+0jK2fnPuUTwzgquHZaO9ncdnsjqs1s2WF3rToZK8dpGlPRsjWgBw==",
+      "peer": true,
+      "engines": {
+        "npm": "^7 || ^8"
+      },
+      "peerDependencies": {
+        "@financial-times/o-brand": "^4.1.0",
+        "@financial-times/o-colors": "^6.0.1",
+        "@financial-times/sass-mq": "^5.0.2"
+      }
+    },
+    "node_modules/@financial-times/o-normalise": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-normalise/-/o-normalise-3.2.2.tgz",
+      "integrity": "sha512-w7eYm2EB4Wf4cY5IJ/B55xst32mFQIW41f+HZpfykJEvI0ohBM2ghfaLu+JpJdaAv8kRaV8245FdDcngDst3wA==",
+      "peer": true,
+      "engines": {
+        "npm": "^7 || ^8"
+      },
+      "peerDependencies": {
+        "@financial-times/o-colors": "^6.0.1",
+        "@financial-times/sass-mq": "^5.0.2"
+      }
+    },
+    "node_modules/@financial-times/o-overlay": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-overlay/-/o-overlay-4.2.4.tgz",
+      "integrity": "sha512-4n4Bp7UqJYjmZTW5gzPnxvyU1pIB5+eK2FUimtxCgcDAt19b6u6zuFaZp3kumLyGNj5Q+qT0GIotLTAaKEVciA==",
+      "peer": true,
+      "dependencies": {
+        "focusable": "^2.3.0",
+        "ftdomdelegate": "^4.0.0"
+      },
+      "engines": {
+        "npm": "^7 || ^8"
+      },
+      "peerDependencies": {
+        "@financial-times/o-brand": "^4.1.0",
+        "@financial-times/o-colors": "^6.0.1",
+        "@financial-times/o-icons": "^7.0.0",
+        "@financial-times/o-normalise": "^3.2.0",
+        "@financial-times/o-spacing": "^3.0.0",
+        "@financial-times/o-typography": "^7.0.1",
+        "@financial-times/o-viewport": "^5.0.0",
+        "@financial-times/o-visual-effects": "^4.0.1"
+      }
+    },
+    "node_modules/@financial-times/o-spacing": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-spacing/-/o-spacing-3.2.1.tgz",
+      "integrity": "sha512-Vyb5zTl5UH+ReR64DAqF+CGv5UF0sWFjkbNbwrPaCK69cOiGopjEhh413A0zmTMZxPv3NcZzZMQQ4XidbRokCQ==",
+      "peer": true,
+      "engines": {
+        "npm": "^7 || ^8"
+      },
+      "peerDependencies": {
+        "@financial-times/math": "^1.0.0"
+      }
+    },
+    "node_modules/@financial-times/o-tooltip": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-tooltip/-/o-tooltip-5.2.2.tgz",
+      "integrity": "sha512-JUklwHvNmEFXfqjc6Ft7jV5Rc3cTfqBbcnexMCOvWTr8BE3Xidbg6/VumLKhmS+MTmG4NFl5EgP4Kt2hLrAa1Q==",
+      "peer": true,
+      "dependencies": {
+        "ftdomdelegate": "^4.0.6"
+      },
+      "engines": {
+        "npm": "^7 || ^8"
+      },
+      "peerDependencies": {
+        "@financial-times/o-grid": "^6.0.0",
+        "@financial-times/o-icons": "^7.0.1",
+        "@financial-times/o-normalise": "^3.0.0",
+        "@financial-times/o-overlay": "^4.0.0",
+        "@financial-times/o-typography": "^7.0.1",
+        "@financial-times/o-viewport": "^5.0.0",
+        "@financial-times/o-visual-effects": "^4.0.1"
+      }
+    },
+    "node_modules/@financial-times/o-typography": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-typography/-/o-typography-7.3.2.tgz",
+      "integrity": "sha512-KqjHDiG0G8gk9tyFKxCEM2l0d0sxk6+o0U19OStHYKBDF0OHyhWZy0ELrgvEaFv+2ZduTCdp4CCt4clHFu2JTA==",
+      "peer": true,
+      "dependencies": {
+        "fontfaceobserver": "^2.0.9"
+      },
+      "engines": {
+        "npm": "^7 || ^8"
+      },
+      "peerDependencies": {
+        "@financial-times/math": "^1.0.0",
+        "@financial-times/o-colors": "^6.0.1",
+        "@financial-times/o-fonts": "^5.0.0",
+        "@financial-times/o-grid": "^6.1.1",
+        "@financial-times/o-icons": "^7.0.0",
+        "@financial-times/o-normalise": "^3.2.0",
+        "@financial-times/o-spacing": "^3.0.0"
+      }
+    },
+    "node_modules/@financial-times/o-utils": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-utils/-/o-utils-2.1.1.tgz",
+      "integrity": "sha512-kZQfGjVI0A8axO3aPs8AIGStxG+jGX0FKZgjBTQAx+4Dud6vloVGJpSix+/Q7ym5rewjhDLsFVECM18Lvswbhw==",
+      "peer": true,
+      "engines": {
+        "npm": "^7 || ^8"
+      }
+    },
+    "node_modules/@financial-times/o-viewport": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-viewport/-/o-viewport-5.1.1.tgz",
+      "integrity": "sha512-9v4R2a291ZFhyFalEx3MOMUTHaJ3TDKWJNfgiPtXHtjTR33xsrrnb+DH74jYOzn9L2ixxakOdUTHHPfpJMWwOA==",
+      "peer": true,
+      "engines": {
+        "npm": "^7 || ^8"
+      },
+      "peerDependencies": {
+        "@financial-times/o-utils": "^2.0.0"
+      }
+    },
+    "node_modules/@financial-times/o-visual-effects": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-visual-effects/-/o-visual-effects-4.2.0.tgz",
+      "integrity": "sha512-lP4weMLDcdu+GkC6RL8vWL3GjtOAZGTKYJkQhRMv3jrnko/Wtw8Ghn/gjR9VSZoAO1FWzuU2063C5T8iKk429g==",
+      "peer": true,
+      "engines": {
+        "npm": "^7 || ^8"
+      },
+      "peerDependencies": {
+        "@financial-times/o-colors": "^6.0.1"
+      }
+    },
+    "node_modules/@financial-times/sass-mq": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@financial-times/sass-mq/-/sass-mq-5.2.3.tgz",
+      "integrity": "sha512-A8+i+9y7Bcmaac72Ggf99D3QnkUxPRceKRGGxMy7GBOdtvCWgU7iN+99u95j/AVPhwX3M0NGqeEObxw1WusaHw==",
+      "peer": true,
+      "engines": {
+        "npm": "^7 || ^8"
+      },
+      "peerDependencies": {
+        "@financial-times/math": "^1.0.0"
       }
     },
     "node_modules/@financial-times/secret-squirrel": {
@@ -5528,6 +5851,11 @@
       "dependencies": {
         "file-uri-to-path": "1.0.0"
       }
+    },
+    "node_modules/black-hole-stream": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/black-hole-stream/-/black-hole-stream-0.0.1.tgz",
+      "integrity": "sha1-M7ega58edFPWBBuCl0SB0hUq6kI="
     },
     "node_modules/blob": {
       "version": "0.0.5",
@@ -9813,8 +10141,7 @@
     "node_modules/fetchres": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/fetchres/-/fetchres-1.7.2.tgz",
-      "integrity": "sha1-DWSA/TR02hrDq76NxWdWSqOEMog=",
-      "dev": true
+      "integrity": "sha1-DWSA/TR02hrDq76NxWdWSqOEMog="
     },
     "node_modules/figgy-pudding": {
       "version": "3.5.2",
@@ -10029,6 +10356,12 @@
         "readable-stream": "^2.3.6"
       }
     },
+    "node_modules/focusable": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/focusable/-/focusable-2.3.0.tgz",
+      "integrity": "sha512-e63a4CAb5yLbn4Scn0wG9F+rEq4ZcbggRc9pD3hufAWf8y8dpZImdIES8YNUufRpKB+p0JS+BRd8RBU+sLAeIw==",
+      "peer": true
+    },
     "node_modules/follow-redirects": {
       "version": "1.14.9",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
@@ -10048,6 +10381,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/fontfaceobserver": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fontfaceobserver/-/fontfaceobserver-2.1.0.tgz",
+      "integrity": "sha512-ReOsO2F66jUa0jmv2nlM/s1MiutJx/srhAe2+TE8dJCMi02ZZOcCTxTCQFr3Yet+uODUtnr4Mewg+tNQ+4V1Ng==",
+      "peer": true
     },
     "node_modules/for-in": {
       "version": "1.0.2",
@@ -10215,6 +10554,11 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/ftdomdelegate": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/ftdomdelegate/-/ftdomdelegate-4.0.6.tgz",
+      "integrity": "sha512-M1d0WNPkXngQlNuD5eWaxNsbigRkJE6qlgRyPSWXfpyq+H7DMF7EB1GC2VYZZtKH3ZIZf97Db8N3Qn7xU1MzPw=="
     },
     "node_modules/function-bind": {
       "version": "1.1.1",
@@ -13466,6 +13810,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/mathsass": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/mathsass/-/mathsass-0.10.1.tgz",
+      "integrity": "sha1-h2j+ICEL1drqttZFxCx+aaTGAAg=",
+      "peer": true,
+      "engines": {
+        "node": ">=0.8.0",
+        "npm": ">=1.2.10"
+      }
+    },
     "node_modules/md5": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
@@ -14481,6 +14835,29 @@
         "uuid": "bin/uuid"
       }
     },
+    "node_modules/n-ui-foundations": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/n-ui-foundations/-/n-ui-foundations-9.0.0.tgz",
+      "integrity": "sha512-fvzG/A+4GNrKX9JaTUt5LzrnrEvqXF+8DVDGcqZI9uMUY1H7AuWHuYXS+f4ZFXttEcnueg3PA8drQXSyVmt0iw==",
+      "hasInstallScript": true,
+      "peer": true,
+      "engines": {
+        "node": "12.x",
+        "npm": "7.x || 8.x"
+      },
+      "peerDependencies": {
+        "@financial-times/o-buttons": "^7.2.0",
+        "@financial-times/o-colors": "^6.4.0",
+        "@financial-times/o-fonts": "^5.2.0",
+        "@financial-times/o-grid": "^6.1.1",
+        "@financial-times/o-icons": "^7.2.0",
+        "@financial-times/o-normalise": "^3.2.0",
+        "@financial-times/o-typography": "^7.2.0",
+        "@financial-times/o-utils": "^2.1.0",
+        "@financial-times/o-viewport": "^5.1.0",
+        "@financial-times/o-visual-effects": "^4.1.0"
+      }
+    },
     "node_modules/nan": {
       "version": "2.15.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
@@ -14621,6 +14998,31 @@
       "dependencies": {
         "encoding": "^0.1.11",
         "is-stream": "^1.0.1"
+      }
+    },
+    "node_modules/next-myft-client": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/next-myft-client/-/next-myft-client-9.0.0.tgz",
+      "integrity": "sha512-TxLrNdPY0q60S5P4pGrqqQvG8gukr7QNAMaDUg7mraGY39GeHyyoHl4WW+hdOJf4N2rVY4ydqCRs6SEbf36tQg==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "black-hole-stream": "0.0.1",
+        "fetchres": "1.7.2",
+        "next-session-client": "^4.0.0"
+      },
+      "engines": {
+        "node": "14.x || 16.x",
+        "npm": "7.x || 8.x"
+      }
+    },
+    "node_modules/next-session-client": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/next-session-client/-/next-session-client-4.0.0.tgz",
+      "integrity": "sha512-S7mcZoOu6WjUIhyt6MtHGP9f2r9urSfqa40EJpmd68fOdG20qWo2QCCd3NpqHykPNyJtV2KSmqsi7ynMTcr4hg==",
+      "hasInstallScript": true,
+      "engines": {
+        "node": "14.x || 16.x",
+        "npm": "7.x || 8.x"
       }
     },
     "node_modules/nice-try": {
@@ -18696,6 +19098,12 @@
       "engines": {
         "node": ">= 4.0.0"
       }
+    },
+    "node_modules/raven-js": {
+      "version": "3.27.2",
+      "resolved": "https://registry.npmjs.org/raven-js/-/raven-js-3.27.2.tgz",
+      "integrity": "sha512-mFWQcXnhRFEQe5HeFroPaEghlnqy7F5E2J3Fsab189ondqUzcjwSVi7el7F36cr6PvQYXoZ1P2F5CSF2/azeMQ==",
+      "peer": true
     },
     "node_modules/raven/node_modules/cookie": {
       "version": "0.3.1",
@@ -26621,6 +27029,19 @@
         "eslint-plugin-no-only-tests": ">=2.0.0"
       }
     },
+    "@financial-times/fticons": {
+      "version": "1.23.1",
+      "resolved": "https://registry.npmjs.org/@financial-times/fticons/-/fticons-1.23.1.tgz",
+      "integrity": "sha512-pBcOFpblNAUVl38Vez+WHpYlRC/gYkk30ANFiDWN7tUjKFsa2AbEMSJ2JBZsGEMvupPMBWKA/zsVqb29FmGnxA==",
+      "peer": true
+    },
+    "@financial-times/math": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/math/-/math-1.1.0.tgz",
+      "integrity": "sha512-de62A+grddYjBzOf5NogvRou2othrHThVxPKf4hWjEvTTMTisPDvVfc7jiVm3OvH7FyGImwrpPJN/u30NzeLmQ==",
+      "peer": true,
+      "requires": {}
+    },
     "@financial-times/n-express": {
       "version": "23.0.2",
       "resolved": "https://registry.npmjs.org/@financial-times/n-express/-/n-express-23.0.2.tgz",
@@ -26855,6 +27276,13 @@
         "winston": "^2.4.0"
       }
     },
+    "@financial-times/n-notification": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-notification/-/n-notification-8.2.2.tgz",
+      "integrity": "sha512-PJrWD/YW/Hf7xqnoqALMMr/RDTy9fX0CG3k3ZHHyf/ihkrXMmjqZGvjw3tZqIJQhrqaTQ7A3By0heKSRTga8JQ==",
+      "peer": true,
+      "requires": {}
+    },
     "@financial-times/n-pa11y-config": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@financial-times/n-pa11y-config/-/n-pa11y-config-1.0.0.tgz",
@@ -26882,6 +27310,146 @@
         "@financial-times/n-logger": "^8.0.0",
         "raven": "^2.3.0"
       }
+    },
+    "@financial-times/o-brand": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-brand/-/o-brand-4.2.1.tgz",
+      "integrity": "sha512-tdDa8JFnHIEYrn4h3mG5j7FI7qZx4S7ywFjzNGTDOxEm6jp0xEpc8laAzSI8QfIhjedGmM26/AkSG3LBJ7/8XQ==",
+      "peer": true
+    },
+    "@financial-times/o-buttons": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-buttons/-/o-buttons-7.5.0.tgz",
+      "integrity": "sha512-5LcYNytGKrZat5mDgV5W3bhmazI87m3oq5IB630xRQoJUBLPeu5MvWTzH0sTm8t19F+tcgEMSD1G5iRqsS4nzw==",
+      "peer": true,
+      "requires": {}
+    },
+    "@financial-times/o-colors": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-colors/-/o-colors-6.4.2.tgz",
+      "integrity": "sha512-M9I652qnTL6nDARt/3S2cbmJsiM34ag+1kfHtt37xMf2ZsXA/M7c0s+fYO2UWJ308+eWSa1aA8P5Dl13jndmzQ==",
+      "peer": true,
+      "requires": {}
+    },
+    "@financial-times/o-editorial-typography": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-editorial-typography/-/o-editorial-typography-2.3.2.tgz",
+      "integrity": "sha512-KrOGq7rbSTEFVKaEEdy6jSaZInb4JyzhjaN4xfDPws1f+AYoiHcZA+146uR5qnlZW85SD3scPueQZ1vfBTU+cw==",
+      "peer": true,
+      "requires": {}
+    },
+    "@financial-times/o-errors": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-errors/-/o-errors-5.2.2.tgz",
+      "integrity": "sha512-27GaGSp6Wb3O66n1zPj4wIL1p8akutIMPttkZ2cq0K0SZcQ2rgb7MtfQ/E6YvMDCUapcCeAwAZ+HMkHEYef4+A==",
+      "peer": true,
+      "requires": {
+        "raven-js": "^3.27.2"
+      }
+    },
+    "@financial-times/o-fonts": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-fonts/-/o-fonts-5.3.3.tgz",
+      "integrity": "sha512-Sxw09RmtFlWrDs8pZcSf+aSnTaW5bL+bhkrXWYsUwlssf5TkI37PHAGeCzSNDcqJ2QSQrHcA4HsaAP2BI6kULw==",
+      "peer": true,
+      "requires": {}
+    },
+    "@financial-times/o-forms": {
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-forms/-/o-forms-9.4.0.tgz",
+      "integrity": "sha512-35aUkEhC4La3wABkqB4QNZwctR+UrFyU0SoSFZH3EA9pCxp20x9CYpYdr8E2106ArK0Uab+jJc8snAw5ukew+A==",
+      "peer": true,
+      "requires": {}
+    },
+    "@financial-times/o-grid": {
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-grid/-/o-grid-6.1.5.tgz",
+      "integrity": "sha512-wjotgIlrkx0YvR96MD6FwB0tKuX4NyDiiz8FXlBGhsB/Csn1qDecsDQuhQ8XesBdbJI1LG1zrnOGrP/WQncCqg==",
+      "peer": true,
+      "requires": {}
+    },
+    "@financial-times/o-icons": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-icons/-/o-icons-7.3.0.tgz",
+      "integrity": "sha512-JXrv87DW4gQtXw880wFSfnFpeOoBlB7AddSQPN1jUIU03058CEKCGST9ZSdbvgDq1bHrcGH9geSrifczhAf8kw==",
+      "peer": true,
+      "requires": {}
+    },
+    "@financial-times/o-loading": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-loading/-/o-loading-5.2.1.tgz",
+      "integrity": "sha512-63wLZuONKI1tygnq3xUxm1zYsLllBFhyQ+0jK2fnPuUTwzgquHZaO9ncdnsjqs1s2WF3rToZK8dpGlPRsjWgBw==",
+      "peer": true,
+      "requires": {}
+    },
+    "@financial-times/o-normalise": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-normalise/-/o-normalise-3.2.2.tgz",
+      "integrity": "sha512-w7eYm2EB4Wf4cY5IJ/B55xst32mFQIW41f+HZpfykJEvI0ohBM2ghfaLu+JpJdaAv8kRaV8245FdDcngDst3wA==",
+      "peer": true,
+      "requires": {}
+    },
+    "@financial-times/o-overlay": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-overlay/-/o-overlay-4.2.4.tgz",
+      "integrity": "sha512-4n4Bp7UqJYjmZTW5gzPnxvyU1pIB5+eK2FUimtxCgcDAt19b6u6zuFaZp3kumLyGNj5Q+qT0GIotLTAaKEVciA==",
+      "peer": true,
+      "requires": {
+        "focusable": "^2.3.0",
+        "ftdomdelegate": "^4.0.0"
+      }
+    },
+    "@financial-times/o-spacing": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-spacing/-/o-spacing-3.2.1.tgz",
+      "integrity": "sha512-Vyb5zTl5UH+ReR64DAqF+CGv5UF0sWFjkbNbwrPaCK69cOiGopjEhh413A0zmTMZxPv3NcZzZMQQ4XidbRokCQ==",
+      "peer": true,
+      "requires": {}
+    },
+    "@financial-times/o-tooltip": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-tooltip/-/o-tooltip-5.2.2.tgz",
+      "integrity": "sha512-JUklwHvNmEFXfqjc6Ft7jV5Rc3cTfqBbcnexMCOvWTr8BE3Xidbg6/VumLKhmS+MTmG4NFl5EgP4Kt2hLrAa1Q==",
+      "peer": true,
+      "requires": {
+        "ftdomdelegate": "^4.0.6"
+      }
+    },
+    "@financial-times/o-typography": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-typography/-/o-typography-7.3.2.tgz",
+      "integrity": "sha512-KqjHDiG0G8gk9tyFKxCEM2l0d0sxk6+o0U19OStHYKBDF0OHyhWZy0ELrgvEaFv+2ZduTCdp4CCt4clHFu2JTA==",
+      "peer": true,
+      "requires": {
+        "fontfaceobserver": "^2.0.9"
+      }
+    },
+    "@financial-times/o-utils": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-utils/-/o-utils-2.1.1.tgz",
+      "integrity": "sha512-kZQfGjVI0A8axO3aPs8AIGStxG+jGX0FKZgjBTQAx+4Dud6vloVGJpSix+/Q7ym5rewjhDLsFVECM18Lvswbhw==",
+      "peer": true
+    },
+    "@financial-times/o-viewport": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-viewport/-/o-viewport-5.1.1.tgz",
+      "integrity": "sha512-9v4R2a291ZFhyFalEx3MOMUTHaJ3TDKWJNfgiPtXHtjTR33xsrrnb+DH74jYOzn9L2ixxakOdUTHHPfpJMWwOA==",
+      "peer": true,
+      "requires": {}
+    },
+    "@financial-times/o-visual-effects": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-visual-effects/-/o-visual-effects-4.2.0.tgz",
+      "integrity": "sha512-lP4weMLDcdu+GkC6RL8vWL3GjtOAZGTKYJkQhRMv3jrnko/Wtw8Ghn/gjR9VSZoAO1FWzuU2063C5T8iKk429g==",
+      "peer": true,
+      "requires": {}
+    },
+    "@financial-times/sass-mq": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@financial-times/sass-mq/-/sass-mq-5.2.3.tgz",
+      "integrity": "sha512-A8+i+9y7Bcmaac72Ggf99D3QnkUxPRceKRGGxMy7GBOdtvCWgU7iN+99u95j/AVPhwX3M0NGqeEObxw1WusaHw==",
+      "peer": true,
+      "requires": {}
     },
     "@financial-times/secret-squirrel": {
       "version": "2.19.0",
@@ -28937,6 +29505,11 @@
       "requires": {
         "file-uri-to-path": "1.0.0"
       }
+    },
+    "black-hole-stream": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/black-hole-stream/-/black-hole-stream-0.0.1.tgz",
+      "integrity": "sha1-M7ega58edFPWBBuCl0SB0hUq6kI="
     },
     "blob": {
       "version": "0.0.5",
@@ -32503,8 +33076,7 @@
     "fetchres": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/fetchres/-/fetchres-1.7.2.tgz",
-      "integrity": "sha1-DWSA/TR02hrDq76NxWdWSqOEMog=",
-      "dev": true
+      "integrity": "sha1-DWSA/TR02hrDq76NxWdWSqOEMog="
     },
     "figgy-pudding": {
       "version": "3.5.2",
@@ -32676,11 +33248,23 @@
         "readable-stream": "^2.3.6"
       }
     },
+    "focusable": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/focusable/-/focusable-2.3.0.tgz",
+      "integrity": "sha512-e63a4CAb5yLbn4Scn0wG9F+rEq4ZcbggRc9pD3hufAWf8y8dpZImdIES8YNUufRpKB+p0JS+BRd8RBU+sLAeIw==",
+      "peer": true
+    },
     "follow-redirects": {
       "version": "1.14.9",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
       "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==",
       "dev": true
+    },
+    "fontfaceobserver": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fontfaceobserver/-/fontfaceobserver-2.1.0.tgz",
+      "integrity": "sha512-ReOsO2F66jUa0jmv2nlM/s1MiutJx/srhAe2+TE8dJCMi02ZZOcCTxTCQFr3Yet+uODUtnr4Mewg+tNQ+4V1Ng==",
+      "peer": true
     },
     "for-in": {
       "version": "1.0.2",
@@ -32815,6 +33399,11 @@
         "mkdirp": ">=0.5 0",
         "rimraf": "2"
       }
+    },
+    "ftdomdelegate": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/ftdomdelegate/-/ftdomdelegate-4.0.6.tgz",
+      "integrity": "sha512-M1d0WNPkXngQlNuD5eWaxNsbigRkJE6qlgRyPSWXfpyq+H7DMF7EB1GC2VYZZtKH3ZIZf97Db8N3Qn7xU1MzPw=="
     },
     "function-bind": {
       "version": "1.1.1",
@@ -35325,6 +35914,12 @@
       "integrity": "sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==",
       "dev": true
     },
+    "mathsass": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/mathsass/-/mathsass-0.10.1.tgz",
+      "integrity": "sha1-h2j+ICEL1drqttZFxCx+aaTGAAg=",
+      "peer": true
+    },
     "md5": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
@@ -36154,6 +36749,13 @@
         }
       }
     },
+    "n-ui-foundations": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/n-ui-foundations/-/n-ui-foundations-9.0.0.tgz",
+      "integrity": "sha512-fvzG/A+4GNrKX9JaTUt5LzrnrEvqXF+8DVDGcqZI9uMUY1H7AuWHuYXS+f4ZFXttEcnueg3PA8drQXSyVmt0iw==",
+      "peer": true,
+      "requires": {}
+    },
     "nan": {
       "version": "2.15.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
@@ -36273,6 +36875,21 @@
           }
         }
       }
+    },
+    "next-myft-client": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/next-myft-client/-/next-myft-client-9.0.0.tgz",
+      "integrity": "sha512-TxLrNdPY0q60S5P4pGrqqQvG8gukr7QNAMaDUg7mraGY39GeHyyoHl4WW+hdOJf4N2rVY4ydqCRs6SEbf36tQg==",
+      "requires": {
+        "black-hole-stream": "0.0.1",
+        "fetchres": "1.7.2",
+        "next-session-client": "^4.0.0"
+      }
+    },
+    "next-session-client": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/next-session-client/-/next-session-client-4.0.0.tgz",
+      "integrity": "sha512-S7mcZoOu6WjUIhyt6MtHGP9f2r9urSfqa40EJpmd68fOdG20qWo2QCCd3NpqHykPNyJtV2KSmqsi7ynMTcr4hg=="
     },
     "nice-try": {
       "version": "1.0.5",
@@ -39564,6 +40181,12 @@
           "dev": true
         }
       }
+    },
+    "raven-js": {
+      "version": "3.27.2",
+      "resolved": "https://registry.npmjs.org/raven-js/-/raven-js-3.27.2.tgz",
+      "integrity": "sha512-mFWQcXnhRFEQe5HeFroPaEghlnqy7F5E2J3Fsab189ondqUzcjwSVi7el7F36cr6PvQYXoZ1P2F5CSF2/azeMQ==",
+      "peer": true
     },
     "raw-body": {
       "version": "2.4.3",

--- a/package.json
+++ b/package.json
@@ -107,5 +107,25 @@
       "pre-commit": "node_modules/.bin/secret-squirrel",
       "pre-push": "make verify -j3"
     }
+  },
+  "peerDependencies": {
+    "@financial-times/n-notification": "^8.2.2",
+    "@financial-times/o-buttons": "^7.5.0",
+    "@financial-times/o-colors": "^6.4.2",
+    "@financial-times/o-editorial-typography": "^2.3.2",
+    "@financial-times/o-errors": "^5.2.2",
+    "@financial-times/o-forms": "^9.4.0",
+    "@financial-times/o-grid": "^6.1.5",
+    "@financial-times/o-icons": "^7.3.0",
+    "@financial-times/o-normalise": "^3.2.2",
+    "@financial-times/o-overlay": "^4.2.4",
+    "@financial-times/o-spacing": "^3.2.1",
+    "@financial-times/o-tooltip": "^5.2.2",
+    "n-ui-foundations": "^9.0.0"
+  },
+  "dependencies": {
+    "ftdomdelegate": "^4.0.6",
+    "next-myft-client": "^9.0.0",
+    "next-session-client": "^4.0.0"
   }
 }

--- a/scripts/prevent-npm-deps.js
+++ b/scripts/prevent-npm-deps.js
@@ -1,8 +1,0 @@
-'use strict';
-
-const {dependencies = {}} = require('../package');
-
-if (Object.keys(dependencies).length > 0) {
-	global.console.error('NPM dependencies included in bower only js project, please remove');
-	process.exit(1);
-}


### PR DESCRIPTION
Migrate from bower to npm.
Install components as peer dependencies with financial-times scope and fix references.