### PR TITLE
UG-940: Reposition manageArticleLists modal after height change on mobile view

### DIFF
--- a/myft/ui/save-article-to-list-variant.js
+++ b/myft/ui/save-article-to-list-variant.js
@@ -7,9 +7,10 @@ const csrfToken = getToken();
 
 let lists = [];
 let haveLoadedLists = false;
+let createListOverlay;
 
 export default async function openSaveArticleToListVariant (name, contentId) {
-	function createList (list) {
+	function createList (list, callback) {
 		if(!list) {
 			if (!lists.length) attachDescription();
 			return contentElement.addEventListener('click', openFormHandler, { once: true });
@@ -24,8 +25,8 @@ export default async function openSaveArticleToListVariant (name, contentId) {
 					overlayContent.insertAdjacentElement('afterbegin', listElement);
 					const announceListContainer = document.querySelector('.myft-ui-create-list-variant-announcement');
 					announceListContainer.textContent = `${list} created`;
-					triggerCreateListEvent(contentId);
 					contentElement.addEventListener('click', openFormHandler, { once: true });
+					callback(createdList.actorId);
 				});
 			})
 			.catch(() => {
@@ -78,7 +79,7 @@ export default async function openSaveArticleToListVariant (name, contentId) {
 	const headingElement = HeadingElement();
 	let [contentElement, removeDescription, attachDescription] = ContentElement(!lists.length);
 
-	const createListOverlay = new Overlay(name, {
+	createListOverlay = new Overlay(name, {
 		html: contentElement,
 		heading: { title: headingElement.outerHTML },
 		modal: false,
@@ -114,13 +115,13 @@ export default async function openSaveArticleToListVariant (name, contentId) {
 	const scrollHandler = getScrollHandler(createListOverlay.wrapper);
 
 	createListOverlay.wrapper.addEventListener('oOverlay.ready', (data) => {
-		positionOverlay(data.currentTarget);
-
 		if (lists.length) {
 			const listElement = ListsElement(lists, addToList, removeFromList);
 			const overlayContent = document.querySelector('.o-overlay__content');
 			overlayContent.insertAdjacentElement('afterbegin', listElement);
 		}
+
+		positionOverlay(data.currentTarget);
 
 		contentElement.addEventListener('click', openFormHandler, { once: true });
 
@@ -164,7 +165,10 @@ function FormElement (createList) {
 		event.preventDefault();
 		event.stopPropagation();
 		const inputListName = formElement.querySelector('input[name="list-name"]');
-		createList(inputListName.value);
+		createList(inputListName.value, (contentId => {
+			triggerCreateListEvent(contentId);
+			positionOverlay(createListOverlay.wrapper);
+		}));
 		inputListName.value = '';
 		formElement.remove();
 	}
@@ -287,10 +291,11 @@ function positionOverlay (target) {
 
 	if (isMobile()) {
 		const shareNavComponent = document.querySelector('.share-nav__horizontal');
+		const topHalfOffset = target.clientHeight + 10;
 		target.style['position'] = 'absolute';
 		target.style['margin-left'] = 0;
 		target.style['margin-top'] = 0;
-		target.style['top'] = calculateLargerScreenHalf(shareNavComponent) === 'ABOVE' ? '-120px' : '50px';
+		target.style['top'] = calculateLargerScreenHalf(shareNavComponent) === 'ABOVE' ? `-${topHalfOffset}px` : '50px';
 	} else {
 		target.style['position'] = 'absolute';
 		target.style['margin-left'] = '45px';


### PR DESCRIPTION
### Description

Calls the positionOverlay method to reposition the modal after creating a list. 
This method uses the modal height to dynamically set the vertical position and keep it from covering the ShareNav menu.

### How to test this code?

- Check out this branch and run `npm link`
- Clone `next-article` and run `npm link @financial-times/n-myft-ui`
- Run `next-article` with `npm start`
- Switch on the `manageArticleLists` flag on [Toggler](https://toggler.ft.com/#manageArticleLists)
- Go to MyFT and make sure you have fewer than 3 lists created.
- Enable mobile view on your DevTools and go to an article page. 
- Click on "Save" and the `manageArticleLists` modal should appear.
- Scroll until the modal appears on the top half of the screen. Add lists and ensure that the component repositions to avoid covering the ShareNav menu (See GIF)

![GIF](https://user-images.githubusercontent.com/7011304/180456542-ade5aea3-d7ce-4207-8f9c-010e648aad06.gif)