### PR TITLE
Allow users from remove topic from myFT

### DIFF
--- a/components/jsx/follow-plus-instant-alerts/follow-plus-instant-alerts.jsx
+++ b/components/jsx/follow-plus-instant-alerts/follow-plus-instant-alerts.jsx
@@ -63,7 +63,8 @@ export default function FollowPlusInstantAlerts({ conceptId, name, csrfToken, se
 			className="n-myft-ui n-myft-ui--follow"
 			method="GET"
 			data-myft-ui="follow"
-			data-concept-id={conceptId}>
+			data-concept-id={conceptId}
+			data-myft-ui-variant="followPlusInstantAlerts">
 			<div
 				className="n-myft-ui__announcement o-normalise-visually-hidden"
 				aria-live="assertive"

--- a/components/jsx/follow-plus-instant-alerts/follow-plus-instant-alerts.jsx
+++ b/components/jsx/follow-plus-instant-alerts/follow-plus-instant-alerts.jsx
@@ -79,8 +79,9 @@ export default function FollowPlusInstantAlerts({ conceptId, name, csrfToken, se
 				className={`n-myft-follow-button n-myft-follow-button--instant-alerts ${setInstantAlertsOn ? 'n-myft-follow-button--instant-alerts--on' : ''}`}
 				data-concept-id={conceptId}
 				data-trackable="follow"
-				type="submit">
-					{buttonText}
+				type="submit"
+				data-component-id="myft-follow-plus-instant-alerts">
+				{buttonText}
 			</button>
 		</form>
 	);

--- a/components/jsx/follow-plus-instant-alerts/index.js
+++ b/components/jsx/follow-plus-instant-alerts/index.js
@@ -13,5 +13,6 @@ export default () => {
 	const preferenceModalToggleEvent = new CustomEvent('myft.preference-modal.show-hide.toggle', { bubbles: true });
 	followPlusInstantAlerts.addEventListener('click', () => {
 		followPlusInstantAlerts.dispatchEvent(preferenceModalToggleEvent);
+		followPlusInstantAlerts.classList.toggle('n-myft-follow-button--instant-alerts--open');
 	});
 };

--- a/components/jsx/follow-plus-instant-alerts/index.js
+++ b/components/jsx/follow-plus-instant-alerts/index.js
@@ -1,0 +1,17 @@
+/**
+ * This feature is part of a test
+ * Therefore we have built it to work within the known parameters of that test
+ * For example we know it will only once appear in the page next to the primary add button on articles
+ * If this was to be used in other locations it would need some additional work to avoid being singleton
+ */
+const followPlusInstantAlerts = document.querySelector('[data-component-id="myft-follow-plus-instant-alerts"]');
+
+export default () => {
+	if (!followPlusInstantAlerts) {
+		return;
+	}
+	const preferenceModalToggleEvent = new CustomEvent('myft.preference-modal.show-hide.toggle', { bubbles: true });
+	followPlusInstantAlerts.addEventListener('click', () => {
+		followPlusInstantAlerts.dispatchEvent(preferenceModalToggleEvent);
+	});
+};

--- a/components/jsx/follow-plus-instant-alerts/main.scss
+++ b/components/jsx/follow-plus-instant-alerts/main.scss
@@ -32,3 +32,15 @@
 	background-position: 50% 41%;
 	margin-left: 12px;
 }
+
+.n-myft-follow-button--instant-alerts--open[aria-pressed=true]::after {
+	content: "";
+	@include oIconsContent(
+		$icon-name: 'arrow-up',
+		$color: oColorsByName('white'),
+		$size: 10
+	);
+	background-size: 21px;
+	background-position: 50% 41%;
+	margin-left: 12px;
+}

--- a/components/jsx/preferences-modal/index.js
+++ b/components/jsx/preferences-modal/index.js
@@ -6,8 +6,46 @@
  */
 const preferencesModal = document.querySelector('[data-component-id="myft-preferences-modal"]');
 
-const preferenceModalShowAndHide = () => {
+/**
+ * This preference modal is part of a test
+ * Therefore we have built the positioning function to work within the known parameters of that test
+ * For example we know it will only appear next to the primary add button on articles
+ * If this was to be used in other locations this function would need further improvements
+ */
+const positionModal = (eventTrigger) => {
+	const modalHorizontalCentering = (eventTrigger.offsetLeft + (eventTrigger.offsetWidth / 2)) - (preferencesModal.offsetWidth / 2);
+	const verticalPadding = 20;
+	const leftPadding = '5px';
+
+	preferencesModal.style.top = `${eventTrigger.offsetTop + eventTrigger.offsetHeight + verticalPadding}px`;
+	preferencesModal.style.left = `${modalHorizontalCentering}px`;
+
+	const modalPositionRelativeToScreen = preferencesModal.getBoundingClientRect();
+
+	if (modalPositionRelativeToScreen.left < 0) {
+		preferencesModal.style.left = leftPadding;
+	}
+
+	if (modalPositionRelativeToScreen.right > window.screen.width) {
+		const triggerRightPosition = eventTrigger.offsetLeft + eventTrigger.offsetWidth;
+		const modalShiftLeftPosition = triggerRightPosition - preferencesModal.offsetWidth;
+
+		preferencesModal.style.left = modalShiftLeftPosition > 0
+			? `${modalShiftLeftPosition}px`
+			: leftPadding;
+	}
+};
+
+const preferenceModalShowAndHide = (event) => {
+	if (!event.target) {
+		return;
+	}
+
 	preferencesModal.classList.toggle('n-myft-ui__preferences-modal--show');
+
+	if (preferencesModal.classList.contains('n-myft-ui__preferences-modal--show')) {
+		positionModal(event.target);
+	}
 };
 
 export default () => {

--- a/components/jsx/preferences-modal/index.js
+++ b/components/jsx/preferences-modal/index.js
@@ -1,0 +1,19 @@
+/**
+ * This feature is part of a test
+ * Therefore we have built it to work within the known parameters of that test
+ * For example we know it will only once appear in the page next to the primary add button on articles
+ * If this was to be used in other locations it would need some additional work to avoid being singleton
+ */
+const preferencesModal = document.querySelector('[data-component-id="myft-preferences-modal"]');
+
+const preferenceModalShowAndHide = () => {
+	preferencesModal.classList.toggle('n-myft-ui__preferences-modal--show');
+};
+
+export default () => {
+	if (!preferencesModal) {
+		return;
+	}
+
+	document.addEventListener('myft.preference-modal.show-hide.toggle', preferenceModalShowAndHide);
+};

--- a/components/jsx/preferences-modal/index.js
+++ b/components/jsx/preferences-modal/index.js
@@ -55,6 +55,8 @@ const preferenceModalShowAndHide = (event) => {
 };
 
 const removeTopic = async (event) => {
+	event.target.setAttribute('disabled', true);
+
 	try {
 		await myFtClient.remove('user', null, 'followed', 'concept', conceptId, { token: csrfToken });
 
@@ -62,6 +64,9 @@ const removeTopic = async (event) => {
 
 	} catch (error) {
 	}
+
+	event.target.removeAttribute('disabled');
+
 }
 
 export default () => {

--- a/components/jsx/preferences-modal/index.js
+++ b/components/jsx/preferences-modal/index.js
@@ -63,11 +63,18 @@ const removeTopic = async (event) => {
 		preferenceModalShowAndHide();
 
 	} catch (error) {
+		const parentNode = event.target.parentNode;
+		const errorElement = document.createElement('span');
+		errorElement.innerHTML = 'Sorry, we are unable to remove this topic. Please try again later or try from ft.com/myft';
+		errorElement.setAttribute('aria-live', 'polite');
+		errorElement.classList.add('n-myft-ui__preferences-modal-error');
+
+		parentNode.insertBefore(errorElement, event.target);
 	}
 
 	event.target.removeAttribute('disabled');
 
-}
+};
 
 export default () => {
 	if (!preferencesModal || !conceptId) {

--- a/components/jsx/preferences-modal/index.js
+++ b/components/jsx/preferences-modal/index.js
@@ -1,3 +1,8 @@
+import myFtClient from 'next-myft-client';
+import getToken from '../../../myft/ui/lib/get-csrf-token';
+
+const csrfToken = getToken();
+
 /**
  * This feature is part of a test
  * Therefore we have built it to work within the known parameters of that test
@@ -5,6 +10,7 @@
  * If this was to be used in other locations it would need some additional work to avoid being singleton
  */
 const preferencesModal = document.querySelector('[data-component-id="myft-preferences-modal"]');
+const conceptId = preferencesModal.dataset.conceptId;
 
 /**
  * This preference modal is part of a test
@@ -48,10 +54,21 @@ const preferenceModalShowAndHide = (event) => {
 	}
 };
 
+const removeTopic = async (event) => {
+	try {
+		await myFtClient.remove('user', null, 'followed', 'concept', conceptId, { token: csrfToken });
+	} catch (error) {
+	}
+}
+
 export default () => {
-	if (!preferencesModal) {
+	if (!preferencesModal || !conceptId) {
 		return;
 	}
+
+	const removeTopicButton = preferencesModal.querySelector('[data-component-id="myft-preference-modal-remove"]');
+
+	removeTopicButton.addEventListener('click', removeTopic);
 
 	document.addEventListener('myft.preference-modal.show-hide.toggle', preferenceModalShowAndHide);
 };

--- a/components/jsx/preferences-modal/index.js
+++ b/components/jsx/preferences-modal/index.js
@@ -18,7 +18,11 @@ const conceptId = preferencesModal.dataset.conceptId;
  * For example we know it will only appear next to the primary add button on articles
  * If this was to be used in other locations this function would need further improvements
  */
-const positionModal = (eventTrigger) => {
+const positionModal = (event) => {
+	if (!event.target) {
+		return;
+	}
+	const eventTrigger = event.target;
 	const modalHorizontalCentering = (eventTrigger.offsetLeft + (eventTrigger.offsetWidth / 2)) - (preferencesModal.offsetWidth / 2);
 	const verticalPadding = 20;
 	const leftPadding = '5px';
@@ -43,20 +47,19 @@ const positionModal = (eventTrigger) => {
 };
 
 const preferenceModalShowAndHide = (event) => {
-	if (!event.target) {
-		return;
-	}
-
 	preferencesModal.classList.toggle('n-myft-ui__preferences-modal--show');
 
 	if (preferencesModal.classList.contains('n-myft-ui__preferences-modal--show')) {
-		positionModal(event.target);
+		positionModal(event);
 	}
 };
 
 const removeTopic = async (event) => {
 	try {
 		await myFtClient.remove('user', null, 'followed', 'concept', conceptId, { token: csrfToken });
+
+		preferenceModalShowAndHide();
+
 	} catch (error) {
 	}
 }

--- a/components/jsx/preferences-modal/main.scss
+++ b/components/jsx/preferences-modal/main.scss
@@ -49,3 +49,11 @@
 	display: block;
 	visibility: visible;
 }
+
+.n-myft-ui__preferences-modal-error {
+	display: block;
+	margin-top: 10px;
+	@include oTypographySans($scale: -1, $weight: 'regular', $style: 'normal');
+	color: oColorsByName('claret');
+	text-align: center;
+}

--- a/components/jsx/preferences-modal/main.scss
+++ b/components/jsx/preferences-modal/main.scss
@@ -3,10 +3,14 @@
 @include oForms();
 
 .n-myft-ui__preferences-modal {
+	display: none;
+	visibility: hidden;
+	position: absolute;
 	background-color: oColorsByName('white-80');
 	border-radius: 10px;
 	border: 2px solid oColorsByName('black-5');
 	width: 275px;
+	z-index: 9999999;
 }
 
 .n-myft-ui__preferences-modal__content {
@@ -39,4 +43,9 @@
 	border: 2px solid oColorsByName('claret-60');
 	background-color: oColorsMix($color: 'claret-60', $percentage: 20);
 	color: oColorsByName('claret-60');
+}
+
+.n-myft-ui__preferences-modal--show {
+	display: block;
+	visibility: visible;
 }

--- a/components/jsx/preferences-modal/main.scss
+++ b/components/jsx/preferences-modal/main.scss
@@ -38,8 +38,8 @@
 	color: oColorsByName('black-80');
 }
 
-.n-myft-ui__preferences-modal__remove-button:hover,
-.n-myft-ui__preferences-modal__remove-button:focus {
+.n-myft-ui__preferences-modal__remove-button:not([disabled]):hover,
+.n-myft-ui__preferences-modal__remove-button:not([disabled]):focus {
 	border: 2px solid oColorsByName('claret-60');
 	background-color: oColorsMix($color: 'claret-60', $percentage: 20);
 	color: oColorsByName('claret-60');

--- a/components/jsx/preferences-modal/preferences-modal.jsx
+++ b/components/jsx/preferences-modal/preferences-modal.jsx
@@ -21,7 +21,7 @@ export default function InstantAlertsPreferencesModal({ flags, currentPreference
 
 	const formattedCurrentPreferences = currentPreferences.join(', ')
 	return (
-		<div className="n-myft-ui__preferences-modal">
+		<div className="n-myft-ui__preferences-modal" data-component-id="myft-preferences-modal">
 			<div className="n-myft-ui__preferences-modal__content">
 					<span className="o-forms-input o-forms-input--checkbox">
 						<label htmlFor="receive-instant-alerts">

--- a/components/jsx/preferences-modal/preferences-modal.jsx
+++ b/components/jsx/preferences-modal/preferences-modal.jsx
@@ -14,23 +14,23 @@ import React from 'react';
  * @param {PreferencesProperties}
  * @returns {React.ReactElement}
 */
-export default function InstantAlertsPreferencesModal({ flags, currentPreferences }) {
+export default function InstantAlertsPreferencesModal({ flags, currentPreferences, visible }) {
 	if (!flags.myFtApiWrite) {
 		return null;
 	}
 
 	const formattedCurrentPreferences = currentPreferences.join(', ')
 	return (
-		<div className="n-myft-ui__preferences-modal" data-component-id="myft-preferences-modal">
+		<div className={`n-myft-ui__preferences-modal ${visible ? 'n-myft-ui__preferences-modal--show' : ''}`} data-component-id="myft-preferences-modal">
 			<div className="n-myft-ui__preferences-modal__content">
-					<span className="o-forms-input o-forms-input--checkbox">
-						<label htmlFor="receive-instant-alerts">
-							<input id="receive-instant-alerts" type="checkbox" name="receive-instant-alerts" value="receive-instant-alerts"/>
-							<span className="o-forms-input__label n-myft-ui__preferences-modal__checkbox__message">
-								Get instant alerts for this topic
-							</span>
-						</label>
-					</span>
+				<span className="o-forms-input o-forms-input--checkbox">
+					<label htmlFor="receive-instant-alerts">
+						<input id="receive-instant-alerts" type="checkbox" name="receive-instant-alerts" value="receive-instant-alerts"/>
+						<span className="o-forms-input__label n-myft-ui__preferences-modal__checkbox__message">
+							Get instant alerts for this topic
+						</span>
+					</label>
+				</span>
 
 				<p className="n-myft-ui__preferences-modal__text">Your alerts are currently: {formattedCurrentPreferences}.</p>
 				<a className="n-myft-ui__preferences-modal__text" href="/myft/alerts">Manage your preferences here</a>

--- a/components/jsx/preferences-modal/preferences-modal.jsx
+++ b/components/jsx/preferences-modal/preferences-modal.jsx
@@ -14,14 +14,14 @@ import React from 'react';
  * @param {PreferencesProperties}
  * @returns {React.ReactElement}
 */
-export default function InstantAlertsPreferencesModal({ flags, currentPreferences, visible }) {
+export default function InstantAlertsPreferencesModal({ conceptId, flags, currentPreferences, visible }) {
 	if (!flags.myFtApiWrite) {
 		return null;
 	}
 
 	const formattedCurrentPreferences = currentPreferences.join(', ')
 	return (
-		<div className={`n-myft-ui__preferences-modal ${visible ? 'n-myft-ui__preferences-modal--show' : ''}`} data-component-id="myft-preferences-modal">
+		<div className={`n-myft-ui__preferences-modal ${visible ? 'n-myft-ui__preferences-modal--show' : ''}`} data-component-id="myft-preferences-modal" data-concept-id={conceptId}>
 			<div className="n-myft-ui__preferences-modal__content">
 				<span className="o-forms-input o-forms-input--checkbox">
 					<label htmlFor="receive-instant-alerts">
@@ -34,7 +34,7 @@ export default function InstantAlertsPreferencesModal({ flags, currentPreference
 
 				<p className="n-myft-ui__preferences-modal__text">Your alerts are currently: {formattedCurrentPreferences}.</p>
 				<a className="n-myft-ui__preferences-modal__text" href="/myft/alerts">Manage your preferences here</a>
-				<button className="n-myft-ui__preferences-modal__remove-button">Remove from myFT</button>
+				<button className="n-myft-ui__preferences-modal__remove-button" data-component-id="myft-preference-modal-remove">Remove from myFT</button>
 			</div>
 		</div>
 	);

--- a/demos/templates/demo.html
+++ b/demos/templates/demo.html
@@ -36,7 +36,9 @@
 							Instant alerts popup to manage preferences
 						</h3>
 
-						{{{renderReactComponent localPath="components/jsx/preferences-modal/preferences-modal.jsx" flags=@root.flags}}}
+						<div style="height:200px">
+							{{{renderReactComponent localPath="components/jsx/preferences-modal/preferences-modal.jsx" flags=@root.flags visible=true}}}
+						</div>
 					{{/instantAlertsPreferencesModal}}
 
 					{{#followPlusInstantAlerts}}

--- a/myft/main.scss
+++ b/myft/main.scss
@@ -16,6 +16,9 @@ $n-notification-is-silent: false !default;
 @import '../components/pin-button/main';
 @import '../components/instant-alert/main';
 
+@import '../components/jsx/follow-plus-instant-alerts/main';
+@import '../components/jsx/preferences-modal/main';
+
 // TODO Fix below
 $spacing-unit: 20px;
 

--- a/myft/ui/myft-buttons/do-form-submit.js
+++ b/myft/ui/myft-buttons/do-form-submit.js
@@ -43,13 +43,20 @@ function getTrackingInfo (formEl) {
 }
 
 export default function (relationshipName, formEl) {
+	const action = getAction(formEl);
+
 	if (formButtonIsDisabled(formEl)) {
+		return;
+	} else if (formEl.getAttribute('data-myft-ui-variant') === 'followPlusInstantAlerts' && action === 'remove') {
+		/**
+		 * The follow + instant alerts button has a 2 click user journey for unfollows
+		 * When the user clicks on a followed button it opens a menu modal
+		 * Amongst other options the menu modal has a "remove" option within it
+		 */
 		return;
 	} else {
 		formEl.querySelector('button').setAttribute('disabled', '');
 	}
-
-	const action = getAction(formEl);
 
 	// note that where the actor is a user, the actorId may be null, in which case myFT client will fill
 	// in the userId from the session 😕


### PR DESCRIPTION
This branches off from #594 so the only commits relevant to this change are the last 4

### Description

Allow users who see the follow + instant alerts experience to remove the topic from their myFT from within the preference modal.

### Whats included

1. Removing the topic from their myFT account
2. Closing the modal when the removal is successful
3. Disabling the button whilst the action is being processed
4. Error handling so the user knows when its failed, and don't close the modal

### Screen recordings

https://github.com/Financial-Times/n-myft-ui/assets/524573/fe044057-f3f6-4c2f-9384-3af917eaa1a3


