### PR TITLE
Adds style to the label of the save article form

### DIFF
--- a/myft/main.scss
+++ b/myft/main.scss
@@ -366,6 +366,10 @@ $spacing-unit: 20px;
 			}
 		}
 	}
+
+	&-label {
+		margin-top: 10px;
+	}
 }
 
 .share-nav {

--- a/myft/ui/save-article-to-list-variant.js
+++ b/myft/ui/save-article-to-list-variant.js
@@ -171,7 +171,7 @@ function FormElement (createList, showPublicToggle, attachDescription, onListCre
 		<label class="myft-ui-create-list-variant-form-name o-forms-field">
 			<span class="o-forms-input o-forms-input--text">
 				<input class="myft-ui-create-list-variant-text" type="text" name="list-name">
-				List name
+				<div class="myft-ui-create-list-variant-label">List name</div>
 			</span>
 		</label>
 


### PR DESCRIPTION
# The problem

Sooooo this is a bit of a long story.  
It starts with the pipeline of **next-myft-page** failing. There was 2 big reasons for that, and one of them was the need to update `o-normalise` (present in the header). This update is adding a new style to the inputs, giving them a big border on focus.   
In **next-myft-page**, when you unsave and save an article to a list, a dialogue window opens, which uses the `save article to list variant` "component" from **n-myft-ui**. This has a sort of label, and the border of the input comes on top of it: 

<img width="1436" alt="Screenshot 2022-12-20 at 16 27 40" src="https://user-images.githubusercontent.com/107469842/208969161-d0421838-2725-4ae2-be07-b82b5beead79.png">

# The solution

Lee suggested that “Input labels are usually above or to the left of the input. I would recommend using a standard o-forms field for this” (see [here](https://financialtimes.slack.com/archives/C02FU5ARJ/p1671552485990989?thread_ts=1671550538.570259&cid=C02FU5ARJ)). I have created an [issue](https://financialtimes.atlassian.net/jira/software/c/projects/CON/boards/1061?modal=detail&selectedIssue=CON-2210&assignee=62a874c0188d08006fe15f2e) to talk about it. But in the meantime, we want to release the latest change on **next-myft-ui** and fix the pipeline. So this PR is about a little fix that adds a bit of margin between the label and the input. 

# Result 

| Before | After | 
| -- | -- | 
|<img width="1436" alt="Screenshot 2022-12-20 at 16 27 40" src="https://user-images.githubusercontent.com/107469842/208969941-1526ac83-2e94-49a7-b7ff-a2c3e93e252e.png">|<img width="1436" alt="Screenshot 2022-12-21 at 18 22 22" src="https://user-images.githubusercontent.com/107469842/208969979-a8c12d2b-3d7a-4d03-9563-64881232a4a2.png">|


NB: if you were careful enough, you saw that there was another place where the border touches the label of an invalid input. This was told to origami and they should increase the space. 

# How to test it ? 

The easiest way is to pull that branch, use `npm link` or `npm install <path of this branch>` in **next-myft-page** (and rebuild and run **next-myft-page** again). Then go on the url of the saved articles, unsave and save again one of the article and the popup window should appear. You select "Add to new list" and select the input to see the border around. The border should not touch the label. 
