### PR TITLE
ug-935 allow load of new design when feature flag present

### DIFF
--- a/components/save-for-later/save-for-later.html
+++ b/components/save-for-later/save-for-later.html
@@ -4,7 +4,7 @@
 	data-myft-ui="saved"
 	action="/myft/save/{{contentId}}"
 	data-js-action="/__myft/api/core/saved/content/{{contentId}}?method=put"
-	{{#ifEquals @root.flags.professorLists 'variant'}}data-myft-ui-variant="createListAndSaveArticleVariant"{{/ifEquals}}>
+	{{#if @root.flags.manageArticleLists}}data-myft-ui-save-new="manageArticleLists"{{/if}}>
 	{{> n-myft-ui/components/csrf-token/input}}
 	<div
 		class="n-myft-ui__announcement o-normalise-visually-hidden"

--- a/myft/ui/lists.js
+++ b/myft/ui/lists.js
@@ -179,8 +179,8 @@ function handleArticleSaved (contentId) {
 function openCreateListAndAddArticleOverlay (contentId) {
 	return myFtClient.getAll('created', 'list')
 		.then(createdLists => createdLists.filter(list => !list.isRedirect))
-		.then(createdLists => {
-			return !createdLists.length ? showCreateListAndAddArticleOverlay(contentId) : showArticleSavedOverlay(contentId);
+		.then(() => {
+			return showCreateListAndAddArticleOverlay(contentId);
 		});
 }
 
@@ -192,8 +192,8 @@ function initialEventListeners () {
 		// Checks if the createListAndSaveArticle variant is active
 		// and will show the variant overlay if the user has no lists,
 		// otherwise it will show the classic overlay
-		const createListVariant = event.currentTarget.querySelector('[data-myft-ui-variant="createListAndSaveArticleVariant"]');
-		if (createListVariant) {
+		const createNewListDesign = event.currentTarget.querySelector('[data-myft-ui-save-new="manageArticleLists"]');
+		if (createNewListDesign) {
 			return openCreateListAndAddArticleOverlay(contentId);
 		}
 


### PR DESCRIPTION
This PR adds a data property to the save for later button if the manageArticleLists flag is enabled.
In the myft.user.saved.content.add event listener, it checks for the data property on the save for later button and displays the new design modal. Previously this component was part of an A/B test, and was only shown if the user had no prior lists; this PR now shows it to all users with the feature flag turned on.

To test: 

- clone locally, checkout the branch and run `npm link`
- pull the latest changes from next-article and run `npm link @financial-times/n-myft-ui` (may need to also take it out of `package.json`)
- Go to FT Toggler and select 'on' on [manageArticleLists](https://toggler.ft.com/#manageArticleLists)
- Go to [an article](https://local.ft.com:5050/content/aa9caaad-c19f-4451-b13b-e514b9c284a5) and click on the Save button on the Share Navigation bar
- Confirm that you can see a modal (currently in development)
- Select 'off' on [manageArticleLists](https://toggler.ft.com/#manageArticleLists)
- Confirm that you do not see a modal.
