### PR TITLE
ug-1045 DAC_expandable_content_01

### DIFF
--- a/myft/ui/save-article-to-list-variant.js
+++ b/myft/ui/save-article-to-list-variant.js
@@ -116,7 +116,6 @@ export default async function openSaveArticleToListVariant (contentId, options =
 		const overlayContent = document.querySelector('.o-overlay__content');
 		removeDescription();
 		overlayContent.insertAdjacentElement('beforeend', formElement);
-		formElement.elements[0].focus();
 	}
 
 	createListOverlay.open();
@@ -258,7 +257,7 @@ function ContentElement (hasDescription, onClick) {
 
 	const content = `
 		<div class="myft-ui-create-list-variant-footer">
-			<button class="myft-ui-create-list-variant-add myft-ui-create-list-variant-add-collapsed" data-trackable="add-to-new-list" text="add to new list">Add to a new list</button>
+			<button class="myft-ui-create-list-variant-add myft-ui-create-list-variant-add-collapsed" aria-expanded=false data-trackable="add-to-new-list" text="add to new list">Add to a new list</button>
 			${hasDescription ? `
 			${description}
 		` : ''}
@@ -284,11 +283,13 @@ function ContentElement (hasDescription, onClick) {
 
 	function restoreFormHandler () {
 		contentElement.querySelector('.myft-ui-create-list-variant-add').classList.add('myft-ui-create-list-variant-add-collapsed');
+		contentElement.querySelector('.myft-ui-create-list-variant-add').setAttribute('aria-expanded', false);
 		return contentElement.addEventListener('click', clickHandler, { once: true });
 	}
 
 	function clickHandler (event) {
 		contentElement.querySelector('.myft-ui-create-list-variant-add').classList.remove('myft-ui-create-list-variant-add-collapsed');
+		contentElement.querySelector('.myft-ui-create-list-variant-add').setAttribute('aria-expanded', true);
 		onClick(event);
 	}
 


### PR DESCRIPTION
***Description***
The new managedSavedLists component did not state that the 'add to a new list' button was expandable or announce when it was expanded or collapsed. See for [ug-1045](https://financialtimes.atlassian.net/browse/UG-1045). 
This PR 
1) adds the `aria-expanded` label 
2) removes focus from the text input in order for the screen reader to announce that the button has expanded

This second part I'm unsure of from a visual UX point of view, and welcome thoughts.

***How to test***
1) Clone the branch locally and run `npm link`
2) Run next-article locally and run `npm link @financial-times/n-myft-ui`
3) Visit an article, e.g. https://local.ft.com:5050/content/f3bb0f96-1816-4481-8318-4f7583326a4a
4) Turn on your screen reader
5) Save an article using the vertical share nav on the left hand side.
6) move to `save to new list` (using your keyboard); it should be announced as a collapsed button
7) click on the button; more content should appear, and it should be announced as an expanded button
8) tab to focus on the text input field
9) if you hit cancel, the button should be announced as collapsed.
