### PR TITLE
CI-1517 feat: add inverse-monochrome theme

### DIFF
--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -42,6 +42,12 @@ $system-code: "n-myft-ui-demo";
 	background-color: oColorsByName('claret-60');
 	color: oColorsByName('white');
 }
+
+.concept-collection--inverse-monochrome {
+	background-color: oColorsByName('white');
+	color: oColorsByName('black');
+}
+
 .concept-collection--alphaville {
 	background-color: oColorsByName('matisse');
 	color: oColorsByName('white');

--- a/demos/templates/demo.html
+++ b/demos/templates/demo.html
@@ -214,6 +214,41 @@
 
 			<div class="o-grid-row">
 				<div data-o-grid-colspan="12">
+					<div class="concept-collection concept-collection--inverse-monochrome">
+						<h3 class="concept-collection__title">
+							Inverse Monochrome
+						</h3>
+						<ul class="concept-collection__list">
+							<li>
+								<button
+									class="n-myft-follow-button n-myft-follow-button--inverse-monochrome"
+									aria-pressed="false">
+									Theo Leanse
+								</button>
+							</li>
+							<li>
+								<button
+									class="n-myft-follow-button n-myft-follow-button--inverse-monochrome"
+									aria-pressed="true">
+									Mr. and Mrs. Dursley, of number four, Privet Drive, were proud to
+									say that they were perfectly normal, thank you very much.
+								</button>
+							</li>
+							<li>
+								<button
+									disabled
+									class="n-myft-follow-button n-myft-follow-button--inverse-monochrome"
+									aria-pressed="true">
+									chee
+								</button>
+							</li>
+						</ul>
+					</div>
+				</div>
+			</div>
+
+			<div class="o-grid-row">
+				<div data-o-grid-colspan="12">
 					<div class="concept-collection concept-collection--opinion">
 						<h3 class="concept-collection__title">
 							Opinion topper
@@ -419,6 +454,42 @@
 								<a
 									disabled
 									class="n-myft-concept-pill n-myft-concept-pill--monochrome"
+									aria-pressed="true">
+									chee
+								</a>
+							</li>
+						</ul>
+					</div>
+				</div>
+			</div>
+
+			<div class="o-grid-row">
+				<div data-o-grid-colspan="12">
+					<div class="concept-collection concept-collection--inverse-monochrome">
+						<h3 class="concept-collection__title">
+							Inverse Monochrome
+						</h3>
+
+						<ul class="concept-collection__list">
+							<li>
+								<a
+									class="n-myft-concept-pill n-myft-concept-pill--inverse-monochrome"
+									aria-pressed="false">
+									Theo Leanse
+								</a>
+							</li>
+							<li>
+								<a
+									class="n-myft-concept-pill n-myft-concept-pill--inverse-monochrome"
+									aria-pressed="false">
+									Mr. and Mrs. Dursley, of number four, Privet Drive, were proud to
+									say that they were perfectly normal, thank you very much.
+								</a>
+							</li>
+							<li>
+								<a
+									disabled
+									class="n-myft-concept-pill n-myft-concept-pill--inverse-monochrome"
 									aria-pressed="true">
 									chee
 								</a>

--- a/mixins/lozenge/_themes.scss
+++ b/mixins/lozenge/_themes.scss
@@ -32,6 +32,14 @@ $myft-lozenge-themes: (
 		pressed-highlight: rgba(oColorsByName('white'), 0.2),
 		disabled: rgba(oColorsByName('white'), 0.5),
 	),
+	inverse-monochrome: (
+		toggle-button-theme: ('color': 'black'),
+		background: oColorsByName('black'),
+		text: oColorsByName('white'),
+		highlight: oColorsByName('black-80'),
+		pressed-highlight: rgba(oColorsByName('black'), 0.2),
+		disabled: rgba(oColorsByName('black'), 0.5),
+	),
 	alphaville: (
 		toggle-button-theme: 'inverse',
 		background: oColorsByName('white'),


### PR DESCRIPTION
For a [topper variation](https://financialtimes.atlassian.net/browse/CI-1517) we need to introduce a new theme for the myFT follow button.

The new theme called **Inverse Monochrome** [has been introduced in Origami for the ft-concept-button](https://github.com/Financial-Times/origami/pull/1009) but next-article relies on this package to show myFT buttons.

This PR [ports the changes from Origami](https://github.com/Financial-Times/origami/pull/1009/files#diff-acc4bf0d1766d58b1dd64d59615ed6e4869207d4d8a329931ea81b15f42282e0R42) and add demo elements accordingly

**New Inverse Monochrome variations in the demo** 

![image](https://user-images.githubusercontent.com/752680/220344174-9ee72fc6-a3b0-4a45-8edc-f7088039bbea.png)

![image](https://user-images.githubusercontent.com/752680/220344237-d4cad9f5-73d3-4b46-acd8-ceb15b606966.png)
