### PR TITLE
UG-967: Fix UX bugs on manageArticleLists component

### DIFF
--- a/myft/main.scss
+++ b/myft/main.scss
@@ -339,7 +339,7 @@ $spacing-unit: 20px;
 			}
 
 			&-public {
-				width: calc(100% - 14px);
+				max-width: 300px;
 				padding: 0 3px;
 			}
 		}

--- a/myft/ui/save-article-to-list-variant.js
+++ b/myft/ui/save-article-to-list-variant.js
@@ -16,7 +16,7 @@ export default async function openSaveArticleToListVariant (contentId, options =
 
 	function createList (newList, cb) {
 		if(!newList || !newList.name) {
-			if (!newList && !newList.name) attachDescription();
+			if (!lists.length) attachDescription();
 			return contentElement.addEventListener('click', openFormHandler, { once: true });
 		}
 


### PR DESCRIPTION
### Description

Fixes two bugs on the manageArticleLists component:

1. The description of the "Add to a new list" button wasn't being restored if the user try to create an empty list
2. The description below the Public/Private toggle was being shown besides the toggle on screen widths between 390px and  780px

### How to test this code?

- Check out this branch and run `npm link`
- Clone `next-article` and  run `npm link @financial-times/n-myft-ui`
- Run `next-article` with `npm start`
- Switch on the`myftListPublicPrivateToggle` flags on [Toggler](https://toggler.ft.com/#manageArticleLists)
- Click on "Save" and the `manageArticleLists` modal should appear.

Bug 1:

- Make sure you have no lists created on [myFT](https://www.ft.com/myft/lists)
- Click on "Add to a new list" to display the form. Submit the empty form
- The button "Add to a new list" should be restored, along with its description "Lists are a simple way to curate your content"

Bug 2:
- Use your browser's dev tools to simulate a device with width between 390px and 780px
- Click on "Add to a new list" to display the form
- You should see the Public/Private toggle below the input text field. Below the toggle, you should see its message "Your profession & list will be visible to others"

| Bug 1 |Bug 2 |
| ------ | ----- |
|![Bug 1](https://user-images.githubusercontent.com/7011304/185170848-805a805e-b4c5-41e1-a69c-a03e72c67435.png)|![Bug 2](https://user-images.githubusercontent.com/7011304/185170806-eb31e6be-6b6f-43dd-bf5a-56b5119b3e34.png)|

