### PR TITLE
CON-2075: Change the data-alternate-label with new rules of aria-label

### DIFF
--- a/components/follow-button/follow-button.html
+++ b/components/follow-button/follow-button.html
@@ -28,7 +28,7 @@
 			{{#ifAll setFollowButtonStateToSelected @root.cacheablePersonalisedUrl}}
 				aria-label="Added {{name}} to myFT: click to remove"
 				title="Remove {{name}} from myFT"
-				data-alternate-label="Add {{name}} to myFT"
+				data-alternate-label="Add to myFT: {{name}}"
 				aria-pressed="true"
 				{{#if alternateText}}
 					data-alternate-text="{{alternateText}}"
@@ -43,7 +43,7 @@
 				aria-pressed="false"
 				aria-label="Add to myFT: {{name}}"
 				title="Add {{name}} to myFT"
-				data-alternate-label="Remove {{name}} from myFT"
+				data-alternate-label="Added {{name}} to myFT: click to remove"
 				{{#if alternateText}}
 					data-alternate-text="{{alternateText}}"
 				{{else}}


### PR DESCRIPTION
# Problem
[Jira](https://financialtimes.atlassian.net/browse/CON-2075):
The label in name criterion requires that the visible label (in this instance ‘added’) be contained in the accessible name (in this instance ‘remove world from myFT’). At the moment they are totally different: "Added" (visual) vs "Remove from myFT".  

# Solution
Use the string "Added {{name}} to myFT: click to remove". Here the visual label 'Added' is the first in the aria label. The following information allows the visual impaired users to be aware of the action when clicking the button.

The previous solution (see [PR](https://github.com/Financial-Times/n-myft-ui/pull/555)) was actually working very well on the demo but.. not in real .. 
When clicking on a button to add a topic to myFT, a little [toggleState function](https://github.com/Financial-Times/n-myft-ui/blob/main/myft-common/index.js) was using the `data-alternate-label` to set the new `aria-label`. So we had to modify this one as well to make it work

# How to test 

This time, instead of testing in demo, you can use **next-stream-page** and point to the local branch of **n-myft-ui**. 
```
npm install /<PATH>/n-myft-ui
```
Then build and run  **next-stream-page**, and check the page https://local.ft.com:5050/world.  
When toggling between "Add to myFT" and "Added", you should see the aria-label getting changed for "Add to myFT: World" and "Added World to myFT: click to remove".  
Extra point if `data-alternate-label` change for the opposite one (so "Added World to myFT: click to remove" if `aria-label` is set to "Add to myFT: World", and vice versa)

![Screenshot 2022-12-13 at 15 52 30](https://user-images.githubusercontent.com/107469842/207380987-87133958-0e33-418e-936c-d3bd2f8c9a20.png)
