### PR TITLE
UG-837: Add Public toggle to new list form on manageArticleLists modal

### DIFF
--- a/components/save-for-later/save-for-later.html
+++ b/components/save-for-later/save-for-later.html
@@ -4,7 +4,8 @@
 	data-myft-ui="saved"
 	action="/myft/save/{{contentId}}"
 	data-js-action="/__myft/api/core/saved/content/{{contentId}}?method=put"
-	{{#if @root.flags.manageArticleLists}}data-myft-ui-save-new="manageArticleLists"{{/if}}>
+	{{#if @root.flags.manageArticleLists}}data-myft-ui-save-new="manageArticleLists"{{/if}}
+	{{#if @root.flags.manageArticleLists}}data-myft-ui-save-new-config="{{#if @root.flags.myftListPublicPrivateToggle}}showPublicToggle{{/if}}"{{/if}}>
 	{{> n-myft-ui/components/csrf-token/input}}
 	<div
 		class="n-myft-ui__announcement o-normalise-visually-hidden"

--- a/myft/main.scss
+++ b/myft/main.scss
@@ -316,6 +316,11 @@ $spacing-unit: 20px;
 				justify-content: flex-end;
 				@include oTypographySans($scale: 2);
 			}
+
+			&-public {
+				width: calc(100% - 14px);
+				padding: 0 3px;
+			}
 		}
 
 		&-lists {

--- a/myft/main.scss
+++ b/myft/main.scss
@@ -289,18 +289,32 @@ $spacing-unit: 20px;
 
 		&-form {
 			display: flex;
+			flex-direction: column;
 			width: calc(100% - 32px);
-			justify-content: space-between;
-			height: 40px;
-			gap: 8px;
-			padding: 0 16px 16px;
+			gap: 16px;
+			padding: 0 16px 12px;
 
 			& > * {
 				flex: 1 1 auto;
+				margin-bottom: 0;
 			}
 
 			.o-forms-input {
 				margin-top: 0;
+			}
+
+			&-toggle {
+				position: absolute;
+			}
+
+			&-toggle-label::after {
+				background-color: oColorsByName('white');
+			}
+
+			&-buttons {
+				display: flex;
+				justify-content: flex-end;
+				@include oTypographySans($scale: 2);
 			}
 		}
 

--- a/myft/main.scss
+++ b/myft/main.scss
@@ -239,7 +239,7 @@ $spacing-unit: 20px;
 		}
 
 		&-add-description {
-			margin: 4px 0;
+			margin: oSpacingByName('s1') 0;
 		}
 
 		&-heading {
@@ -258,7 +258,7 @@ $spacing-unit: 20px;
 
 		&-footer {
 			border-top: 1px solid oColorsByName('black-5');
-			padding: 16px;
+			padding: oSpacingByName('s4');
 		}
 
 		&-icon {
@@ -291,8 +291,8 @@ $spacing-unit: 20px;
 			display: flex;
 			flex-direction: column;
 			width: calc(100% - 32px);
-			gap: 16px;
-			padding: 0 16px 12px;
+			gap: oSpacingByName('s4');
+			padding: 0 oSpacingByName('s4') oSpacingByName('s3');
 
 			& > * {
 				flex: 1 1 auto;
@@ -324,12 +324,12 @@ $spacing-unit: 20px;
 		}
 
 		&-lists {
-			padding: 16px 16px 0;
+			padding: oSpacingByName('s4') oSpacingByName('s4') 0;
 			@include oTypographySans($scale: 1);
 			&-text {
 				@include oTypographySans($weight: 'semibold');
 				color: oColorsByName('black-80');
-				margin-bottom: 16px;
+				margin-bottom: oSpacingByName('s4');
 			}
 			&-container {
 				margin-top: 0;

--- a/myft/main.scss
+++ b/myft/main.scss
@@ -288,11 +288,12 @@ $spacing-unit: 20px;
 		}
 
 		&-form {
+			$field-spacing: 's4';
 			display: flex;
 			flex-direction: column;
 			width: calc(100% - 32px);
-			gap: oSpacingByName('s4');
-			padding: 0 oSpacingByName('s4') oSpacingByName('s3');
+			gap: oSpacingByName($field-spacing);
+			padding: 0 oSpacingByName($field-spacing) oSpacingByName('s3');
 
 			& > * {
 				flex: 1 1 auto;

--- a/myft/ui/lists.js
+++ b/myft/ui/lists.js
@@ -180,8 +180,13 @@ function showArticleSavedOverlay (contentId) {
 	showListsOverlay('Article saved', `/myft/list?fragment=true&fromArticleSaved=true&contentId=${contentId}`, contentId);
 }
 
-function showCreateListAndAddArticleOverlay (contentId, name = 'myft-ui-create-list-variant') {
-	return openSaveArticleToListVariant(name, contentId);
+function showCreateListAndAddArticleOverlay (contentId, config) {
+	const options = {
+		name: 'myft-ui-create-list-variant',
+		...config
+	};
+
+	return openSaveArticleToListVariant(contentId, options);
 }
 
 function handleArticleSaved (contentId) {
@@ -194,11 +199,11 @@ function handleArticleSaved (contentId) {
 		});
 }
 
-function openCreateListAndAddArticleOverlay (contentId) {
+function openCreateListAndAddArticleOverlay (contentId, config) {
 	return myFtClient.getAll('created', 'list')
 		.then(createdLists => createdLists.filter(list => !list.isRedirect))
 		.then(() => {
-			return showCreateListAndAddArticleOverlay(contentId);
+			return showCreateListAndAddArticleOverlay(contentId, config);
 		});
 }
 
@@ -269,7 +274,9 @@ function initialEventListeners () {
 		// otherwise it will show the classic overlay
 		const newListDesign = event.currentTarget.querySelector('[data-myft-ui-save-new="manageArticleLists"]');
 		if (newListDesign) {
-			return openCreateListAndAddArticleOverlay(contentId);
+			const configKeys = newListDesign.dataset.myftUiSaveNewConfig.split(',');
+			const config = configKeys.reduce((configObj, key) => (key ? { ...configObj, [key]: true} : configObj), {});
+			return openCreateListAndAddArticleOverlay(contentId, config);
 		}
 
 		handleArticleSaved(contentId);

--- a/myft/ui/save-article-to-list-variant.js
+++ b/myft/ui/save-article-to-list-variant.js
@@ -11,7 +11,9 @@ let lists = [];
 let haveLoadedLists = false;
 let createListOverlay;
 
-export default async function openSaveArticleToListVariant (name, contentId) {
+export default async function openSaveArticleToListVariant (contentId, options = {}) {
+	const { name, showPublicToggle = false } = options;
+
 	function createList (newList, cb) {
 		if(!newList || !newList.name) {
 			if (!newList && !newList.name) attachDescription();
@@ -93,7 +95,7 @@ export default async function openSaveArticleToListVariant (name, contentId) {
 	}
 
 	function openFormHandler () {
-		const formElement = FormElement(createList);
+		const formElement = FormElement(createList, showPublicToggle);
 		const overlayContent = document.querySelector('.o-overlay__content');
 		removeDescription();
 		overlayContent.insertAdjacentElement('beforeend', formElement);
@@ -139,7 +141,7 @@ export default async function openSaveArticleToListVariant (name, contentId) {
 	});
 }
 
-function FormElement (createList) {
+function FormElement (createList, showPublicToggle) {
 	const formString = `
 	<form class="myft-ui-create-list-variant-form">
 		<label class="o-forms-field">
@@ -148,21 +150,25 @@ function FormElement (createList) {
 			</span>
 		</label>
 
-		<div class="o-forms-field" role="group">
-			<span class="o-forms-input o-forms-input--toggle">
-				<label>
-					<input class="myft-ui-create-list-variant-form-toggle" type="checkbox" name="is-shareable" value="public" checked>
-					<span class="o-forms-input__label myft-ui-create-list-variant-form-toggle-label">
-						<span class="o-forms-input__label__main">
-							Public
+		${showPublicToggle ?
+		`<div class="o-forms-field" role="group">
+				<span class="o-forms-input o-forms-input--toggle">
+					<label>
+						<input class="myft-ui-create-list-variant-form-toggle" type="checkbox" name="is-shareable" value="public" checked>
+						<span class="o-forms-input__label myft-ui-create-list-variant-form-toggle-label">
+							<span class="o-forms-input__label__main">
+								Public
+							</span>
+							<span id="toggle-group-option-1-description" class="o-forms-input__label__prompt">
+								Your list & profession will be visible to others
+							</span>
 						</span>
-						<span id="toggle-group-option-1-description" class="o-forms-input__label__prompt">
-							Your list & profession will be visible to others
-						</span>
-					</span>
-				</label>
-			</span>
-		</div>
+					</label>
+				</span>
+			</div>` :
+		''
+}
+
 
 		<div class="myft-ui-create-list-variant-form-buttons">
 			<button class="o-buttons o-buttons--big o-buttons--secondary" type="submit">
@@ -182,7 +188,7 @@ function FormElement (createList) {
 
 		const newList = {
 			name: inputListName.value,
-			isShareable: inputIsShareable.checked
+			isShareable: inputIsShareable ? inputIsShareable.checked : false
 		};
 
 		createList(newList, ((contentId, listId) => {
@@ -190,8 +196,6 @@ function FormElement (createList) {
 			triggerAddToListEvent(contentId, listId);
 			positionOverlay(createListOverlay.wrapper);
 		}));
-		inputListName.value = '';
-		inputIsShareable.value = true;
 		formElement.remove();
 	}
 
@@ -317,20 +321,19 @@ function realignOverlay (originalScrollPosition, target) {
 function positionOverlay (target) {
 	target.style['min-width'] = '340px';
 	target.style['width'] = '100%';
-	target.style['margin-top'] = '-50px';
+	target.style['margin-top'] = 0;
 	target.style['left'] = 0;
+	target.style['top'] = 0;
 
 	if (isMobile()) {
 		const shareNavComponent = document.querySelector('.share-nav__horizontal');
 		const topHalfOffset = target.clientHeight + 10;
 		target.style['position'] = 'absolute';
 		target.style['margin-left'] = 0;
-		target.style['margin-top'] = 0;
 		target.style['top'] = calculateLargerScreenHalf(shareNavComponent) === 'ABOVE' ? `-${topHalfOffset}px` : '50px';
 	} else {
 		target.style['position'] = 'absolute';
 		target.style['margin-left'] = '45px';
-		target.style['top'] = '220px';
 	}
 }
 

--- a/myft/ui/save-article-to-list-variant.js
+++ b/myft/ui/save-article-to-list-variant.js
@@ -251,7 +251,7 @@ function ListsElement (lists, addToList, removeFromList) {
 
 	const listsTemplate = `
 	<div class="myft-ui-create-list-variant-lists o-forms-field o-forms-field--optional" role="group">
-		<span class="myft-ui-create-list-variant-lists-text">Add to a list</span>
+		<span class="myft-ui-create-list-variant-lists-text">Add to list</span>
 		<span class="myft-ui-create-list-variant-lists-container o-forms-input o-forms-input--checkbox">
 		</span>
 	</div>

--- a/myft/ui/save-article-to-list-variant.js
+++ b/myft/ui/save-article-to-list-variant.js
@@ -144,23 +144,23 @@ export default async function openSaveArticleToListVariant (contentId, options =
 function FormElement (createList, showPublicToggle) {
 	const formString = `
 	<form class="myft-ui-create-list-variant-form">
-		<label class="o-forms-field">
+		<label class="myft-ui-create-list-variant-form-name o-forms-field">
 			<span class="o-forms-input o-forms-input--text">
 				<input class="myft-ui-create-list-variant-text" type="text" name="list-name" aria-label="List name">
 			</span>
 		</label>
 
 		${showPublicToggle ?
-		`<div class="o-forms-field" role="group">
+		`<div class="myft-ui-create-list-variant-form-public o-forms-field" role="group">
 				<span class="o-forms-input o-forms-input--toggle">
 					<label>
 						<input class="myft-ui-create-list-variant-form-toggle" type="checkbox" name="is-shareable" value="public" checked>
-						<span class="o-forms-input__label myft-ui-create-list-variant-form-toggle-label">
+						<span class="myft-ui-create-list-variant-form-toggle-label o-forms-input__label">
 							<span class="o-forms-input__label__main">
 								Public
 							</span>
-							<span id="toggle-group-option-1-description" class="o-forms-input__label__prompt">
-								Your list & profession will be visible to others
+							<span id="myft-ui-create-list-variant-form-public-description" class="o-forms-input__label__prompt">
+								Your profession & list will be visible to others
 							</span>
 						</span>
 					</label>


### PR DESCRIPTION
### Description

- Adds the attribute `data-myft-ui-save-new-config` to the Save button. It'll use it to add configuration props to the `manageArticleLists` component
- Adds the value `showToggleProp` to that attribute if the `myftListPublicPrivateToggle` flag is on
- Passes a config object to the `manageArticleLists`. Passes the `name` and the `showToggleProp` properties through it.
- Conditionally shows the Public toggle on the `FormElement` if the `showToggleProp` is true
- Adds the markup for the "Public" toggle to the `FormElement`
- Captures the Public toggle state and sends it to the `createList` method. The `createList` method will use it to display a fake door message
- Changes the markup and style of the `FormElement` to add the design changes required for this feature

This toggle is part of a smoke test. For now, it doesn't change anything on the created list, but it'll help us measure interest in this feature



### How to test this code?

- Check out this branch and run `npm link`
- Clone `next-article` and  run `npm link @financial-times/n-myft-ui`
- Run `next-article` with `npm start`
- Switch on the `manageArticleLists` and `myftListPublicPrivateToggle` flags on [Toggler](https://toggler.ft.com/#manageArticleLists)
- Click on "Save" and the `manageArticleLists` modal should appear.
- Click on "Add to a new list" to display the form. The public toggle should appear below the text input. Changing its selection shouldn't have any effect on the list creation

| Desktop |Mobile |
| ------ | ----- |
|<img width="516" alt="Screenshot 2022-08-10 at 12 59 35" src="https://user-images.githubusercontent.com/7011304/183895897-53e28e89-2415-4b63-a2bb-e5683364aee4.png">|<img width="194" alt="Screenshot 2022-08-10 at 12 59 52" src="https://user-images.githubusercontent.com/7011304/183895922-8bc81352-9683-408d-aaf9-bf7b3cc430c5.png">|

Please make sure the changes are not impacting these consumer apps in unexpected ways:
 
- [x] [next-myft-page](https://github.com/Financial-Times/next-myft-page) ([Live](https://www.ft.com/myft), [Local](https://local.ft.com:5050/myft))
- [x] [next-video-page](https://github.com/Financial-Times/next-video-page) ([Live](https://www.ft.com/video), [Local](https://local.ft.com:5050/video))
- [x] [next-tour-page](https://github.com/Financial-Times/next-tour-page) ([Live](https://www.ft.com/tour), [Local](https://local.ft.com:5050/tour))
- [x] [next-search-page](https://github.com/Financial-Times/next-search-page) ([Live](https://www.ft.com/search), [Local](https://local.ft.com:5050/search))



