### PR TITLE
[CON-2746] - Migrate to Node v18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ references:
       - image: cimg/node:<< parameters.node-version >>-browsers
     parameters:
       node-version:
-        default: "16.14"
+        default: "18.17"
         type: string
 
   workspace_root: &workspace_root ~/project
@@ -71,8 +71,8 @@ jobs:
       - run:
           name: Checkout next-ci-shared-helpers
           command: git clone --depth 1
-            git@github.com:Financial-Times/next-ci-shared-helpers.git
-            .circleci/shared-helpers
+            git@github.com:Financial-Times/next-ci-shared-helpers.git --branch
+            unpin-heroku .circleci/shared-helpers
       - *restore_npm_cache
       - run:
           name: Install project dependencies
@@ -142,7 +142,7 @@ workflows:
           name: build-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: ["16.14"]
+              node-version: [ "16.20", "18.17" ]
       - test:
           filters:
             <<: *filters_ignore_tags
@@ -151,12 +151,12 @@ workflows:
           name: test-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: ["16.14"]
+              node-version: [ "16.20", "18.17" ]
       - deploy:
           filters:
             <<: *filters_only_main
           requires:
-            - build-v16.14
+            - build-v18.17
   build-test-publish:
     jobs:
       - build:
@@ -166,7 +166,7 @@ workflows:
           name: build-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: ["16.14"]
+              node-version: [ "16.20", "18.17" ]
       - test:
           filters:
             <<: *filters_version_tag
@@ -175,13 +175,13 @@ workflows:
           name: test-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: ["16.14"]
+              node-version: [ "16.20", "18.17" ]
       - publish:
           context: npm-publish-token
           filters:
             <<: *filters_version_tag
           requires:
-            - test-v16.14
+            - test-v18.17
 
   nightly:
     triggers:
@@ -195,7 +195,7 @@ workflows:
           name: build-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: ["16.14"]
+              node-version: [ "16.20", "18.17" ]
       - test:
           requires:
             - build-v<< matrix.node-version >>
@@ -203,7 +203,7 @@ workflows:
           name: test-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: ["16.14"]
+              node-version: [ "16.20", "18.17" ]
 
 notify:
   webhooks:

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,14 @@ node_modules/@financial-times/n-gage/index.mk:
 
 -include node_modules/@financial-times/n-gage/index.mk
 
+NODE_VERSION := $(shell node --version)
+NODE_MAJOR_VERSION := $(shell echo $(NODE_VERSION) | cut -c2-3)
+ifeq ($(NODE_MAJOR_VERSION),18)
+	NODE_OPTS := "--openssl-legacy-provider --dns-result-order=ipv4first"
+endif
+
 run:
-	node _test-server/app
+	@node _test-server/app
 
 demo-build:
 	@rm -rf node_modules/@financial-times/n-myft-ui
@@ -22,10 +28,10 @@ static-demo: demo-build
 	@scripts/make-static-demo.sh
 
 test-build:
-	NODE_OPTIONS="--openssl-legacy-provider" webpack --mode=development
+	NODE_OPTIONS=$(NODE_OPTS) webpack --mode=development
 
 test-unit:
-	node_modules/karma/bin/karma start
+	NODE_OPTIONS=$(NODE_OPTS) node_modules/karma/bin/karma start
 
 a11y: demo-build
 	@node .pa11yci.js

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ static-demo: demo-build
 	@scripts/make-static-demo.sh
 
 test-build:
-	webpack --mode=development
+	NODE_OPTIONS="--openssl-legacy-provider" webpack --mode=development
 
 test-unit:
 	node_modules/karma/bin/karma start

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "@financial-times/n-myft-ui",
       "version": "0.0.0",
-      "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
         "date-fns": "2.16.1",
@@ -87,7 +86,7 @@
         "webpack-cli": "^4.9.2"
       },
       "engines": {
-        "node": "16.x",
+        "node": "16.x || 18.x",
         "npm": "7.x || 8.x || 9.x"
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "commit": "commit-wizard",
-    "prepare": "npx snyk protect || npx snyk protect -d || true",
-    "preinstall": "[ \"$INIT_CWD\" != \"$PWD\" ] || npm_config_yes=true npx check-engine"
+    "prepare": "npx snyk protect || npx snyk protect -d || true"
   },
   "repository": {
     "type": "git",
@@ -110,11 +109,10 @@
     "superstore-sync": "^2.1.1"
   },
   "volta": {
-    "node": "16.14.2",
-    "npm": "7.24.2"
+    "node": "18.17.0"
   },
   "engines": {
-    "node": "16.x",
+    "node": "16.x || 18.x",
     "npm": "7.x || 8.x || 9.x"
   },
   "x-dash": {


### PR DESCRIPTION
**Description**

PR to achieve upgrade to Node v18. This is part of [migrating to Node v.18 Initiative](https://financialtimes.atlassian.net/browse/CON-2706).

In order to achieve the migration, it has been used the following [migration script](https://github.com/Financial-Times/platform-scripts/tree/7c571c9e8e5e452e6cf16f36fc44b0769c71551f/upgrade-node-18).