### PR TITLE
UG-955 add cancel button to add to list form

### DIFF
--- a/myft/main.scss
+++ b/myft/main.scss
@@ -339,7 +339,7 @@ $spacing-unit: 20px;
 			}
 
 			&-public {
-				width: calc(100% - 14px);
+				max-width: 300px;
 				padding: 0 3px;
 			}
 		}

--- a/myft/ui/save-article-to-list-variant.js
+++ b/myft/ui/save-article-to-list-variant.js
@@ -96,7 +96,7 @@ export default async function openSaveArticleToListVariant (contentId, options =
 	}
 
 	function openFormHandler () {
-		const formElement = FormElement(createList, showPublicToggle, restoreFormHandler);
+		const formElement = FormElement(createList, showPublicToggle, restoreFormHandler, attachDescription);
 		const overlayContent = document.querySelector('.o-overlay__content');
 		removeDescription();
 		overlayContent.insertAdjacentElement('beforeend', formElement);
@@ -182,7 +182,7 @@ function getResizeHandler (target) {
 	};
 }
 
-function FormElement (createList, showPublicToggle, restoreFormHandler) {
+function FormElement (createList, showPublicToggle, restoreFormHandler, attachDescription) {
 	const formString = `
 	<form class="myft-ui-create-list-variant-form">
 		<label class="myft-ui-create-list-variant-form-name o-forms-field">
@@ -252,7 +252,8 @@ function FormElement (createList, showPublicToggle, restoreFormHandler) {
 		event.preventDefault();
 		event.stopPropagation();
 		formElement.remove();
-		restoreFormHandler()
+		if (!lists.length) attachDescription();
+		restoreFormHandler();
 	}
 
 	formElement.querySelector('button[type="submit"]').addEventListener('click', handleSubmit);

--- a/myft/ui/save-article-to-list-variant.js
+++ b/myft/ui/save-article-to-list-variant.js
@@ -16,7 +16,7 @@ export default async function openSaveArticleToListVariant (contentId, options =
 
 	function createList (newList, cb) {
 		if(!newList || !newList.name) {
-			if (!newList && !newList.name) attachDescription();
+			if (!lists.length) attachDescription();
 			return contentElement.addEventListener('click', openFormHandler, { once: true });
 		}
 

--- a/myft/ui/save-article-to-list-variant.js
+++ b/myft/ui/save-article-to-list-variant.js
@@ -211,6 +211,9 @@ function FormElement (createList, showPublicToggle) {
 }
 
 		<div class="myft-ui-create-list-variant-form-buttons">
+			<button class="o-buttons o-buttons--primary o-buttons--inverse o-buttons--big" type="click">
+			Cancel
+			</button>
 			<button class="o-buttons o-buttons--big o-buttons--secondary" type="submit">
 			Add
 			</button>
@@ -245,7 +248,27 @@ function FormElement (createList, showPublicToggle) {
 
 	}
 
+	function handleCancelClick (event) {
+		event.preventDefault();
+		event.stopPropagation();
+		const inputListName = formElement.querySelector('input[name="list-name"]');
+		const inputIsShareable = formElement.querySelector('input[name="is-shareable"]');
+
+		const createNewList = {
+			name: inputListName.value,
+			isShareable: inputIsShareable ? inputIsShareable.checked : false
+		};
+
+		createList(createNewList, ((contentId, listId) => {
+			triggerCreateListEvent(contentId, listId);
+			triggerAddToListEvent(contentId, listId);
+			positionOverlay(createListOverlay.wrapper);
+		}));
+		formElement.remove()
+	}
+
 	formElement.querySelector('button[type="submit"]').addEventListener('click', handleSubmit);
+	formElement.querySelector('button[type="click"]').addEventListener('click', handleCancelClick);
 
 	return formElement;
 }

--- a/myft/ui/save-article-to-list-variant.js
+++ b/myft/ui/save-article-to-list-variant.js
@@ -251,20 +251,13 @@ function FormElement (createList, showPublicToggle) {
 	function handleCancelClick (event) {
 		event.preventDefault();
 		event.stopPropagation();
-		const inputListName = formElement.querySelector('input[name="list-name"]');
-		const inputIsShareable = formElement.querySelector('input[name="is-shareable"]');
 
-		const createNewList = {
-			name: inputListName.value,
-			isShareable: inputIsShareable ? inputIsShareable.checked : false
-		};
-
-		createList(createNewList, ((contentId, listId) => {
+		createList(((contentId, listId) => {
 			triggerCreateListEvent(contentId, listId);
 			triggerAddToListEvent(contentId, listId);
 			positionOverlay(createListOverlay.wrapper);
 		}));
-		formElement.remove()
+		formElement.remove();
 	}
 
 	formElement.querySelector('button[type="submit"]').addEventListener('click', handleSubmit);

--- a/myft/ui/save-article-to-list-variant.js
+++ b/myft/ui/save-article-to-list-variant.js
@@ -17,7 +17,7 @@ export default async function openSaveArticleToListVariant (contentId, options =
 	function createList (newList, cb) {
 		if(!newList || !newList.name) {
 			if (!lists.length) attachDescription();
-			return restoreFormHandler()
+			return restoreFormHandler();
 		}
 
 		myFtClient.add('user', null, 'created', 'list', uuid(), { name: newList.name,	token: csrfToken })
@@ -30,13 +30,13 @@ export default async function openSaveArticleToListVariant (contentId, options =
 					overlayContent.insertAdjacentElement('afterbegin', listElement);
 					const announceListContainer = document.querySelector('.myft-ui-create-list-variant-announcement');
 					announceListContainer.textContent = `${newList.name} created`;
-					restoreFormHandler()
+					restoreFormHandler();
 					cb(contentId, createdList.actorId);
 				});
 			})
 			.catch(() => {
 				if (!lists.length) attachDescription();
-				return restoreFormHandler()
+				return restoreFormHandler();
 			});
 	}
 
@@ -117,7 +117,7 @@ export default async function openSaveArticleToListVariant (contentId, options =
 
 		positionOverlay(data.currentTarget);
 
-		restoreFormHandler()
+		restoreFormHandler();
 
 		document.querySelector('.article-content').addEventListener('click', outsideClickHandler);
 

--- a/myft/ui/save-article-to-list-variant.js
+++ b/myft/ui/save-article-to-list-variant.js
@@ -31,7 +31,7 @@ export default async function openSaveArticleToListVariant (contentId, options =
 					const announceListContainer = document.querySelector('.myft-ui-create-list-variant-announcement');
 					announceListContainer.textContent = `${newList.name} created`;
 					restoreFormHandler();
-					cb(contentId, createdList.actorId);
+					cb(contentId, createdList);
 				});
 			})
 			.catch(() => {


### PR DESCRIPTION
### Description
Add cancel button to add to list form and and functionality that closes the form when the `cancel` button is clicked without saving any changes

### Ticket
https://financialtimes.atlassian.net/browse/UG-955

### How to test
1) in `n-myft-ui` run `npm link`
2) in another terminal tab cd into `next-article` and run `npm link @financial-times/n-myft-ui` then `npm run watch`
3) open another terminal tab and cd into `next-article` again and run `npm start`
4) visit https://toggler.ft.com/ and switch on `myftListPublicPrivateToggle` and `manageArticleLists` flags
5) visit any article on https://local.ft.com:5050/
6) click the save article button on the share-nav, this will open the add to list modal
7) click `add to a new list` to open the add to list form, you should see the public/private toggle, `cancel` and `add` buttons
8) type something into the form textbox and click the `cancel` button, the form should close without saving the changes
9) click `add to a new list` again and the form should reopen