### PR TITLE
[CON-2137] Updated styles on myft button

### DIFF
--- a/mixins/lozenge/_themes.scss
+++ b/mixins/lozenge/_themes.scss
@@ -42,7 +42,7 @@ $myft-lozenge-themes: (
 	)
 );
 
-@function getValue($key) {
+@function getThemeColor($key) {
 	@return map-get($theme-map, $key);
 }
 

--- a/mixins/lozenge/_themes.scss
+++ b/mixins/lozenge/_themes.scss
@@ -13,7 +13,8 @@ $myft-lozenge-themes: (
 		highlight: rgba(white, 0.8),
 		pressed-highlight: rgba(white, 0.2),
 		disabled: rgba(oColorsByName('white'), 0.5),
-		focus-outline: oColorsByName('white')
+		focus-outline: oColorsByName('white'),
+		mix-blend-mode: lighten
 	),
 	opinion: (
 		background: oColorsByName('oxford-40'),
@@ -41,7 +42,7 @@ $myft-lozenge-themes: (
 	)
 );
 
-@function getThemeColor($key) {
+@function getValue($key) {
 	@return map-get($theme-map, $key);
 }
 

--- a/mixins/lozenge/_toggle-icon.scss
+++ b/mixins/lozenge/_toggle-icon.scss
@@ -24,12 +24,12 @@
 @mixin myftToggleIcon($theme: standard) {
 	@include withTheme($theme) {
 		&::before {
-			@include plusIcon(getValue(background));
+			@include plusIcon(getThemeColor(background));
 		}
 
 		&[aria-pressed="true"] {
 			&::before {
-				@include tickIcon(getValue(text));
+				@include tickIcon(getThemeColor(text));
 			}
 		}
 
@@ -38,12 +38,12 @@
 			background: transparent;
 
 			&::before {
-				@include plusIcon(getValue(disabled));
+				@include plusIcon(getThemeColor(disabled));
 				opacity: 0.5;
 			}
 
 			&[aria-pressed="true"]::before {
-				@include tickIcon(getValue(disabled));
+				@include tickIcon(getThemeColor(disabled));
 			}
 		}
 	}

--- a/mixins/lozenge/_toggle-icon.scss
+++ b/mixins/lozenge/_toggle-icon.scss
@@ -24,12 +24,12 @@
 @mixin myftToggleIcon($theme: standard) {
 	@include withTheme($theme) {
 		&::before {
-			@include plusIcon(getThemeColor(background));
+			@include plusIcon(getValue(background));
 		}
 
 		&[aria-pressed="true"] {
 			&::before {
-				@include tickIcon(getThemeColor(text));
+				@include tickIcon(getValue(text));
 			}
 		}
 
@@ -38,12 +38,12 @@
 			background: transparent;
 
 			&::before {
-				@include plusIcon(getThemeColor(disabled));
+				@include plusIcon(getValue(disabled));
 				opacity: 0.5;
 			}
 
 			&[aria-pressed="true"]::before {
-				@include tickIcon(getThemeColor(disabled));
+				@include tickIcon(getValue(disabled));
 			}
 		}
 	}

--- a/mixins/lozenge/main.scss
+++ b/mixins/lozenge/main.scss
@@ -56,36 +56,45 @@
 
 	@include withTheme($theme) {
 		background-color: transparent;
-		border: 1px solid getThemeColor(background);
-		color: getThemeColor(background);
+		border: 1px solid getValue(background);
+		color: getValue(background);
 
-		@include focusOutlineColor(getThemeColor(focus-outline));
+		@include focusOutlineColor(getValue(focus-outline));
 
 		&:hover,
 		&:focus {
-			background-color: getThemeColor(pressed-highlight);
-			border-color: getThemeColor(background);
-			color: getThemeColor(background);
+			background-color: getValue(pressed-highlight);
+			border-color: getValue(background);
+			color: getValue(background);
 		}
 
 		&[aria-pressed="true"] {
-			background-color: getThemeColor(background);
-			border: 1px solid getThemeColor(background);
-			color: getThemeColor(text);
+			background-color: getValue(background);
+			border: 1px solid getValue(background);
+			color: getValue(text);
 
+			@if get(mix-blend-mode) {
+				mix-blend-mode: lighten;
+			}
 			&:hover,
 			&:focus {
-				background-color: getThemeColor(highlight);
-				border-color: getThemeColor(highlight);
-				color: getThemeColor(text);
+				border-color: getValue(highlight);
+				color: getValue(text);
+
+				@if getValue(mix-blend-mode) {
+					mix-blend-mode: getValue(mix-blend-mode);
+					background-color: rgba(getValue(highlight), 0.85);
+				} @else {
+					background-color: getValue(highlight);
+				}
 			}
 		}
 
 		&[disabled]:hover,
 		&[disabled] {
 			background: transparent;
-			border: 1px solid getThemeColor(disabled);
-			color: getThemeColor(disabled);
+			border: 1px solid getValue(disabled);
+			color: getValue(disabled);
 		}
 	}
 }

--- a/mixins/lozenge/main.scss
+++ b/mixins/lozenge/main.scss
@@ -73,7 +73,7 @@
 			border: 1px solid getValue(background);
 			color: getValue(text);
 
-			@if get(mix-blend-mode) {
+			@if getValue(mix-blend-mode) {
 				mix-blend-mode: lighten;
 			}
 			&:hover,

--- a/mixins/lozenge/main.scss
+++ b/mixins/lozenge/main.scss
@@ -56,36 +56,36 @@
 
 	@include withTheme($theme) {
 		background-color: transparent;
-		border: 1px solid getValue(background);
-		color: getValue(background);
+		border: 1px solid getThemeColor(background);
+		color: getThemeColor(background);
 
-		@include focusOutlineColor(getValue(focus-outline));
+		@include focusOutlineColor(getThemeColor(focus-outline));
 
 		&:hover,
 		&:focus {
-			background-color: getValue(pressed-highlight);
-			border-color: getValue(background);
-			color: getValue(background);
+			background-color: getThemeColor(pressed-highlight);
+			border-color: getThemeColor(background);
+			color: getThemeColor(background);
 		}
 
 		&[aria-pressed="true"] {
-			background-color: getValue(background);
-			border: 1px solid getValue(background);
-			color: getValue(text);
+			background-color: getThemeColor(background);
+			border: 1px solid getThemeColor(background);
+			color: getThemeColor(text);
 
-			@if getValue(mix-blend-mode) {
+			@if getThemeColor(mix-blend-mode) {
 				mix-blend-mode: lighten;
 			}
 			&:hover,
 			&:focus {
-				border-color: getValue(highlight);
-				color: getValue(text);
+				border-color: getThemeColor(highlight);
+				color: getThemeColor(text);
 
-				@if getValue(mix-blend-mode) {
-					mix-blend-mode: getValue(mix-blend-mode);
-					background-color: rgba(getValue(highlight), 0.85);
+				@if getThemeColor(mix-blend-mode) {
+					mix-blend-mode: getThemeColor(mix-blend-mode);
+					background-color: rgba(getThemeColor(highlight), 0.85);
 				} @else {
-					background-color: getValue(highlight);
+					background-color: getThemeColor(highlight);
 				}
 			}
 		}
@@ -93,8 +93,8 @@
 		&[disabled]:hover,
 		&[disabled] {
 			background: transparent;
-			border: 1px solid getValue(disabled);
-			color: getValue(disabled);
+			border: 1px solid getThemeColor(disabled);
+			color: getThemeColor(disabled);
 		}
 	}
 }


### PR DESCRIPTION
**Description**

Updated myft button styles to make use of the [mix-blend-mode](https://developer.mozilla.org/en-US/docs/Web/CSS/mix-blend-mode) property on the inverse theme to better calculate colors based on parent background color.

![image](https://user-images.githubusercontent.com/2019650/203385179-81fa2a9d-3ff6-468f-b4c4-7781490a00f1.png)

hover over
![image](https://user-images.githubusercontent.com/2019650/203385093-0445995d-538f-4ba5-8398-cab69b399629.png)

