### PR TITLE
PT-237 Show browser option in preferences modal

### DIFF
--- a/components/jsx/preferences-modal/main.scss
+++ b/components/jsx/preferences-modal/main.scss
@@ -52,7 +52,6 @@
 
 .n-myft-ui__preferences-modal-error {
 	display: block;
-	margin-top: 10px;
 	@include oTypographySans($scale: -1, $weight: 'regular', $style: 'normal');
 	color: oColorsByName('claret');
 	text-align: center;

--- a/components/jsx/preferences-modal/preferences-modal.jsx
+++ b/components/jsx/preferences-modal/preferences-modal.jsx
@@ -43,7 +43,7 @@ export default function InstantAlertsPreferencesModal({ flags, conceptId, visibl
 					</label>
 				</span>
 
-				<p data-component-id="myft-preferences-modal-list" className="n-myft-ui__preferences-modal__text">Your alerts are currently:</p>
+				<p data-component-id="myft-preferences-modal-list" className="n-myft-ui__preferences-modal__text"></p>
 				<a className="n-myft-ui__preferences-modal__text" href="/myft/alerts">Manage your preferences here</a>
 				<span className="n-myft-ui__preferences-modal-error" data-component-id="myft-preference-modal-error"></span>
 				<button className="n-myft-ui__preferences-modal__remove-button" data-component-id="myft-preference-modal-remove">Remove from myFT</button>


### PR DESCRIPTION
### Description:
Adds the browser option to the preferences modal when the user has browser notifications enabled for instant alerts.
This code is "heavily inspired" by the code in `next-myft-page` that ticks the checkbox for "Notifications on this device" :https://github.com/Financial-Times/next-myft-page/blob/main/client/components/alerts/js/push-notifications.js#L53

this PR extends #597 
JIRA: https://financialtimes.atlassian.net/jira/software/c/projects/PT/boards/1655?modal=detail&selectedIssue=PT-237


https://github.com/Financial-Times/n-myft-ui/assets/10453619/925fdbd7-1f75-4323-b72b-e79fece5268e

