### PR TITLE
ug-1233 check for existence of get method

### DIFF
--- a/myft/ui/myft-buttons/init.js
+++ b/myft/ui/myft-buttons/init.js
@@ -37,7 +37,7 @@ function anonEventListeners (flags = {}) {
 
 	// 11/5/23 - US Growth test for Free Article Demand, see https://financialtimes.atlassian.net/browse/UG-1191
 	// This will be cleaned up after the test as part of https://financialtimes.atlassian.net/browse/UG-1221
-	if (flags.get('podcastReferral')) {
+	if (flags.get && flags.get('podcastReferral')) {
 		messages.saved = `<a href="/register/access?multistepRegForm=multistep" data-trackable="Register">Register</a> for free or  <a href="${signInLink}" data-trackable="Sign In">sign in</a> in to save this article`;
 	};
 


### PR DESCRIPTION
Bug fix to address comments in https://github.com/Financial-Times/n-myft-ui/pull/580. If `opts.flags` is empty, a default object will be used, which won't have the get method on it. We therefore need to check for the get method as well as  evaluating it.