### PR TITLE
UG-1156 Add data-trackable to add and close buttons

### DIFF
--- a/myft/ui/lists.js
+++ b/myft/ui/lists.js
@@ -87,6 +87,11 @@ async function openSaveArticleToList (contentId, options = {}) {
 		class: 'myft-ui-create-list',
 	});
 
+	function addCloseButtonDataTrackable () {
+		const closeBtn = document.querySelector('.o-overlay__close');
+		closeBtn.setAttribute('data-trackable', 'close-button'); 
+	}
+
 	function outsideClickHandler (e) {
 		const overlayContent = document.querySelector('.o-overlay__content');
 		const overlayContainer = document.querySelector('.o-overlay');
@@ -150,6 +155,8 @@ async function openSaveArticleToList (contentId, options = {}) {
 
 		document.body.removeEventListener('click', outsideClickHandler);
 	});
+
+	addCloseButtonDataTrackable()
 }
 
 function getScrollHandler (target) {
@@ -192,7 +199,7 @@ function FormElement (createList, attachDescription, onListCreated, onCancel, mo
 			<button class="o-buttons o-buttons--primary o-buttons--inverse o-buttons--big" type="button" data-trackable="cancel-link" text="cancel">
 			Cancel
 			</button>
-			<button class="o-buttons o-buttons--big o-buttons--secondary" type="submit">
+			<button class="o-buttons o-buttons--big o-buttons--secondary" type="submit" data-trackable="add-button">
 			Add
 			</button>
 		</div>

--- a/myft/ui/lists.js
+++ b/myft/ui/lists.js
@@ -89,7 +89,7 @@ async function openSaveArticleToList (contentId, options = {}) {
 
 	function addCloseButtonDataTrackable () {
 		const closeBtn = document.querySelector('.o-overlay__close');
-		closeBtn.setAttribute('data-trackable', 'close-button'); 
+		closeBtn.setAttribute('data-trackable', 'close-button');
 	}
 
 	function outsideClickHandler (e) {
@@ -156,7 +156,7 @@ async function openSaveArticleToList (contentId, options = {}) {
 		document.body.removeEventListener('click', outsideClickHandler);
 	});
 
-	addCloseButtonDataTrackable()
+	addCloseButtonDataTrackable();
 }
 
 function getScrollHandler (target) {


### PR DESCRIPTION
### Description
add data-trackable to the add and close buttons on the `save article to list` journey as requested by the analytics team. This will help to record more accurate numbers on the [Amplitude chart](https://analytics.eu.amplitude.com/ftdotcom/chart/e-aamt7sa?source=copy+url)

### Ticket
https://financialtimes.atlassian.net/browse/UG-1156

### How to test
1. clone this repo and run `npm install`
2. then run `npm link`
3. open a new terminal and clone `next-article`
4. in next-article, run `npm install` then `npm link @financial-times/n-myft-ui`
5. run `npm run watch`
6. open a new terminal `cd` into `next-article` and run `npm start`
7. visit an article page on https://local.ft.com:5050/ 
8. click the "save" button to open the 'save article to list' modal 
9. open dev tools, click on the `network` tab and type `ingest` into the filter bar
10. complete the form and click on the `add` button to submit the form
11. check the network tab for the add button `cta:click` event and ensure that the `data-trackable: "add-button"` is present.
12. re-open the modal and click the close button
13. check the network tab for the close button `cta:click` event and ensure that the `data-trackable: "close-button"` is present.