### PR TITLE
UG-956: Add showMessageOverlay function to manageArticleLists component

### DIFF
--- a/myft/main.scss
+++ b/myft/main.scss
@@ -183,6 +183,26 @@ $spacing-unit: 20px;
 		}
 	}
 
+	.myft-ui-create-list-variant-message {
+		border-radius: 10px;
+		border: 1px solid oColorsByName('black-5');
+		background: oColorsByName('white-80');
+
+		&-content {
+			display: flex;
+			flex-direction: column;
+
+			h3 {
+				margin: 0;
+			}
+		}
+
+		&-buttons {
+			text-align: center;
+		}
+	}
+
+
 	.myft-ui-create-list-variant {
 		border-radius: 10px;
 		border: 1px solid oColorsByName('black-5');

--- a/myft/ui/save-article-to-list-variant.js
+++ b/myft/ui/save-article-to-list-variant.js
@@ -135,12 +135,12 @@ export default async function openSaveArticleToListVariant (contentId, options =
 }
 
 function showMessageOverlay () {
-	function onClick () {
+	function onContinue () {
 		messageOverlay.destroy();
 		createListOverlay.show();
 	}
 
-	const messageElement = MessageElement(onClick);
+	const messageElement = MessageElement(onContinue);
 
 	const messageOverlay = new Overlay('myft-ui-create-list-variant-message', {
 		html: messageElement,

--- a/myft/ui/save-article-to-list-variant.js
+++ b/myft/ui/save-article-to-list-variant.js
@@ -102,17 +102,10 @@ export default async function openSaveArticleToListVariant (contentId, options =
 		formElement.elements[0].focus();
 	}
 
-	function getScrollHandler (target) {
-		return realignOverlay(window.scrollY, target);
-	}
-
-	function resizeHandler () {
-		positionOverlay(createListOverlay.wrapper);
-	}
-
 	createListOverlay.open();
 
 	const scrollHandler = getScrollHandler(createListOverlay.wrapper);
+	const resizeHandler = getResizeHandler(createListOverlay.wrapper);
 
 	createListOverlay.wrapper.addEventListener('oOverlay.ready', (data) => {
 		if (lists.length) {
@@ -156,15 +149,8 @@ function showMessageOverlay () {
 		class: 'myft-ui-create-list-variant-message',
 	});
 
-	function getScrollHandler (target) {
-		return realignOverlay(window.scrollY, target);
-	}
-
-	function resizeHandler () {
-		positionOverlay(messageOverlay.wrapper);
-	}
-
-	const scrollHandler = getScrollHandler(createListOverlay.wrapper);
+	const scrollHandler = getScrollHandler(messageOverlay.wrapper);
+	const resizeHandler = getResizeHandler(messageOverlay.wrapper);
 
 	messageOverlay.open();
 
@@ -183,6 +169,16 @@ function showMessageOverlay () {
 	});
 
 	return messageOverlay;
+}
+
+function getScrollHandler (target) {
+	return realignOverlay(window.scrollY, target);
+}
+
+function getResizeHandler (target) {
+	return function resizeHandler () {
+		positionOverlay(target);
+	};
 }
 
 function FormElement (createList, showPublicToggle) {

--- a/myft/ui/save-article-to-list-variant.js
+++ b/myft/ui/save-article-to-list-variant.js
@@ -350,9 +350,11 @@ function ListCheckboxElement (addToList, removeFromList) {
 
 function MessageElement (onContinue) {
 	const message = `
-	<div class="myft-ui-create-list-variant-message-content">
-		<h3>Thank you for your interest in making a public list</h3>
-		<p>We're currently testing this feature. For now, your list remains private and isn’t visible to others.</p>
+	<div class="myft-ui-create-list-variant-message-content" >
+		<div class="myft-ui-create-list-variant-message-text" aria-live="polite">
+			<h3>Thank you for your interest in making a public list</h3>
+			<p>We're currently testing this feature. For now, your list remains private and isn't visible to others.</p>
+		</div>
 		<div class="myft-ui-create-list-variant-message-buttons">
 			<button class="o-buttons o-buttons--big o-buttons--secondary">
 			Continue

--- a/myft/ui/save-article-to-list-variant.js
+++ b/myft/ui/save-article-to-list-variant.js
@@ -22,15 +22,16 @@ export default async function openSaveArticleToListVariant (contentId, options =
 
 		myFtClient.add('user', null, 'created', 'list', uuid(), { name: newList.name,	token: csrfToken })
 			.then(detail => {
-				myFtClient.add('list', detail.subject, 'contained', 'content', contentId, { token: csrfToken }).then((createdList) => {
-					lists.unshift({ name: newList.name, uuid: createdList.actorId, checked: true, isShareable: !!newList.isShareable });
+				myFtClient.add('list', detail.subject, 'contained', 'content', contentId, { token: csrfToken }).then((data) => {
+					const createdList = { name: newList.name, uuid: data.actorId, checked: true, isShareable: !!newList.isShareable };
+					lists.unshift(createdList);
 					const listElement = ListsElement(lists, addToList, removeFromList);
 					const overlayContent = document.querySelector('.o-overlay__content');
 					overlayContent.insertAdjacentElement('afterbegin', listElement);
 					const announceListContainer = document.querySelector('.myft-ui-create-list-variant-announcement');
-					announceListContainer.textContent = `${newList.name} created`;
+					announceListContainer.textContent = `${createdList.name} created`;
 					contentElement.addEventListener('click', openFormHandler, { once: true });
-					cb(contentId, createdList.actorId);
+					cb(contentId, createdList);
 				});
 			})
 			.catch(() => {
@@ -230,12 +231,12 @@ function FormElement (createList, showPublicToggle) {
 			isShareable: inputIsShareable ? inputIsShareable.checked : false
 		};
 
-		createList(newList, ((contentId, listId) => {
-			triggerCreateListEvent(contentId, listId);
-			triggerAddToListEvent(contentId, listId);
+		createList(newList, ((contentId, createdList) => {
+			triggerCreateListEvent(contentId, createdList.uuid);
+			triggerAddToListEvent(contentId, createdList.uuid);
 			positionOverlay(createListOverlay.wrapper);
 
-			if (inputIsShareable.checked) {
+			if (createdList.isShareable) {
 				createListOverlay.close();
 				showMessageOverlay();
 			}


### PR DESCRIPTION
### Description

- Adds the `MessageElement` component that includes the markup of the fake door message and, as an argument, expects a click handler for its button.
- Adds the `showMessageOverlay` method to display the fake door message for this smoke test. This method passes the a handler to the `MessageElement` with logic to close the messageOverlay and restore the createListOverlay after clicking on "Continue"
- Adds logic in the `createList` callback to close the `createListOverlay` and show the messageOverlay if the **Public** toggle is checked.

### How to test this code?

- Check out this branch and run `npm link`
- Clone `next-article` and  run `npm link @financial-times/n-myft-ui`
- Run `next-article` with `npm start`
- Switch on the `manageArticleLists` and `myftListPublicPrivateToggle` flags on [Toggler](https://toggler.ft.com/#manageArticleLists)
- Click on "Save" and the `manageArticleLists` modal should appear.
- Click on "Add to a new list" to display the form. Create a new list making sure the Public toggle is checked
- You should see the fake door message informing you that this feature is not available (See screenshots). Click on continue and the `manageArticleLists` modal should reappear.

| Desktop |Mobile |
| ------ | ----- |
|<img width="912" alt="Screenshot 2022-08-15 at 16 04 00" src="https://user-images.githubusercontent.com/7011304/184662115-f6819865-8973-40ed-a43a-05756514314d.png">|<img width="272" alt="Screenshot 2022-08-15 at 16 03 38" src="https://user-images.githubusercontent.com/7011304/184662249-86d78bb3-c269-44d7-86a2-845171d83360.png">|

Please make sure the changes are not impacting these consumer apps in unexpected ways:
 
- [x] [next-myft-page](https://github.com/Financial-Times/next-myft-page) ([Live](https://www.ft.com/myft), [Local](https://local.ft.com:5050/myft))
- [x] [next-video-page](https://github.com/Financial-Times/next-video-page) ([Live](https://www.ft.com/video), [Local](https://local.ft.com:5050/video))
- [x] [next-tour-page](https://github.com/Financial-Times/next-tour-page) ([Live](https://www.ft.com/tour), [Local](https://local.ft.com:5050/tour))
- [x] [next-search-page](https://github.com/Financial-Times/next-search-page) ([Live](https://www.ft.com/search), [Local](https://local.ft.com:5050/search))
