### PR TITLE
bug fix: always add list element to dom so that new lists created within the component appear

### DIFF
--- a/myft/ui/save-article-to-list-variant.js
+++ b/myft/ui/save-article-to-list-variant.js
@@ -125,9 +125,10 @@ export default async function openSaveArticleToListVariant (contentId, options =
 	const resizeHandler = getResizeHandler(createListOverlay.wrapper);
 
 	createListOverlay.wrapper.addEventListener('oOverlay.ready', (data) => {
-		if (lists.length) {
-			const overlayContent = document.querySelector('.o-overlay__content');
-			overlayContent.insertAdjacentElement('afterbegin', listElement);
+		const overlayContent = document.querySelector('.o-overlay__content');
+		overlayContent.insertAdjacentElement('afterbegin', listElement);
+		if (!lists.length) {
+			hideListElement();
 		}
 
 		if (!modal) {


### PR DESCRIPTION
# The change

Currently we conditionally add the list element to our modal if the users has existing lists when opening our modal. However, this means that, if a user goes on to add a list in the modal, the element is not in the DOM to re-render with the new list. 

This PR adds the element always, and conditionally hides it if there are no lists. It already gets unhidden as part of the submit add list process.

# How to test

1. Checkout the branch locally and run `npm link`
2. Locally in next-article, run `npm link @financial-times/n-myft-ui`, then build and run
3. In myft (prod or local), check that you have no lists. If you do and you want to keep them, I can provide a test user 🙂 
4. Visit a local article, e.g. https://local.ft.com:5050/content/f78fb12c-1b90-457d-86c7-efc4df6b0a23. Use the right hand myft bar to open the save article modal. Check that the experience is the same as prod, i.e.
<img width="325" alt="Screenshot 2023-01-16 at 11 12 19" src="https://user-images.githubusercontent.com/54366961/212665082-26b50d58-34d0-436b-98b7-91f126abe73c.png">
5. Add to a new list by filling in the details, and hit add. You should return to the initial modal view, with the new list present, e.g. 
<img width="322" alt="Screenshot 2023-01-16 at 11 14 12" src="https://user-images.githubusercontent.com/54366961/212665368-f214e5c9-a70e-4bd0-a7b7-234c15f7704e.png">
6. Add more lists and check that they appear.
7. Close the modal and reopen. The lists should appear, e.g. 
<img width="318" alt="Screenshot 2023-01-16 at 11 15 11" src="https://user-images.githubusercontent.com/54366961/212665556-ee7188f7-8c8f-4fa3-8c8a-71e650795569.png">
