### PR TITLE
Open close preference modal

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,4 @@
 # See https://help.github.com/articles/about-codeowners/ for more information about this file.
 
+/components/jsx/* @Financial-times/accounts
 * @Financial-Times/content-discovery

--- a/components/jsx/follow-plus-instant-alerts/follow-plus-instant-alerts.jsx
+++ b/components/jsx/follow-plus-instant-alerts/follow-plus-instant-alerts.jsx
@@ -63,7 +63,8 @@ export default function FollowPlusInstantAlerts({ conceptId, name, csrfToken, se
 			className="n-myft-ui n-myft-ui--follow"
 			method="GET"
 			data-myft-ui="follow"
-			data-concept-id={conceptId}>
+			data-concept-id={conceptId}
+			data-myft-ui-variant="followPlusInstantAlerts">
 			<div
 				className="n-myft-ui__announcement o-normalise-visually-hidden"
 				aria-live="assertive"

--- a/components/jsx/follow-plus-instant-alerts/follow-plus-instant-alerts.jsx
+++ b/components/jsx/follow-plus-instant-alerts/follow-plus-instant-alerts.jsx
@@ -79,8 +79,9 @@ export default function FollowPlusInstantAlerts({ conceptId, name, csrfToken, se
 				className={`n-myft-follow-button n-myft-follow-button--instant-alerts ${setInstantAlertsOn ? 'n-myft-follow-button--instant-alerts--on' : ''}`}
 				data-concept-id={conceptId}
 				data-trackable="follow"
-				type="submit">
-					{buttonText}
+				type="submit"
+				data-component-id="myft-follow-plus-instant-alerts">
+				{buttonText}
 			</button>
 		</form>
 	);

--- a/components/jsx/follow-plus-instant-alerts/index.js
+++ b/components/jsx/follow-plus-instant-alerts/index.js
@@ -14,5 +14,6 @@ export default () => {
 	const preferenceModalToggleEvent = new CustomEvent('myft.preference-modal.show-hide.toggle', { bubbles: true });
 	followPlusInstantAlerts.addEventListener('click', () => {
 		followPlusInstantAlerts.dispatchEvent(preferenceModalToggleEvent);
+		followPlusInstantAlerts.classList.toggle('n-myft-follow-button--instant-alerts--open');
 	});
 };

--- a/components/jsx/follow-plus-instant-alerts/index.js
+++ b/components/jsx/follow-plus-instant-alerts/index.js
@@ -1,0 +1,18 @@
+export default () => {
+	/**
+	 * This feature is part of a test
+	 * Therefore we have built it to work within the known parameters of that test
+	 * For example we know it will only once appear in the page next to the primary add button on articles
+	 * If this was to be used in other locations it would need some additional work to avoid being singleton
+	 */
+	const followPlusInstantAlerts = document.querySelector('[data-component-id="myft-follow-plus-instant-alerts"]');
+
+	if (!followPlusInstantAlerts) {
+		return;
+	}
+
+	const preferenceModalToggleEvent = new CustomEvent('myft.preference-modal.show-hide.toggle', { bubbles: true });
+	followPlusInstantAlerts.addEventListener('click', () => {
+		followPlusInstantAlerts.dispatchEvent(preferenceModalToggleEvent);
+	});
+};

--- a/components/jsx/follow-plus-instant-alerts/main.scss
+++ b/components/jsx/follow-plus-instant-alerts/main.scss
@@ -32,3 +32,15 @@
 	background-position: 50% 41%;
 	margin-left: 12px;
 }
+
+.n-myft-follow-button--instant-alerts--open[aria-pressed=true]::after {
+	content: "";
+	@include oIconsContent(
+		$icon-name: 'arrow-up',
+		$color: oColorsByName('white'),
+		$size: 10
+	);
+	background-size: 21px;
+	background-position: 50% 41%;
+	margin-left: 12px;
+}

--- a/components/jsx/preferences-modal/index.js
+++ b/components/jsx/preferences-modal/index.js
@@ -1,0 +1,23 @@
+const preferenceModalShowAndHide = ({ event, preferencesModal }) => {
+	if (!event.target) {
+		return;
+	}
+
+	preferencesModal.classList.toggle('n-myft-ui__preferences-modal--show');
+};
+
+export default () => {
+	/**
+	 * This feature is part of a test
+	 * Therefore we have built it to work within the known parameters of that test
+	 * For example we know it will only once appear in the page next to the primary add button on articles
+	 * If this was to be used in other locations it would need some additional work to avoid being singleton
+	 */
+	const preferencesModal = document.querySelector('[data-component-id="myft-preferences-modal"]');
+
+	if (!preferencesModal) {
+		return;
+	}
+
+	document.addEventListener('myft.preference-modal.show-hide.toggle', event => preferenceModalShowAndHide({ event, preferencesModal}));
+};

