### PR TITLE
UG-939 Use new category for list tracking events

### DIFF
--- a/myft/ui/lib/relationship-config.js
+++ b/myft/ui/lib/relationship-config.js
@@ -11,12 +11,6 @@ const relationshipConfig = {
 		subjectType: 'concept',
 		uiSelector: '[data-myft-ui="follow"]'
 	},
-	contained: {
-		actorType: 'list',
-		idProperty: 'data-content-id',
-		subjectType: 'content',
-		uiSelector: '[data-myft-ui="contained"]'
-	}
 };
 
 export default relationshipConfig;

--- a/myft/ui/lib/tracking.js
+++ b/myft/ui/lib/tracking.js
@@ -39,12 +39,10 @@ const getExtraContext = (subjectType, subjectId) => {
  * @param {Object} postedData Event's extra data (required for checking if an instant alert was turned on or off)
  * @return {String} label for the action to send in the custom event
  */
-const getAction = (subjectType, action, postedData, resultData) => {
+const getAction = (subjectType, action, postedData) => {
 	if (action === 'update' && subjectType === 'concept') {
 		const updateState = (postedData && postedData._rel && postedData._rel.instant && postedData._rel.instant === 'true') ? 'on' : 'off';
 		return `instant-alert-${updateState}`;
-	} else if (resultData && resultData.rel && resultData.rel.type && resultData.rel.type === 'contained') {
-		return `${action}-to-list-success`;
 	} else {
 		return customDataSettings[subjectType][action];
 	}
@@ -57,7 +55,7 @@ const getAction = (subjectType, action, postedData, resultData) => {
 export function custom (eventData) {
 	if (Object.keys(customDataSettings).indexOf(eventData.subjectType) !== -1) {
 		const options = Object.assign(
-			{action: getAction(eventData.subjectType, eventData.action, eventData.postedData, eventData.resultData)},
+			{action: getAction(eventData.subjectType, eventData.action, eventData.postedData)},
 			eventData.trackingInfo);
 		const extraContext = getExtraContext(eventData.subjectType, eventData.subjectId);
 		Object.assign(options, extraContext);

--- a/myft/ui/lists.js
+++ b/myft/ui/lists.js
@@ -222,6 +222,18 @@ function handleRemoveToggleSubmit (event) {
 	myFtClient[action]('list', listId, 'contained', 'content', contentId, { token: csrfToken.value })
 		.then(() => {
 			myFtUiButtonStates.toggleButton(submitBtnEl, !isSubmitBtnPressed);
+
+			document.body.dispatchEvent(new CustomEvent('oTracking.event', {
+				detail: {
+					category: 'list',
+					action: action === 'add' ? 'add-success' : 'remove-success',
+					article_id: contentId,
+					list_id: listId,
+					teamName: 'customer-products-us-growth',
+					amplitudeExploratory: true
+				},
+				bubbles: true
+			}));
 		})
 		.catch(error => {
 			setTimeout(() => submitBtnEl.removeAttribute('disabled'));

--- a/myft/ui/lists.js
+++ b/myft/ui/lists.js
@@ -95,6 +95,10 @@ function setUpCreateListListeners (overlay, contentId) {
 	const createListButton = overlay.content.querySelector('.js-create-list');
 	const nameInput = overlay.content.querySelector('.js-name');
 
+	if (!createListButton) {
+		return;
+	}
+
 	createListButton.addEventListener('click', event => {
 		event.preventDefault();
 

--- a/myft/ui/lists.js
+++ b/myft/ui/lists.js
@@ -51,6 +51,18 @@ function updateAfterAddToList (listId, contentId, wasAdded) {
 				content: message,
 				trackable: 'myft-feedback-notification'
 			});
+
+			document.body.dispatchEvent(new CustomEvent('oTracking.event', {
+				detail: {
+					category: 'list',
+					action: 'copy-success',
+					article_id: contentId,
+					list_id: listId,
+					teamName: 'customer-products-us-growth',
+					amplitudeExploratory: true
+				},
+				bubbles: true
+			}));
 		});
 }
 

--- a/myft/ui/myft-buttons/init.js
+++ b/myft/ui/myft-buttons/init.js
@@ -66,13 +66,6 @@ function signedInEventListeners () {
 						const isPressed = !!event.detail.results;
 						buttonStates.setStateOfButton(relationshipName, event.detail.subject, isPressed, undefined, resultData, true);
 
-						// don't send tracking events for list actions, as any
-						// list-related code will send its own `list` category
-						// tracking events
-						if (actorType === 'list') {
-							return;
-						}
-
 						tracking.custom({
 							subjectType,
 							action,

--- a/myft/ui/myft-buttons/init.js
+++ b/myft/ui/myft-buttons/init.js
@@ -65,6 +65,14 @@ function signedInEventListeners () {
 						const resultData = event.detail.results && event.detail.results[0];
 						const isPressed = !!event.detail.results;
 						buttonStates.setStateOfButton(relationshipName, event.detail.subject, isPressed, undefined, resultData, true);
+
+						// don't send tracking events for list actions, as any
+						// list-related code will send its own `list` category
+						// tracking events
+						if (actorType === 'list') {
+							return;
+						}
+
 						tracking.custom({
 							subjectType,
 							action,

--- a/myft/ui/save-article-to-list-variant.js
+++ b/myft/ui/save-article-to-list-variant.js
@@ -179,7 +179,7 @@ function ContentElement (hasDescription) {
 
 	const content = `
 		<div class="myft-ui-create-list-variant-footer">
-			<button class="myft-ui-create-list-variant-add" data-trackable="add-to-a-new-list">Add to a new list</button>
+			<button class="myft-ui-create-list-variant-add" data-trackable="add-to-new-list">Add to a new list</button>
 			${hasDescription ? `
 			${description}
 		` : ''}

--- a/myft/ui/save-article-to-list-variant.js
+++ b/myft/ui/save-article-to-list-variant.js
@@ -329,8 +329,8 @@ async function getLists () {
 function triggerAddToListEvent (contentId, listId) {
 	return document.body.dispatchEvent(new CustomEvent('oTracking.event', {
 		detail: {
-			category: 'professorLists',
-			action: 'add-to-list',
+			category: 'list',
+			action: 'add-success',
 			article_id: contentId,
 			list_id: listId,
 			teamName: 'customer-products-us-growth',
@@ -343,8 +343,8 @@ function triggerAddToListEvent (contentId, listId) {
 function triggerRemoveFromListEvent (contentId, listId) {
 	return document.body.dispatchEvent(new CustomEvent('oTracking.event', {
 		detail: {
-			category: 'professorLists',
-			action: 'remove-from-list',
+			category: 'list',
+			action: 'remove-success',
 			article_id: contentId,
 			list_id: listId,
 			teamName: 'customer-products-us-growth',
@@ -357,8 +357,8 @@ function triggerRemoveFromListEvent (contentId, listId) {
 function triggerCreateListEvent (contentId, listId) {
 	document.body.dispatchEvent(new CustomEvent('oTracking.event', {
 		detail: {
-			category: 'professorLists',
-			action: 'create-list',
+			category: 'list',
+			action: 'create-success',
 			article_id: contentId,
 			list_id: listId,
 			teamName: 'customer-products-us-growth',

--- a/myft/ui/save-article-to-list-variant.js
+++ b/myft/ui/save-article-to-list-variant.js
@@ -179,7 +179,7 @@ function ContentElement (hasDescription) {
 
 	const content = `
 		<div class="myft-ui-create-list-variant-footer">
-			<button class="myft-ui-create-list-variant-add" data-trackable="add-to-new-list">Add to a new list</button>
+			<button class="myft-ui-create-list-variant-add" data-trackable="add-to-new-list" text="Add to a new list">Add to a new list</button>
 			${hasDescription ? `
 			${description}
 		` : ''}

--- a/myft/ui/save-article-to-list-variant.js
+++ b/myft/ui/save-article-to-list-variant.js
@@ -25,6 +25,7 @@ export default async function openSaveArticleToListVariant (name, contentId) {
 					const announceListContainer = document.querySelector('.myft-ui-create-list-variant-announcement');
 					announceListContainer.textContent = `${list} created`;
 					triggerCreateListEvent(contentId, createdList.actorId);
+					triggerAddToListEvent(contentId, createdList.actorId);
 					contentElement.addEventListener('click', openFormHandler, { once: true });
 				});
 			})

--- a/myft/ui/save-article-to-list-variant.js
+++ b/myft/ui/save-article-to-list-variant.js
@@ -24,7 +24,7 @@ export default async function openSaveArticleToListVariant (name, contentId) {
 					overlayContent.insertAdjacentElement('afterbegin', listElement);
 					const announceListContainer = document.querySelector('.myft-ui-create-list-variant-announcement');
 					announceListContainer.textContent = `${list} created`;
-					triggerCreateListEvent(contentId);
+					triggerCreateListEvent(contentId, createdList.actorId);
 					contentElement.addEventListener('click', openFormHandler, { once: true });
 				});
 			})
@@ -39,13 +39,13 @@ export default async function openSaveArticleToListVariant (name, contentId) {
 			return;
 		}
 
-		myFtClient.add('list', list.uuid, 'contained', 'content', contentId, { token: csrfToken }).then(() => {
+		myFtClient.add('list', list.uuid, 'contained', 'content', contentId, { token: csrfToken }).then((addedList) => {
 			const indexToUpdate = lists.indexOf(list);
 			lists[indexToUpdate] = { ...lists[indexToUpdate], checked: true };
 			const listElement = ListsElement(lists, addToList, removeFromList);
 			const overlayContent = document.querySelector('.o-overlay__content');
 			overlayContent.insertAdjacentElement('afterbegin', listElement);
-			triggerAddToListEvent(contentId);
+			triggerAddToListEvent(contentId, addedList.actorId);
 		});
 	}
 
@@ -54,13 +54,13 @@ export default async function openSaveArticleToListVariant (name, contentId) {
 			return;
 		}
 
-		myFtClient.remove('list', list.uuid, 'contained', 'content', contentId, { token: csrfToken }).then(() => {
+		myFtClient.remove('list', list.uuid, 'contained', 'content', contentId, { token: csrfToken }).then((removedList) => {
 			const indexToUpdate = lists.indexOf(list);
 			lists[indexToUpdate] = { ...lists[indexToUpdate], checked: false };
 			const listElement = ListsElement(lists, addToList, removeFromList);
 			const overlayContent = document.querySelector('.o-overlay__content');
 			overlayContent.insertAdjacentElement('afterbegin', listElement);
-			triggerRemoveFromListEvent(contentId);
+			triggerRemoveFromListEvent(contentId, removedList.actorId);
 		});
 	}
 
@@ -179,7 +179,7 @@ function ContentElement (hasDescription) {
 
 	const content = `
 		<div class="myft-ui-create-list-variant-footer">
-			<button class="myft-ui-create-list-variant-add">Add to a new list</button>
+			<button class="myft-ui-create-list-variant-add" data-trackable="add-to-a-new-list">Add to a new list</button>
 			${hasDescription ? `
 			${description}
 		` : ''}
@@ -205,7 +205,7 @@ function ContentElement (hasDescription) {
 
 function HeadingElement () {
 	const heading = `
-		<span class="myft-ui-create-list-variant-heading">Added to <a href="https://www.ft.com/myft/saved-articles">saved articles</a> in <span class="myft-ui-create-list-variant-icon"><span class="myft-ui-create-list-variant-icon-visually-hidden">my FT</span></span></span>
+		<span class="myft-ui-create-list-variant-heading">Added to <a href="https://www.ft.com/myft/saved-articles" data-trackable="saved-articles">saved articles</a> in <span class="myft-ui-create-list-variant-icon"><span class="myft-ui-create-list-variant-icon-visually-hidden">my FT</span></span></span>
 		`;
 
 	return stringToHTMLElement(heading);
@@ -326,12 +326,13 @@ async function getLists () {
 		});
 }
 
-function triggerAddToListEvent (contentId) {
+function triggerAddToListEvent (contentId, listId) {
 	return document.body.dispatchEvent(new CustomEvent('oTracking.event', {
 		detail: {
 			category: 'professorLists',
 			action: 'add-to-list',
 			article_id: contentId,
+			list_id: listId,
 			teamName: 'customer-products-us-growth',
 			amplitudeExploratory: true
 		},
@@ -339,12 +340,13 @@ function triggerAddToListEvent (contentId) {
 	}));
 }
 
-function triggerRemoveFromListEvent (contentId) {
+function triggerRemoveFromListEvent (contentId, listId) {
 	return document.body.dispatchEvent(new CustomEvent('oTracking.event', {
 		detail: {
 			category: 'professorLists',
 			action: 'remove-from-list',
 			article_id: contentId,
+			list_id: listId,
 			teamName: 'customer-products-us-growth',
 			amplitudeExploratory: true
 		},
@@ -352,12 +354,13 @@ function triggerRemoveFromListEvent (contentId) {
 	}));
 }
 
-function triggerCreateListEvent (contentId) {
+function triggerCreateListEvent (contentId, listId) {
 	document.body.dispatchEvent(new CustomEvent('oTracking.event', {
 		detail: {
 			category: 'professorLists',
 			action: 'create-list',
 			article_id: contentId,
+			list_id: listId,
 			teamName: 'customer-products-us-growth',
 			amplitudeExploratory: true
 		},
@@ -368,7 +371,8 @@ function triggerCreateListEvent (contentId) {
 		detail: {
 			category: 'myFT',
 			action: 'create-list-success',
-			article_id: contentId
+			article_id: contentId,
+			list_id: listId,
 		},
 		bubbles: true
 	}));

--- a/myft/ui/save-article-to-list-variant.js
+++ b/myft/ui/save-article-to-list-variant.js
@@ -366,14 +366,4 @@ function triggerCreateListEvent (contentId, listId) {
 		},
 		bubbles: true
 	}));
-
-	return document.body.dispatchEvent(new CustomEvent('oTracking.event', {
-		detail: {
-			category: 'myFT',
-			action: 'create-list-success',
-			article_id: contentId,
-			list_id: listId,
-		},
-		bubbles: true
-	}));
 }


### PR DESCRIPTION
All list-related tracking events will be moving to a new table in the Data platform. In preparation for this, we will be using a new event tracking category `list`. For more information, please see the [tracking spec](https://docs.google.com/spreadsheets/d/1NCpmuMCqqBJLrG8BRdCy5Wa16Qk5yZYBux28nAxAJYk/edit#gid=0).

This PR:

- Removes the existing `myFT:save` and `myFT:unsave` events that were being fired when adding/removing an article from a list (these events should only fire when an article is saved or unsaved).
- Removes/renames the `professorLists` events that were being used for a previous AB test.
- Implements the new events from the tracking spec.
- Moves logic for removing/re-adding an article from/to a list from the shared `myft-buttons` lib to the `lists` component.

To test the changes within `next-article`:

1. Check out this branch and run `npm link`
2. Clone `next-article` and run `npm link @financial-times/n-myft-ui`
3. Run `next-article` with `npm start`
4. Switch on the `manageArticleLists` flag on [Toggler](https://toggler.ft.com/#manageArticleLists)
5. Trigger the events for the article page on [this spreadsheet](https://docs.google.com/spreadsheets/d/1NCpmuMCqqBJLrG8BRdCy5Wa16Qk5yZYBux28nAxAJYk/edit#gid=0) and make sure they trigger a call to `https://spoor-api.ft.com` and include the expected properties.

To test the changes within `next-myft-page`, see [this related PR](https://github.com/Financial-Times/next-myft-page/pull/2545).
