### PR TITLE
ug-1103 - bug fix: move delegate creation inside init function 

### DIFF
--- a/myft/ui/myft-buttons/init.js
+++ b/myft/ui/myft-buttons/init.js
@@ -8,9 +8,16 @@ import Delegate from 'ftdomdelegate';
 import personaliseLinks from '../personalise-links';
 import doFormSubmit from './do-form-submit';
 import enhanceActionUrls from './enhance-action-urls';
+import readyState from 'ready-state';
 
-const delegate = new Delegate(document.body);
 let initialised;
+
+function createDelegate (action, selector, cb) {
+	readyState.domready.then(() => {
+		const delegate = new Delegate(document.body);
+		delegate.on(action, selector, cb);
+	});
+}
 
 function getInteractionHandler (relationshipName) {
 	return (ev, formEl) => {
@@ -29,7 +36,7 @@ function anonEventListeners () {
 	};
 
 	['followed', 'saved'].forEach(action => {
-		delegate.on('submit', relationshipConfig[action].uiSelector, event => {
+		createDelegate('submit', relationshipConfig[action].uiSelector, event => {
 			event.preventDefault();
 			nNotification.show({
 				content: messages[action],
@@ -77,7 +84,7 @@ function signedInEventListeners () {
 					});
 				});
 
-			delegate.on('submit', uiSelector, getInteractionHandler(relationshipName));
+			createDelegate('submit', uiSelector, getInteractionHandler(relationshipName));
 		}
 	});
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "js-cookie": "^2.2.1",
         "next-myft-client": "^10.3.0",
         "next-session-client": "^4.0.0",
+        "ready-state": "^2.0.5",
         "superstore-sync": "^2.1.1"
       },
       "devDependencies": {
@@ -18143,6 +18144,11 @@
       "engines": {
         "node": ">=0.10"
       }
+    },
+    "node_modules/ready-state": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/ready-state/-/ready-state-2.0.5.tgz",
+      "integrity": "sha512-rwuszAC+hAAhQWK0alQOSq0Fa5/SO9XvbzVY/Ki82d1ocwLY7kdjEooVbYg7GELrCXySckTmsuTgLd8hqKz9Og=="
     },
     "node_modules/rechoir": {
       "version": "0.7.1",
@@ -38038,6 +38044,11 @@
         "micromatch": "^3.1.10",
         "readable-stream": "^2.0.2"
       }
+    },
+    "ready-state": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/ready-state/-/ready-state-2.0.5.tgz",
+      "integrity": "sha512-rwuszAC+hAAhQWK0alQOSq0Fa5/SO9XvbzVY/Ki82d1ocwLY7kdjEooVbYg7GELrCXySckTmsuTgLd8hqKz9Og=="
     },
     "rechoir": {
       "version": "0.7.1",

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "js-cookie": "^2.2.1",
     "next-myft-client": "^10.3.0",
     "next-session-client": "^4.0.0",
+    "ready-state": "^2.0.5",
     "superstore-sync": "^2.1.1"
   },
   "volta": {


### PR DESCRIPTION
### Description

We received reports of users regularly getting the core experience when interacting with the save article component. This PR aims to improve the situation by doing the following:

- Moves the DOM delegate into the init function of the buttons. This means that is should only be run after the DOM is ready (i.e. emitted the DOMContentLoaded event), as this is listened for before initialising components. 
- Checks the ready state of the DOM in case it still isn't ready, and adds an event listener to create the delegate if not.
- Moves this into a function that any of the buttons' init functions can use

However, it should be noted that people with exceptionally slow download speeds may still get the core experience as they will be able to interact with the SSR button before any client side javascript has had the chance to run.

### How to test

It's difficult to test that it fixes the bug, because it's very difficult to reproduce it! 

First try to run next-article locally and replicate the issue. I found it appears for me if I throttle my bandwidth to fast 3G in dev tools (making sure to wait until the page has loaded - this will catch the bug where the delegate has failed). Also make sure that you have disabled your cache.

1. Clone the branch locally and run `npm link`
2. In next-article run `npm link @financial-times/n-myft-ui`, build and run
3. With the same speed, test that the saved modal appears (once the page has fully loaded). 
4. Try will a slower speed/before the client-side javascript has loaded (or disable it), the core experience should still work

### Screenshots
Before:
<img width="937" alt="Screenshot 2023-01-23 at 16 15 35" src="https://user-images.githubusercontent.com/54366961/214093546-d0dd9f97-5d46-423c-86cc-8dfc8a06eb61.png">

After:
<img width="341" alt="Screenshot 2023-01-23 at 16 21 30" src="https://user-images.githubusercontent.com/54366961/214093583-aecd1c08-5133-41ce-9bbd-bb46715e4479.png">

