### PR TITLE
CON-2075: Label in name of follow button in 'Added' state (DAC)

### DIFF
--- a/components/follow-button/follow-button.html
+++ b/components/follow-button/follow-button.html
@@ -26,7 +26,7 @@
 		></div>
 		<button
 			{{#ifAll setFollowButtonStateToSelected @root.cacheablePersonalisedUrl}}
-				aria-label="Remove {{name}} from myFT"
+				aria-label="Added {{name}} to myFT: click to remove"
 				title="Remove {{name}} from myFT"
 				data-alternate-label="Add {{name}} to myFT"
 				aria-pressed="true"

--- a/demos/app.js
+++ b/demos/app.js
@@ -42,6 +42,7 @@ app.engine('.html', new PageKitHandlebars({
 app.use('/public', nExpress.static(path.join(__dirname, '../public'), { redirect: false }));
 
 app.get('/', (req, res) => {
+	res.locals.cacheablePersonalisedUrl = true;
 	res.render('demo', Object.assign({
 		title: 'n-myft-ui demo',
 		flags: {

--- a/demos/templates/demo.html
+++ b/demos/templates/demo.html
@@ -37,6 +37,15 @@
 
 					<h2
 						class="demo-section__title">
+						Unfollow button
+					</h2>
+
+					{{#followButton}}
+						{{> n-myft-ui/components/follow-button/follow-button setFollowButtonStateToSelected=true }}
+					{{/followButton}}
+
+					<h2
+						class="demo-section__title">
 						x-dash follow button
 					</h2>
 

--- a/demos/templates/demo.html
+++ b/demos/templates/demo.html
@@ -26,31 +26,20 @@
 			class="demo-section">
 			<div class="o-grid-row">
 				<div data-o-grid-colspan="12">
-					<h2
-						class="demo-section__title">
-						Follow button
-					</h2>
-
 					{{#followButton}}
+						<h2
+							class="demo-section__title">
+							Follow button
+						</h2>
 						{{> n-myft-ui/components/follow-button/follow-button}}
 					{{/followButton}}
 
-					<h2
-						class="demo-section__title">
-						Unfollow button
-					</h2>
-
 					{{#followButton}}
+						<h2
+							class="demo-section__title">
+							Unfollow button
+						</h2>
 						{{> n-myft-ui/components/follow-button/follow-button setFollowButtonStateToSelected=true }}
-					{{/followButton}}
-
-					<h2
-						class="demo-section__title">
-						x-dash follow button
-					</h2>
-
-					{{#followButton}}
-						{{> n-myft-ui/components/follow-button/follow-button buttonText=name}}
 					{{/followButton}}
 
 					{{#saveButton}}
@@ -94,7 +83,6 @@
 						</h2>
 						{{> n-myft-ui/components/instant-alert/instant-alert }}
 					{{/instantAlert}}
-
 
 				</div>
 			</div>


### PR DESCRIPTION
# Problem
[Jira](https://financialtimes.atlassian.net/browse/CON-2075):  
The label in name criterion requires that the visible label (in this instance ‘added’) be contained in the accessible name (in this instance ‘remove world from myFT’). At the moment they are totally different: "Added" (visual) vs "Remove <Subject> from myFT". 

# Solution

Use the string "Added {{name}} to myFT: click to remove". Here the visual label 'Added' is the first in the aria label. The following information allows the visual impaired users to be aware of the action when clicking the button. 

# How to test
In the demo, you should find a button in the "Added" state. If you inspect it, you can find the aria-label that should say "Added {{name}} to myFT: click to remove".

![Screenshot 2022-12-09 at 11 17 32](https://user-images.githubusercontent.com/107469842/206690976-12ccb035-1691-4d83-8168-1ea340867854.png)
