### PR TITLE
ug-1046 DAC_label_in_name

### DIFF
--- a/myft/ui/save-article-to-list-variant.js
+++ b/myft/ui/save-article-to-list-variant.js
@@ -167,7 +167,8 @@ function FormElement (createList, showPublicToggle, attachDescription, onListCre
 	<form class="myft-ui-create-list-variant-form">
 		<label class="myft-ui-create-list-variant-form-name o-forms-field">
 			<span class="o-forms-input o-forms-input--text">
-				<input class="myft-ui-create-list-variant-text" type="text" name="list-name" aria-label="List name">
+				<input class="myft-ui-create-list-variant-text" type="text" name="list-name">
+				List name
 			</span>
 		</label>
 


### PR DESCRIPTION
*** Description ***

When a user is creating a new list in the save article component, visually we see "Add to a new list" but the screen reader announces only "list name", which is not visually seen anywhere. The recommendation is to add a visual label for the text input rather than `aria-label`. See [ug-1046](https://financialtimes.atlassian.net/browse/UG-1046) for more details.

NB:
[This PR](https://github.com/Financial-Times/n-myft-ui/pull/541) announces "Add to a new list" to the screen reader

*** Visual changes ***

Before:
<img width="278" alt="Screenshot 2022-11-04 at 10 06 31" src="https://user-images.githubusercontent.com/54366961/199947012-601f179a-1694-4bde-92fc-feb93a66c661.png">

After:
<img width="277" alt="Screenshot 2022-11-04 at 10 13 43" src="https://user-images.githubusercontent.com/54366961/199948504-f8a9a2ef-f1e5-4dd7-a722-11696cbc0d94.png">

*** How to test ***

1. Clone the branch locally and run npm link
2. Run next-article locally and run npm link @financial-times/n-myft-ui
3. Visit an article, e.g. https://local.ft.com:5050/content/f3bb0f96-1816-4481-8318-4f7583326a4a
4. Save an article using the vertical share nav on the left hand side.
5. Click on the "add to a new list" button.
6. Check that the "List name" is present as in the screenshot above.
