### PR TITLE
UG-938: Limit visible number of lists to 3 or 4 on saveArticleToList variant

### DIFF
--- a/myft/main.scss
+++ b/myft/main.scss
@@ -314,6 +314,11 @@ $spacing-unit: 20px;
 			}
 			&-container {
 				margin-top: 0;
+				height: 92px;
+				overflow-y: auto;
+				@include oGridRespondTo($from: M) {
+					height: 126px;
+				}
 			}
 		}
 	}

--- a/myft/main.scss
+++ b/myft/main.scss
@@ -314,10 +314,11 @@ $spacing-unit: 20px;
 			}
 			&-container {
 				margin-top: 0;
-				height: 92px;
+				max-height: 92px;
+				padding-bottom: 2px;
 				overflow-y: auto;
 				@include oGridRespondTo($from: M) {
-					height: 126px;
+					max-height: 126px;
 				}
 			}
 		}


### PR DESCRIPTION
### Description

Added CSS rules to limit the number of visible lists on the modal to:
3 on mobile view
4 on tablet and desktop view

### How to test this code?

- Check out this branch and run `npm link`
- Clone `next-article` and run `npm link @financial-times/n-myft-ui`
- Run `next-article` with `npm start`
- Switch on the manageArticleLists flag on [Toggler](https://toggler.ft.com/#manageArticleLists)
- Go to an article and run the following snippet to enable the "Manage article's list" modal
- Create more than 4 lists and make sure that:
  - On mobile view, there are only 3 visible lists and you can scroll through the rest
  - On desktop view, there are only 4 visible lists and you can scroll through the rest
