### PR TITLE
PT-234 Instant Alerts Onboarding Popup

### DIFF
--- a/components/jsx/preferences-modal/main.scss
+++ b/components/jsx/preferences-modal/main.scss
@@ -1,0 +1,42 @@
+@import '@financial-times/o-colors/main';
+@import '@financial-times/o-forms/main';
+@include oForms();
+
+.n-myft-ui__preferences-modal {
+	background-color: oColorsByName('white-80');
+	border-radius: 10px;
+	border: 2px solid oColorsByName('black-5');
+	width: 275px;
+}
+
+.n-myft-ui__preferences-modal__content {
+	position: relative;
+	margin: 20px 20px 24px;
+}
+
+.n-myft-ui__preferences-modal__checkbox__message {
+	@include oTypographySans($scale: 0, $weight: 'semibold', $style: 'normal');
+}
+
+.n-myft-ui__preferences-modal__text {
+	@include oTypographySans($scale: -1, $weight: 'regular', $style: 'normal');
+	margin-bottom: 0;
+}
+
+.n-myft-ui__preferences-modal__remove-button {
+	margin-top: 20px;
+	height: 32px;
+	width: 100%;
+	border-radius: 20px;
+	border: 2px solid oColorsByName('black-20');
+	background-color: oColorsByName('white-80');
+	@include oTypographySans($scale: -1, $weight: 'regular', $style: 'normal');
+	color: oColorsByName('black-80');
+}
+
+.n-myft-ui__preferences-modal__remove-button:hover,
+.n-myft-ui__preferences-modal__remove-button:focus {
+	border: 2px solid oColorsByName('claret-60');
+	background-color: oColorsMix($color: 'claret-60', $percentage: 20);
+	color: oColorsByName('claret-60');
+}

--- a/components/jsx/preferences-modal/preferences-modal.jsx
+++ b/components/jsx/preferences-modal/preferences-modal.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+
+/**
+ * @typedef {object} PreferencesProperties
+ * @property {string[]} currentPreferences
+ * Current alert preferences the user has set up.
+ * @property {object.<string, boolean>} flags
+ * 	FT.com feature flags
+ */
+
+/**
+ * Create a popup modal to manage myFT alert preferences
+ * @public
+ * @param {PreferencesProperties}
+ * @returns {React.ReactElement}
+*/
+export default function InstantAlertsPreferencesModal({ flags, currentPreferences }) {
+	if (!flags.myFtApiWrite) {
+		return null;
+	}
+
+	const formattedCurrentPreferences = currentPreferences.join(', ')
+	return (
+		<div className="n-myft-ui__preferences-modal">
+			<div className="n-myft-ui__preferences-modal__content">
+					<span className="o-forms-input o-forms-input--checkbox">
+						<label htmlFor="receive-instant-alerts">
+							<input id="receive-instant-alerts" type="checkbox" name="receive-instant-alerts" value="receive-instant-alerts"/>
+							<span className="o-forms-input__label n-myft-ui__preferences-modal__checkbox__message">
+								Get instant alerts for this topic
+							</span>
+						</label>
+					</span>
+
+				<p className="n-myft-ui__preferences-modal__text">Your alerts are currently: {formattedCurrentPreferences}.</p>
+				<a className="n-myft-ui__preferences-modal__text" href="/myft/alerts">Manage your preferences here</a>
+				<button className="n-myft-ui__preferences-modal__remove-button">Remove from myFT</button>
+			</div>
+		</div>
+	);
+};

--- a/demos/app.js
+++ b/demos/app.js
@@ -15,7 +15,8 @@ const fixtures = {
 	conceptList: require('./fixtures/concept-list'),
 	pinButton: require('./fixtures/pin-button'),
 	instantAlert: require('./fixtures/instant-alert'),
-	followPlusInstantAlerts: require('./fixtures/jsx/follow-plus-instant-alerts')
+	followPlusInstantAlerts: require('./fixtures/jsx/follow-plus-instant-alerts'),
+	instantAlertsPreferencesModal: require('./fixtures/jsx/preferences-modal'),
 };
 
 const app = module.exports = nExpress({

--- a/demos/fixtures/jsx/preferences-modal.json
+++ b/demos/fixtures/jsx/preferences-modal.json
@@ -1,0 +1,3 @@
+{
+    "currentPreferences": ["email", "desktop"]
+}

--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -9,6 +9,7 @@ $system-code: "n-myft-ui-demo";
 @import '../../components/follow-button/main';
 @import '../../components/jsx/follow-plus-instant-alerts/main';
 @import '../../components/onboarding-cta/main';
+@import '../../components/jsx/preferences-modal/main';
 
 @import '../../components/digest-promo/main';
 .n-myft-digest-promo {

--- a/demos/templates/demo.html
+++ b/demos/templates/demo.html
@@ -29,6 +29,16 @@
 
 				<div data-o-grid-colspan="12">
 					<h2>JSX components</h2>
+
+					{{#instantAlertsPreferencesModal}}
+						<h3
+							class="demo-section__title">
+							Instant alerts popup to manage preferences
+						</h3>
+
+						{{{renderReactComponent localPath="components/jsx/preferences-modal/preferences-modal.jsx" flags=@root.flags}}}
+					{{/instantAlertsPreferencesModal}}
+
 					{{#followPlusInstantAlerts}}
 						<h3
 							class="demo-section__title">


### PR DESCRIPTION
### Description:
This PR implements the instant alerts onboarding pop up modal. It will be opened when clicked on the component implemented in this related PR (https://github.com/Financial-Times/n-myft-ui/pull/590)

For now, this is just a modal that matches designs. The modal has been added to the demo. We will be implementing the functionality to open/close the modal on a subsequent PR.

[JIRA](https://financialtimes.atlassian.net/jira/software/c/projects/PT/boards/1655?modal=detail&selectedIssue=PT-234)

Designs: https://www.figma.com/file/yyojM73dWDAF5BPgrMv7du/PT-219-To-increase-the-number-of-instant-alert-users?type=design&node-id=703-6064&mode=design&t=UvW4KTXefFngMMCs-0

Screenshots:

https://github.com/Financial-Times/n-myft-ui/assets/10453619/01df058f-e209-4d1f-8beb-c4761a889d55



