### PR TITLE
ug-968 - add tracking to see how many people have to scroll to add to a new list

### DIFF
--- a/myft/ui/save-article-to-list-variant.js
+++ b/myft/ui/save-article-to-list-variant.js
@@ -10,6 +10,8 @@ const csrfToken = getToken();
 let lists = [];
 let haveLoadedLists = false;
 let createListOverlay;
+let scrolledOnOpen;
+let listOverlayBottom;
 
 export default async function openSaveArticleToListVariant (contentId, options = {}) {
 	const { name, showPublicToggle = false } = options;
@@ -118,6 +120,7 @@ export default async function openSaveArticleToListVariant (contentId, options =
 	}
 
 	createListOverlay.open();
+	scrolledOnOpen = window.scrollY;
 
 	const scrollHandler = getScrollHandler(createListOverlay.wrapper);
 	const resizeHandler = getResizeHandler(createListOverlay.wrapper);
@@ -129,6 +132,8 @@ export default async function openSaveArticleToListVariant (contentId, options =
 		}
 
 		positionOverlay(data.currentTarget);
+
+		listOverlayBottom = document.querySelector('.myft-ui-create-list-variant').getBoundingClientRect().bottom;
 
 		restoreFormHandler();
 
@@ -306,6 +311,7 @@ function ContentElement (hasDescription, onClick) {
 
 	const contentElement = stringToHTMLElement(content);
 
+	contentElement.querySelector('.myft-ui-create-list-variant-add').addEventListener('click', checkScrollToAdd);
 	contentElement.querySelector('.myft-ui-create-list-variant-add').addEventListener('click', triggerAddToNewListEvent);
 
 	function removeDescription () {
@@ -589,4 +595,20 @@ function triggerCancelEvent () {
 		},
 		bubbles: true
 	}));
+}
+
+//Temporary event to determine whether users need to scroll to add to a list
+function checkScrollToAdd () {
+	//if the bottom of the overlay was not showing and scrolling has occurred since it was opened
+	if(listOverlayBottom > window.innerHeight && window.scrollY > scrolledOnOpen) {
+		document.body.dispatchEvent(new CustomEvent('oTracking.event', {
+			detail: {
+				category: 'publicToggle',
+				action: 'scrollToAdd',
+				teamName: 'customer-products-us-growth',
+				amplitudeExploratory: true
+			},
+			bubbles: true
+		}));
+	}
 }


### PR DESCRIPTION
### Context
The new manage article lists component that is live can be cut off on smaller desktop screens when the user hasn't scrolled (i.e. is saving the list before reading) and the large top ad is displayed, e.g.:

<img width="948" alt="UG-967" src="https://user-images.githubusercontent.com/54366961/190379583-d65ccfc7-ac9f-4659-a1b1-56e4d74b9e48.png">

### This PR
We want to know how big a problem this is before putting in design and engineering effort to fix this, so this PR adds a tracking event when the user has had to scroll down the list to get to the 'add to new list' button.

### How to test
1. checkout this branch locally and run npm link
2. on a local copy of next-article, run `npm link @financial-times/@n-myft-ui`, then `npm run build && npm start`
3. go to an article, e.g. https://local.ft.com:5050/content/361d7a3c-a097-4599-a124-f2bdd4d714be and ensure that you have dev tools open in the network tab, filtered on 'ingest'
4. Ensure your screen is small enough to just show the 'save' button on the myft sharenav
5. Click on 'save', and then scroll down and click on '+ add to new list'. You should see an ingest of type `publicToggle:scrollToAdd` should be triggered.
6. Try again with various screen sizes - the `publicToggle:scrollToAdd` should only be fired when the overlay was opened with the bottom hidden, and a scroll has taken place before clicking on '+ add to new list'
