### PR TITLE
UG-943 Fix bug that causes the modal to stay open after clicking inside it

### DIFF
--- a/myft/ui/save-article-to-list-variant.js
+++ b/myft/ui/save-article-to-list-variant.js
@@ -125,7 +125,7 @@ export default async function openSaveArticleToListVariant (name, contentId) {
 
 		contentElement.addEventListener('click', openFormHandler, { once: true });
 
-		document.querySelector('.article-content').addEventListener('click', outsideClickHandler, { once: true });
+		document.querySelector('.article-content').addEventListener('click', outsideClickHandler);
 
 		window.addEventListener('scroll', scrollHandler);
 
@@ -136,6 +136,8 @@ export default async function openSaveArticleToListVariant (name, contentId) {
 		window.removeEventListener('scroll', scrollHandler);
 
 		window.removeEventListener('oViewport.resize', resizeHandler);
+
+		document.querySelector('.article-content').removeEventListener('click', outsideClickHandler);
 	});
 }
 

--- a/myft/ui/save-article-to-list-variant.js
+++ b/myft/ui/save-article-to-list-variant.js
@@ -89,7 +89,11 @@ export default async function openSaveArticleToListVariant (name, contentId) {
 
 	function outsideClickHandler (e) {
 		const overlayContent = document.querySelector('.o-overlay__content');
-		if(createListOverlay.visible && (!overlayContent || !overlayContent.contains(e.target))) {
+		const overlayContainer = document.querySelector('.o-overlay');
+		// we don't want to close the overlay if the click happened inside the
+		// overlay, except if the click happened on the overlay close button
+		const isTargetInsideOverlay = overlayContainer.contains(e.target) && !e.target.classList.contains('o-overlay__close');
+		if(createListOverlay.visible && (!overlayContent || !isTargetInsideOverlay)) {
 			createListOverlay.close();
 		}
 	}


### PR DESCRIPTION
Fixes a bug that causes the modal to stay open after clicking inside of it.

How to test:

1. Checkout PR and run `npm link`
2. Clone `next-article` and run `npm link @financial-times/n-myft-ui`.
3. Run `next-article` with `npm start`.
4. Enable the `manageArticleLists` flag on Toggler.
5. Go to an article page and click on the save button on the share nav; the save to list modal window should show.
6. Click on anywhere within the modal window (apart from the close button).
7. Click outside the modal window.
8. The modal should close.