--- a/components/jsx/preferences-modal/index.js
+++ b/components/jsx/preferences-modal/index.js
@@ -1,9 +1,43 @@
+/**
+ * This preference modal is part of a test
+ * Therefore we have built the positioning function to work within the known parameters of that test
+ * For example we know it will only appear next to the primary add button on articles
+ * If this was to be used in other locations this function would need further improvements
+ */
+const positionModal = ({ eventTrigger, preferencesModal }) => {
+	const modalHorizontalCentering = (eventTrigger.offsetLeft + (eventTrigger.offsetWidth / 2)) - (preferencesModal.offsetWidth / 2);
+	const verticalPadding = 16;
+	const leftPadding = '5px';
+
+	preferencesModal.style.top = `${eventTrigger.offsetTop + eventTrigger.offsetHeight + verticalPadding}px`;
+	preferencesModal.style.left = `${modalHorizontalCentering}px`;
+
+	const modalPositionRelativeToScreen = preferencesModal.getBoundingClientRect();
+
+	if (modalPositionRelativeToScreen.left < 0) {
+		preferencesModal.style.left = leftPadding;
+	}
+
+	if (modalPositionRelativeToScreen.right > window.screen.width) {
+		const triggerRightPosition = eventTrigger.offsetLeft + eventTrigger.offsetWidth;
+		const modalShiftLeftPosition = triggerRightPosition - preferencesModal.offsetWidth;
+
+		preferencesModal.style.left = modalShiftLeftPosition > 0
+			? `${modalShiftLeftPosition}px`
+			: leftPadding;
+	}
+};
+
 const preferenceModalShowAndHide = ({ event, preferencesModal }) => {
 	if (!event.target) {
 		return;
 	}
 
 	preferencesModal.classList.toggle('n-myft-ui__preferences-modal--show');
+
+	if (preferencesModal.classList.contains('n-myft-ui__preferences-modal--show')) {
+		positionModal({ eventTrigger: event.target, preferencesModal });
+	}
 };
 
 export default () => {
@@ -19,5 +53,5 @@ export default () => {
 		return;
 	}
 
-	document.addEventListener('myft.preference-modal.show-hide.toggle', event => preferenceModalShowAndHide({ event, preferencesModal}));
+	document.addEventListener('myft.preference-modal.show-hide.toggle', event => preferenceModalShowAndHide({ event, preferencesModal }));
 };

--- a/components/jsx/preferences-modal/main.scss
+++ b/components/jsx/preferences-modal/main.scss
@@ -3,10 +3,14 @@
 @include oForms();
 
 .n-myft-ui__preferences-modal {
+	display: none;
+	visibility: hidden;
+	position: absolute;
 	background-color: oColorsByName('white-80');
 	border-radius: 10px;
 	border: 2px solid oColorsByName('black-5');
 	width: 275px;
+	z-index: 9999999;
 }
 
 .n-myft-ui__preferences-modal__content {
@@ -39,4 +43,9 @@
 	border: 2px solid oColorsByName('claret-60');
 	background-color: oColorsMix($color: 'claret-60', $percentage: 20);
 	color: oColorsByName('claret-60');
+}
+
+.n-myft-ui__preferences-modal--show {
+	display: block;
+	visibility: visible;
 }

