### PR TITLE
CON-2093: Change the headings of collections

### DIFF
--- a/components/collections/collections.html
+++ b/components/collections/collections.html
@@ -2,9 +2,9 @@
 	class="collection {{#if liteStyle}}collection--lite{{else}}collection--regular{{/if}}"
 	data-trackable="{{#if trackable}}{{trackable}}{{else}}collection{{/if}}">
 	<header class="collection__header {{#if liteStyle}}collection__header--lite{{else}}collection__header--regular{{/if}}">
-		<h2 class="collection__title {{#if liteStyle}}collection__title--lite{{else}}collection__title--regular{{/if}}">
+		<h3 class="collection__title {{#if liteStyle}}collection__title--lite{{else}}collection__title--regular{{/if}}">
 			{{title}}
-		</h2>
+		</h3>
 	</header>
 	<ul class="collection__concepts">
 		{{#concepts}}


### PR DESCRIPTION
# Problem

[JIRA ticket](https://financialtimes.atlassian.net/jira/software/c/projects/CON/boards/1061?modal=detail&selectedIssue=CON-2093&assignee=62a874c0188d08006fe15f2e): We have cards that have the wrong headings. 

The places where it is used are mostly already having a h2 so we need the cards to have a h3 as a title. 

# Usage 

Here are some examples of the places: 

- Next tour page.  h2 is above:
<img width="1023" alt="Screenshot 2022-11-23 at 11 54 22" src="https://user-images.githubusercontent.com/107469842/203541957-e7a7b6f1-8bb7-41cd-82ca-9762bfa4cb18.png">

- MyftPage. h2 is above:
<img width="1297" alt="Screenshot 2022-11-23 at 11 54 37" src="https://user-images.githubusercontent.com/107469842/203542144-ad9faada-b105-430d-958b-d77814afeb03.png">

- Some stream page: that case is a bit more complex because above is a h1. After discussion with (DAC) Jake Roberts, it is ok (even if not ideal) to have a h1 before a h3. He suggested that we could add a h2 that is hidden. This is mostly for maps of headings to make sense. 
<img width="1270" alt="Screenshot 2022-11-23 at 11 54 30" src="https://user-images.githubusercontent.com/107469842/203542483-e1fb00ed-aca8-47fe-955d-cf0e0cc3f373.png">


# Screenshot of the actual change

| Before with a h2 | After with a h3 |
| - | - |
|<img width="1147" alt="before" src="https://user-images.githubusercontent.com/107469842/203542754-5138469b-998f-41ce-b255-6973905ec8d9.png">|<img width="1149" alt="after" src="https://user-images.githubusercontent.com/107469842/203543795-fe0ddf1c-0e6b-4d17-b097-86864cc43d95.png">|


# Other considerations

Tested and approved. 

Pages that uses n-myft-ui where I could not find any 'collection' component: 
- next-front-page
- next-article
- next-video-page
- next-search-page
