### PR TITLE
UG-1127 Public lists post test cleanup

### DIFF
--- a/components/save-for-later/save-for-later.html
+++ b/components/save-for-later/save-for-later.html
@@ -5,7 +5,7 @@
 	action="/myft/save/{{contentId}}"
 	data-js-action="/__myft/api/core/saved/content/{{contentId}}?method=put"
 	{{#if @root.flags.manageArticleLists}}data-myft-ui-save-new="manageArticleLists"{{/if}}
-	{{#if @root.flags.manageArticleLists}}data-myft-ui-save-new-config="{{#if @root.flags.myftListPublicPrivateToggle}}showPublicToggle{{/if}},{{#if modal}}modal{{/if}}"{{/if}}>
+	{{#if @root.flags.manageArticleLists}}data-myft-ui-save-new-config="{{#if modal}}modal{{/if}}"{{/if}}>
 	{{> n-myft-ui/components/csrf-token/input}}
 	<div
 		class="n-myft-ui__announcement o-normalise-visually-hidden"

--- a/myft/ui/lists.js
+++ b/myft/ui/lists.js
@@ -187,10 +187,9 @@ function showArticleSavedOverlay (contentId) {
 	showListsOverlay('Article saved', `/myft/list?fragment=true&fromArticleSaved=true&contentId=${contentId}`, contentId);
 }
 
-function showCreateListAndAddArticleOverlay (contentId, config) {
+function showCreateListAndAddArticleOverlay (contentId) {
 	const options = {
 		name: 'myft-ui-create-list-variant',
-		...config
 	};
 
 	return openSaveArticleToListVariant(contentId, options);
@@ -206,11 +205,11 @@ function handleArticleSaved (contentId) {
 		});
 }
 
-function openCreateListAndAddArticleOverlay (contentId, config) {
+function openCreateListAndAddArticleOverlay (contentId) {
 	return myFtClient.getAll('created', 'list')
 		.then(createdLists => createdLists.filter(list => !list.isRedirect))
 		.then(() => {
-			return showCreateListAndAddArticleOverlay(contentId, config);
+			return showCreateListAndAddArticleOverlay(contentId);
 		});
 }
 
@@ -284,8 +283,6 @@ function initialEventListeners () {
 		// otherwise it will show the classic overlay
 		const newListDesign = event.currentTarget.querySelector('[data-myft-ui-save-new="manageArticleLists"]');
 		if (newListDesign) {
-			const configKeys = newListDesign.dataset.myftUiSaveNewConfig.split(',');
-			const config = configKeys.reduce((configObj, key) => (key ? { ...configObj, [key]: true} : configObj), {});
 
 			// Temporary events on the public toggle feature.
 			// These will be used to build a sanity check dashboard, and will be removed after we get clean-up this test.
@@ -300,7 +297,7 @@ function initialEventListeners () {
 				bubbles: true
 			}));
 
-			return openCreateListAndAddArticleOverlay(contentId, config);
+			return openCreateListAndAddArticleOverlay(contentId);
 		}
 
 		handleArticleSaved(contentId);

--- a/myft/ui/lists.js
+++ b/myft/ui/lists.js
@@ -288,7 +288,7 @@ function initialEventListeners () {
 			// These will be used to build a sanity check dashboard, and will be removed after we get clean-up this test.
 			document.body.dispatchEvent(new CustomEvent('oTracking.event', {
 				detail: {
-					category: 'publicToggle',
+					category: 'lists',
 					action: 'savedArticle',
 					article_id: contentId,
 					teamName: 'customer-products-us-growth',

--- a/myft/ui/lists.js
+++ b/myft/ui/lists.js
@@ -187,9 +187,10 @@ function showArticleSavedOverlay (contentId) {
 	showListsOverlay('Article saved', `/myft/list?fragment=true&fromArticleSaved=true&contentId=${contentId}`, contentId);
 }
 
-function showCreateListAndAddArticleOverlay (contentId) {
+function showCreateListAndAddArticleOverlay (contentId, config) {
 	const options = {
 		name: 'myft-ui-create-list-variant',
+		...config
 	};
 
 	return openSaveArticleToListVariant(contentId, options);
@@ -205,11 +206,11 @@ function handleArticleSaved (contentId) {
 		});
 }
 
-function openCreateListAndAddArticleOverlay (contentId) {
+function openCreateListAndAddArticleOverlay (contentId, config) {
 	return myFtClient.getAll('created', 'list')
 		.then(createdLists => createdLists.filter(list => !list.isRedirect))
 		.then(() => {
-			return showCreateListAndAddArticleOverlay(contentId);
+			return showCreateListAndAddArticleOverlay(contentId, config);
 		});
 }
 
@@ -283,6 +284,8 @@ function initialEventListeners () {
 		// otherwise it will show the classic overlay
 		const newListDesign = event.currentTarget.querySelector('[data-myft-ui-save-new="manageArticleLists"]');
 		if (newListDesign) {
+			const configKeys = newListDesign.dataset.myftUiSaveNewConfig.split(',');
+			const config = configKeys.reduce((configObj, key) => (key ? { ...configObj, [key]: true} : configObj), {});
 
 			// Temporary events on the public toggle feature.
 			// These will be used to build a sanity check dashboard, and will be removed after we get clean-up this test.
@@ -297,7 +300,7 @@ function initialEventListeners () {
 				bubbles: true
 			}));
 
-			return openCreateListAndAddArticleOverlay(contentId);
+			return openCreateListAndAddArticleOverlay(contentId, config);
 		}
 
 		handleArticleSaved(contentId);

--- a/myft/ui/save-article-to-list-variant.js
+++ b/myft/ui/save-article-to-list-variant.js
@@ -177,20 +177,20 @@ function FormElement (createList, attachDescription, onListCreated, onCancel, mo
 		</label>
 
 		<div class="myft-ui-create-list-variant-form-public o-forms-field" role="group">
-				<span class="o-forms-input o-forms-input--toggle">
-					<label>
-						<input class="myft-ui-create-list-variant-form-toggle" type="checkbox" name="is-public" value="public" checked data-trackable="private-link" text="private">
-						<span class="myft-ui-create-list-variant-form-toggle-label o-forms-input__label">
-							<span class="o-forms-input__label__main">
-								Public
-							</span>
-							<span id="myft-ui-create-list-variant-form-public-description" class="o-forms-input__label__prompt">
-								Your profession & list will be visible to others
-							</span>
+			<span class="o-forms-input o-forms-input--toggle">
+				<label>
+					<input class="myft-ui-create-list-variant-form-toggle" type="checkbox" name="is-public" value="public" checked data-trackable="private-link" text="private">
+					<span class="myft-ui-create-list-variant-form-toggle-label o-forms-input__label">
+						<span class="o-forms-input__label__main">
+							Public
 						</span>
-					</label>
-				</span>
-			</div>
+						<span id="myft-ui-create-list-variant-form-public-description" class="o-forms-input__label__prompt">
+							Your profession & list will be visible to others
+						</span>
+					</span>
+				</label>
+			</span>
+		</div>
 
 		<div class="myft-ui-create-list-variant-form-buttons">
 			<button class="o-buttons o-buttons--primary o-buttons--inverse o-buttons--big" type="button" data-trackable="cancel-link" text="cancel">

--- a/myft/ui/save-article-to-list-variant.js
+++ b/myft/ui/save-article-to-list-variant.js
@@ -14,7 +14,7 @@ let scrolledOnOpen;
 let listOverlayBottom;
 
 export default async function openSaveArticleToListVariant (contentId, options = {}) {
-	const { name, showPublicToggle = false, modal = false } = options;
+	const { name, modal = false } = options;
 
 	function createList (newList, cb) {
 		if(!newList || !newList.name) {
@@ -112,7 +112,7 @@ export default async function openSaveArticleToListVariant (contentId, options =
 
 	function openFormHandler () {
 		hideListElement();
-		const formElement = FormElement(createList, showPublicToggle, attachDescription, onFormListCreated, onFormCancel, modal);
+		const formElement = FormElement(createList, attachDescription, onFormListCreated, onFormCancel, modal);
 		const overlayContent = document.querySelector('.o-overlay__content');
 		removeDescription();
 		overlayContent.insertAdjacentElement('beforeend', formElement);
@@ -166,7 +166,7 @@ function getResizeHandler (target) {
 	};
 }
 
-function FormElement (createList, showPublicToggle, attachDescription, onListCreated, onCancel, modal=false) {
+function FormElement (createList, attachDescription, onListCreated, onCancel, modal=false) {
 	const formString = `
 	<form class="myft-ui-create-list-variant-form">
 		<label class="myft-ui-create-list-variant-form-name o-forms-field">
@@ -176,8 +176,7 @@ function FormElement (createList, showPublicToggle, attachDescription, onListCre
 			</span>
 		</label>
 
-		${showPublicToggle ?
-		`<div class="myft-ui-create-list-variant-form-public o-forms-field" role="group">
+		<div class="myft-ui-create-list-variant-form-public o-forms-field" role="group">
 				<span class="o-forms-input o-forms-input--toggle">
 					<label>
 						<input class="myft-ui-create-list-variant-form-toggle" type="checkbox" name="is-public" value="public" checked data-trackable="private-link" text="private">
@@ -191,9 +190,7 @@ function FormElement (createList, showPublicToggle, attachDescription, onListCre
 						</span>
 					</label>
 				</span>
-			</div>` :
-		''
-}
+			</div>
 
 		<div class="myft-ui-create-list-variant-form-buttons">
 			<button class="o-buttons o-buttons--primary o-buttons--inverse o-buttons--big" type="button" data-trackable="cancel-link" text="cancel">
@@ -242,9 +239,7 @@ function FormElement (createList, showPublicToggle, attachDescription, onListCre
 	formElement.querySelector('button[type="submit"]').addEventListener('click', handleSubmit);
 	formElement.querySelector('button[type="button"]').addEventListener('click', handleCancelClick);
 
-	if (showPublicToggle) {
-		addPublicToggleListener(formElement);
-	}
+	addPublicToggleListener(formElement);
 
 	return formElement;
 }

--- a/myft/ui/save-article-to-list-variant.js
+++ b/myft/ui/save-article-to-list-variant.js
@@ -230,7 +230,6 @@ function FormElement (createList, attachDescription, onListCreated, onCancel, mo
 	function handleCancelClick (event) {
 		event.preventDefault();
 		event.stopPropagation();
-		triggerCancelEvent();
 		formElement.remove();
 		if (!lists.length) attachDescription();
 		onCancel();
@@ -248,7 +247,6 @@ function addPublicToggleListener (formElement) {
 	function onPublicToggleClick (event) {
 		event.target.setAttribute('data-trackable', event.target.checked ? 'private-link' : 'public-link');
 		event.target.setAttribute('text', event.target.checked ? 'private' : 'public');
-		triggerPublicToggleEvent(event.target.checked);
 	}
 
 	formElement.querySelector('input[name="is-public"]').addEventListener('click', onPublicToggleClick);
@@ -485,39 +483,11 @@ function triggerCreateListEvent (contentId, listId) {
 
 // Temporary event on the public toggle feature.
 // These will be used to build a sanity check dashboard, and will be removed after we get clean-up this test.
-function triggerPublicToggleEvent (isPublic) {
-	document.body.dispatchEvent(new CustomEvent('oTracking.event', {
-		detail: {
-			category: 'publicToggle',
-			action: `${isPublic ? 'setPublic' : 'setPrivate'}`,
-			teamName: 'customer-products-us-growth',
-			amplitudeExploratory: true
-		},
-		bubbles: true
-	}));
-}
-
-// Temporary event on the public toggle feature.
-// These will be used to build a sanity check dashboard, and will be removed after we get clean-up this test.
 function triggerAddToNewListEvent () {
 	document.body.dispatchEvent(new CustomEvent('oTracking.event', {
 		detail: {
 			category: 'publicToggle',
 			action: 'addToNewList',
-			teamName: 'customer-products-us-growth',
-			amplitudeExploratory: true
-		},
-		bubbles: true
-	}));
-}
-
-// Temporary event on the public toggle feature.
-// These will be used to build a sanity check dashboard, and will be removed after we get clean-up this test.
-function triggerCancelEvent () {
-	document.body.dispatchEvent(new CustomEvent('oTracking.event', {
-		detail: {
-			category: 'publicToggle',
-			action: 'cancel ',
 			teamName: 'customer-products-us-growth',
 			amplitudeExploratory: true
 		},


### PR DESCRIPTION
### Description
As a result of the public/private lists test being successful, the public/private toggle feature is now ready to be shipped to all users. This PR involves removing any config that was created for the test.

### Ticket
https://financialtimes.atlassian.net/browse/UG-1127

### How to test
1. checkout this branch locally
2. run `make install` and then run `npm link`
3. Clone `next-article` , run `npm install` and then run `npm link @financial-times/n-myft-ui`
4. Run `npm run watch` on `next-article`
5. Make sure you’re logged in on Vault and run next-article in a new terminal with `npm start`
6. Go to any article and click on “Save”. The modal should appear next to the ShaveNav menu.
7. click "add to a new list" and you should see the public/private toggle
8. click the toggle to ensure it switches between public and private
9. save the article to a new list and visit https://local.ft.com:5050/myft/lists/ to ensure that the list has been saved successfully.