### PR TITLE
CON-2091: Label in name, collections button (DAC)

### DIFF
--- a/components/collections/collections.html
+++ b/components/collections/collections.html
@@ -74,7 +74,7 @@
 							,
 						{{~/unless~}}
 					{{~/concepts~}}"
-				aria-label="Add all topics in the {{title}} collection to my F T"
+				aria-label="Add all to myFT: {{title}} collection"
 				data-alternate-label="Remove all topics in the {{title}} collection from my F T"
 				data-alternate-text="Added"
 				title="Add all topics in the {{title}} collection to my F T">


### PR DESCRIPTION
# The problem 

[Jira](https://financialtimes.atlassian.net/browse/CON-2091):
Change the order in which the topic of the button appear in label of collections. The aria label needs to sounds similar to the visual label, so have the extra info about the subject either before or after the "same string" as the one displayed on the button.

# Solution
Add the topic of the collection before the "Add add to myFT"

# How to test
When inspecting a collection, you should see the aria-label as such "Something collection: add to myFT"