### PR TITLE
Set status of instant alert checkbox and bell on page load

### DIFF
--- a/components/jsx/follow-plus-instant-alerts/index.js
+++ b/components/jsx/follow-plus-instant-alerts/index.js
@@ -16,4 +16,18 @@ export default () => {
 		followPlusInstantAlerts.dispatchEvent(preferenceModalToggleEvent);
 		followPlusInstantAlerts.classList.toggle('n-myft-follow-button--instant-alerts--open');
 	});
+
+	document.body.addEventListener('myft.user.followed.concept.load', (event) => {
+		const conceptId = followPlusInstantAlerts.dataset.conceptId;
+		// search through all the concepts that the user has followed and check whether
+		// 1. the concept which this instant alert modal controls is within them, AND;
+		// 2. the said concept has instant alert enabled
+		// if so, set the bell on in the button
+		const currentConcept = event.detail.items.find(item => item && item.uuid === conceptId);
+		if (currentConcept && currentConcept._rel && currentConcept._rel.instant) {
+			followPlusInstantAlerts.classList.add('n-myft-follow-button--instant-alerts--on');
+		} else {
+			followPlusInstantAlerts.classList.remove('n-myft-follow-button--instant-alerts--on');
+		}
+	});
 };

--- a/components/jsx/preferences-modal/index.js
+++ b/components/jsx/preferences-modal/index.js
@@ -54,4 +54,19 @@ export default () => {
 	}
 
 	document.addEventListener('myft.preference-modal.show-hide.toggle', event => preferenceModalShowAndHide({ event, preferencesModal }));
+
+	document.body.addEventListener('myft.user.followed.concept.load', (event) => {
+		const conceptId = preferencesModal.dataset.conceptId;
+		const instantAlertsCheckbox = preferencesModal.querySelector('[data-component-id="myft-preferences-modal-checkbox"]');
+		// search through all the concepts that the user has followed and check whether
+		// 1. the concept which this instant alert modal controls is within them, AND;
+		// 2. the said concept has instant alert enabled
+		// if so, check the checkbox within the modal
+		const currentConcept = event.detail.items.find(item => item && item.uuid === conceptId);
+		if (currentConcept && currentConcept._rel && currentConcept._rel.instant) {
+			instantAlertsCheckbox.checked = true;
+		} else {
+			instantAlertsCheckbox.checked = false;
+		}
+	});
 };

--- a/components/jsx/preferences-modal/preferences-modal.jsx
+++ b/components/jsx/preferences-modal/preferences-modal.jsx
@@ -1,11 +1,15 @@
 import React from 'react';
 
 /**
- * @typedef {object} PreferencesProperties
+ * @typedef {Object} PreferencesProperties
  * @property {string[]} currentPreferences
  * Current alert preferences the user has set up.
- * @property {object.<string, boolean>} flags
- * 	FT.com feature flags
+ * @property {string} conceptId
+ * Concept id of the concept which the modal controls
+ * @property {Record<string, boolean>} flags
+ * FT.com feature flags
+ * @property {boolean} visible
+ * Controls the visibility of the modal
  */
 
 /**
@@ -14,18 +18,28 @@ import React from 'react';
  * @param {PreferencesProperties}
  * @returns {React.ReactElement}
 */
-export default function InstantAlertsPreferencesModal({ flags, currentPreferences, visible }) {
+export default function InstantAlertsPreferencesModal({ flags, conceptId, currentPreferences, visible }) {
 	if (!flags.myFtApiWrite) {
 		return null;
 	}
 
 	const formattedCurrentPreferences = currentPreferences.join(', ')
 	return (
-		<div className={`n-myft-ui__preferences-modal ${visible ? 'n-myft-ui__preferences-modal--show' : ''}`} data-component-id="myft-preferences-modal">
+		<div
+			className={`n-myft-ui__preferences-modal ${visible ? 'n-myft-ui__preferences-modal--show' : ''}`}
+			data-component-id="myft-preferences-modal"
+			data-concept-id={conceptId}
+		>
 			<div className="n-myft-ui__preferences-modal__content">
 				<span className="o-forms-input o-forms-input--checkbox">
 					<label htmlFor="receive-instant-alerts">
-						<input id="receive-instant-alerts" type="checkbox" name="receive-instant-alerts" value="receive-instant-alerts"/>
+						<input
+							id="receive-instant-alerts"
+							type="checkbox"
+							name="receive-instant-alerts"
+							value="receive-instant-alerts"
+							data-component-id="myft-preferences-modal-checkbox"
+						/>
 						<span className="o-forms-input__label n-myft-ui__preferences-modal__checkbox__message">
 							Get instant alerts for this topic
 						</span>


### PR DESCRIPTION
## Description

This sets the status of the instant alert checkbox within the preference modal and the bell on the follow concept button on page load. It listens to the event `myft.user.followed.concept.load`, and sets the checkbox ticked and the bell on when the user has followed the topic AND has instant alert on for that topic.

## Whats included

1. set the status of the instant alert checkbox within the preference modal on event `myft.user.followed.concept.load`
2. set the status of the bell on the follow concept button on event `myft.user.followed.concept.load`

## Screen Recording

https://github.com/Financial-Times/n-myft-ui/assets/28527037/08529132-c668-40a5-a2b4-221cfa59b1af

## JIRA

[JIRA ticket](https://financialtimes.atlassian.net/browse/PT-254)