### PR TITLE
Update o-tooltip to the latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -97,7 +97,7 @@
         "@financial-times/o-normalise": "^3.0.0",
         "@financial-times/o-overlay": "^4.0.0",
         "@financial-times/o-spacing": "^3.0.0",
-        "@financial-times/o-tooltip": "^5.0.0",
+        "@financial-times/o-tooltip": "^5.2.4",
         "@financial-times/o-topper": "^5.2.3",
         "n-ui-foundations": "^9.0.0"
       }
@@ -3031,9 +3031,9 @@
       }
     },
     "node_modules/@financial-times/o-tooltip": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@financial-times/o-tooltip/-/o-tooltip-5.2.2.tgz",
-      "integrity": "sha512-JUklwHvNmEFXfqjc6Ft7jV5Rc3cTfqBbcnexMCOvWTr8BE3Xidbg6/VumLKhmS+MTmG4NFl5EgP4Kt2hLrAa1Q==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-tooltip/-/o-tooltip-5.2.4.tgz",
+      "integrity": "sha512-GXC320/zwTNvacG4PCHSwGBPb+3eWMw7pePUAw41iJ70Wjwy+H9aGbbQikWOiBCiSb6BohwImWOJ6RR0g1dReg==",
       "peer": true,
       "dependencies": {
         "ftdomdelegate": "^4.0.6"
@@ -3042,6 +3042,7 @@
         "npm": "^7 || ^8"
       },
       "peerDependencies": {
+        "@financial-times/o-brand": "^4.2.1",
         "@financial-times/o-grid": "^6.0.0",
         "@financial-times/o-icons": "^7.0.1",
         "@financial-times/o-normalise": "^3.0.0",
@@ -25571,9 +25572,9 @@
       "requires": {}
     },
     "@financial-times/o-tooltip": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@financial-times/o-tooltip/-/o-tooltip-5.2.2.tgz",
-      "integrity": "sha512-JUklwHvNmEFXfqjc6Ft7jV5Rc3cTfqBbcnexMCOvWTr8BE3Xidbg6/VumLKhmS+MTmG4NFl5EgP4Kt2hLrAa1Q==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-tooltip/-/o-tooltip-5.2.4.tgz",
+      "integrity": "sha512-GXC320/zwTNvacG4PCHSwGBPb+3eWMw7pePUAw41iJ70Wjwy+H9aGbbQikWOiBCiSb6BohwImWOJ6RR0g1dReg==",
       "peer": true,
       "requires": {
         "ftdomdelegate": "^4.0.6"

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "@financial-times/o-normalise": "^3.0.0",
     "@financial-times/o-overlay": "^4.0.0",
     "@financial-times/o-spacing": "^3.0.0",
-    "@financial-times/o-tooltip": "^5.0.0",
+    "@financial-times/o-tooltip": "^5.2.4",
     "@financial-times/o-topper": "^5.2.3",
     "n-ui-foundations": "^9.0.0"
   },


### PR DESCRIPTION
Update from v5.2.2 to v5.2.4
https://github.com/Financial-Times/origami/blob/main/components/o-tooltip/CHANGELOG.md