### PR TITLE
PT-239 Trigger preferences modal when add to myFT Button is clicked

### DIFF
--- a/components/jsx/follow-plus-instant-alerts/follow-plus-instant-alerts.jsx
+++ b/components/jsx/follow-plus-instant-alerts/follow-plus-instant-alerts.jsx
@@ -77,6 +77,7 @@ export default function FollowPlusInstantAlerts({ conceptId, name, csrfToken, se
 			<button
 				{...dynamicButtonAttributes}
 				className={`n-myft-follow-button n-myft-follow-button--instant-alerts ${setInstantAlertsOn ? 'n-myft-follow-button--instant-alerts--on' : ''}`}
+				data-component-id="follow-plus-instant-alerts"
 				data-concept-id={conceptId}
 				data-trackable="follow"
 				type="submit">

--- a/components/jsx/follow-plus-instant-alerts/index.js
+++ b/components/jsx/follow-plus-instant-alerts/index.js
@@ -1,0 +1,11 @@
+export default () => {
+	const addToMyFTButton = document.querySelector('[data-component-id="follow-plus-instant-alerts"]');
+	if (!addToMyFTButton) return;
+
+	const customEvent = new CustomEvent('instantAlertsOnboarding');
+
+	addToMyFTButton.addEventListener('click', (event) => {
+		event.preventDefault();
+		document.dispatchEvent(customEvent);
+	});
+};

--- a/components/jsx/preferences-modal/index.js
+++ b/components/jsx/preferences-modal/index.js
@@ -1,0 +1,10 @@
+export default () => {
+	const preferencesModal = document.querySelector('[data-component-id="preferences-modal"]');
+	if (!preferencesModal) return;
+	preferencesModal.classList.add('n-myft-ui__preferences-modal-live');
+
+	document.addEventListener('instantAlertsOnboarding', (event) => {
+		event.preventDefault();
+		preferencesModal.classList.toggle('n-myft-ui__preferences-modal__hide');
+	});
+};

--- a/components/jsx/preferences-modal/main.scss
+++ b/components/jsx/preferences-modal/main.scss
@@ -9,6 +9,13 @@
 	width: 275px;
 }
 
+//this class needs to be active in prod but cannot be used in the demo as it the position absolute makes it render on top of other components
+.n-myft-ui__preferences-modal-live {
+	position: absolute;
+	margin-top: 50px;
+	z-index: 999;
+}
+
 .n-myft-ui__preferences-modal__content {
 	position: relative;
 	margin: 20px 20px 24px;
@@ -39,4 +46,9 @@
 	border: 2px solid oColorsByName('claret-60');
 	background-color: oColorsMix($color: 'claret-60', $percentage: 20);
 	color: oColorsByName('claret-60');
+}
+
+.n-myft-ui__preferences-modal__hide {
+	visibility: hidden;
+	display: none;
 }

--- a/components/jsx/preferences-modal/preferences-modal.jsx
+++ b/components/jsx/preferences-modal/preferences-modal.jsx
@@ -14,14 +14,14 @@ import React from 'react';
  * @param {PreferencesProperties}
  * @returns {React.ReactElement}
 */
-export default function InstantAlertsPreferencesModal({ flags, currentPreferences }) {
+export default function InstantAlertsPreferencesModal({ flags, currentPreferences, hide=false }) {
 	if (!flags.myFtApiWrite) {
 		return null;
 	}
 
 	const formattedCurrentPreferences = currentPreferences.join(', ')
 	return (
-		<div className="n-myft-ui__preferences-modal">
+		<div data-component-id="preferences-modal" className={`n-myft-ui__preferences-modal${hide ? ' n-myft-ui__preferences-modal__hide' : ''}`}>
 			<div className="n-myft-ui__preferences-modal__content">
 					<span className="o-forms-input o-forms-input--checkbox">
 						<label htmlFor="receive-instant-alerts">

--- a/myft/main.scss
+++ b/myft/main.scss
@@ -15,6 +15,8 @@ $n-notification-is-silent: false !default;
 @import './ui/lists';
 @import '../components/pin-button/main';
 @import '../components/instant-alert/main';
+@import '../components/jsx/follow-plus-instant-alerts/main';
+@import '../components/jsx/preferences-modal/main';
 
 // TODO Fix below
 $spacing-unit: 20px;


### PR DESCRIPTION
### Description
This PR implements the interaction between the new add to myFT button and the preferences modal. 
    -The preferences modal is closed/open by clicking on the add to myFT button.
    -The preferences modal is closed if you click anywhere else on the screen.

[JIRA](https://financialtimes.atlassian.net/jira/software/c/projects/PT/boards/1655?modal=detail&selectedIssue=PT-239)

screengrab: 

https://github.com/Financial-Times/n-myft-ui/assets/10453619/63014b6f-0dbf-4693-b4a8-c72d8188a9b5


