### PR TITLE
CON-2091: Change the data-alternate-label with new rules of aria-label in collection

### DIFF
--- a/components/collections/collections.html
+++ b/components/collections/collections.html
@@ -75,9 +75,9 @@
 						{{~/unless~}}
 					{{~/concepts~}}"
 				aria-label="Add all to myFT: {{title}} collection"
-				data-alternate-label="Remove all topics in the {{title}} collection from my F T"
+				data-alternate-label="Added: click to remove all topics in the {{title}} collection from my FT"
 				data-alternate-text="Added"
-				title="Add all topics in the {{title}} collection to my F T">
+				title="Add all topics in the {{title}} collection to my FT">
 				Add all to myFT
 			</button>
 		</form>


### PR DESCRIPTION
# The problem

[Jira](https://financialtimes.atlassian.net/browse/CON-2091):
The label in name criterion requires that the visible label be contained in the accessible name. 

# Solution

Use the `aria-label` "Add all to myFT:  {{name}} collection" and "Added: click to remove all topics in the {{name}} collection from my FT". 

The previous solution (see [here](https://github.com/Financial-Times/n-myft-ui/pull/554)) was actually working very well on the demo but.. not in real ..
When clicking on a button to add a topic to myFT, a little [toggleState function](https://github.com/Financial-Times/n-myft-ui/blob/main/myft-common/index.js) uses the `data-alternate-label` to set the new `aria-label`. So we have to modify this one as well to make it work.

# How to test it

This time, you can use **next-myft-page** and point to this branch of **n-myft-ui**.
```
npm install /<PATH>/n-myft-ui
```

Then build and run **next-myft-page**, and check the myFT page, at the bottom where the collection cards are.  
When toggling between "Add all to myFT" and "Added", you should see the aria-label getting changed for "Add all to myFT:  {{name}} collection" and "Added: click to remove all topics in the {{name}} collection from my FT".  
Extra point if data-alternate-label change for the opposite one 
![Screenshot 2022-12-13 at 16 50 11](https://user-images.githubusercontent.com/107469842/207394675-3b01039f-7a71-4a3e-9096-aa20da1a7838.png)