--- a/components/jsx/preferences-modal/preferences-modal.jsx
+++ b/components/jsx/preferences-modal/preferences-modal.jsx
@@ -21,7 +21,7 @@ export default function InstantAlertsPreferencesModal({ flags, currentPreference
 
 	const formattedCurrentPreferences = currentPreferences.join(', ')
 	return (
-		<div className="n-myft-ui__preferences-modal">
+		<div className="n-myft-ui__preferences-modal" data-component-id="myft-preferences-modal">
 			<div className="n-myft-ui__preferences-modal__content">
 					<span className="o-forms-input o-forms-input--checkbox">
 						<label htmlFor="receive-instant-alerts">

--- a/components/jsx/preferences-modal/preferences-modal.jsx
+++ b/components/jsx/preferences-modal/preferences-modal.jsx
@@ -14,23 +14,23 @@ import React from 'react';
  * @param {PreferencesProperties}
  * @returns {React.ReactElement}
 */
-export default function InstantAlertsPreferencesModal({ flags, currentPreferences }) {
+export default function InstantAlertsPreferencesModal({ flags, currentPreferences, visible }) {
 	if (!flags.myFtApiWrite) {
 		return null;
 	}
 
 	const formattedCurrentPreferences = currentPreferences.join(', ')
 	return (
-		<div className="n-myft-ui__preferences-modal" data-component-id="myft-preferences-modal">
+		<div className={`n-myft-ui__preferences-modal ${visible ? 'n-myft-ui__preferences-modal--show' : ''}`} data-component-id="myft-preferences-modal">
 			<div className="n-myft-ui__preferences-modal__content">
-					<span className="o-forms-input o-forms-input--checkbox">
-						<label htmlFor="receive-instant-alerts">
-							<input id="receive-instant-alerts" type="checkbox" name="receive-instant-alerts" value="receive-instant-alerts"/>
-							<span className="o-forms-input__label n-myft-ui__preferences-modal__checkbox__message">
-								Get instant alerts for this topic
-							</span>
-						</label>
-					</span>
+				<span className="o-forms-input o-forms-input--checkbox">
+					<label htmlFor="receive-instant-alerts">
+						<input id="receive-instant-alerts" type="checkbox" name="receive-instant-alerts" value="receive-instant-alerts"/>
+						<span className="o-forms-input__label n-myft-ui__preferences-modal__checkbox__message">
+							Get instant alerts for this topic
+						</span>
+					</label>
+				</span>
 
 				<p className="n-myft-ui__preferences-modal__text">Your alerts are currently: {formattedCurrentPreferences}.</p>
 				<a className="n-myft-ui__preferences-modal__text" href="/myft/alerts">Manage your preferences here</a>

--- a/demos/templates/demo.html
+++ b/demos/templates/demo.html
@@ -36,7 +36,9 @@
 							Instant alerts popup to manage preferences
 						</h3>
 
-						{{{renderReactComponent localPath="components/jsx/preferences-modal/preferences-modal.jsx" flags=@root.flags}}}
+						<div style="height:200px">
+							{{{renderReactComponent localPath="components/jsx/preferences-modal/preferences-modal.jsx" flags=@root.flags visible=true}}}
+						</div>
 					{{/instantAlertsPreferencesModal}}
 
 					{{#followPlusInstantAlerts}}

--- a/myft/main.scss
+++ b/myft/main.scss
@@ -16,6 +16,9 @@ $n-notification-is-silent: false !default;
 @import '../components/pin-button/main';
 @import '../components/instant-alert/main';
 
+@import '../components/jsx/follow-plus-instant-alerts/main';
+@import '../components/jsx/preferences-modal/main';
+
 // TODO Fix below
 $spacing-unit: 20px;
 

--- a/myft/ui/myft-buttons/do-form-submit.js
+++ b/myft/ui/myft-buttons/do-form-submit.js
@@ -43,13 +43,20 @@ function getTrackingInfo (formEl) {
 }
 
 export default function (relationshipName, formEl) {
+	const action = getAction(formEl);
+
 	if (formButtonIsDisabled(formEl)) {
+		return;
+	} else if (formEl.getAttribute('data-myft-ui-variant') === 'followPlusInstantAlerts' && action === 'remove') {
+		/**
+		 * The follow + instant alerts button has a 2 click user journey for unfollows
+		 * When the user clicks on a followed button it opens a menu modal
+		 * Amongst other options the menu modal has a "remove" option within it
+		 */
 		return;
 	} else {
 		formEl.querySelector('button').setAttribute('disabled', '');
 	}
-
-	const action = getAction(formEl);
 
 	// note that where the actor is a user, the actorId may be null, in which case myFT client will fill
 	// in the userId from the session 😕


### PR DESCRIPTION
### Description

This enables the preference modal to be toggled open and closed via a custom event. It also sets up the new follow + instant alert button to dispatch that event so the components work together.

### Whats included

1. Ability to open and close the preference modal
2. The follow + instant alerts button to act as a trigger for that open and close
3. Disabling the 1 click remove follow user journey that would normally happen when you click on a added state button
4. Now if the button is in added state and you click on it then it will only trigger preference modal and do nothing else
5. Very basic positioning logic to ensure the modal is always within the viewport

### Whats not included

Stuff that will happen in future PR's (I didn't want this to get too large)

1. Any functionality within the preference modal including the ability to remove the topic follow
2. Tracking
3. The ability to close the preference modal by clicking anywhere else on the page
5. Probably some stuff I have forgotten :)

### Screen recording

https://github.com/Financial-Times/n-myft-ui/assets/524573/bf5d8193-01f3-4893-9037-dcf45fc0584a


### Jira

https://financialtimes.atlassian.net/browse/PT-239
