### PR TITLE
Allow for variant styling of the new follow button

### DIFF
--- a/components/jsx/follow-plus-instant-alerts/follow-plus-instant-alerts.jsx
+++ b/components/jsx/follow-plus-instant-alerts/follow-plus-instant-alerts.jsx
@@ -17,6 +17,8 @@ import CsrfToken from '../csrf-token/input';
  * 	An indicator to switch the rendering to show instant alerts as turned on
  * @property {object.<string, boolean>} flags
  * 	FT.com feature flags
+ * @property {string} variant
+ * 	color variant of the follow button
  */
 
 /**
@@ -26,7 +28,7 @@ import CsrfToken from '../csrf-token/input';
  * @returns {React.ReactElement}
 */
 
-export default function FollowPlusInstantAlerts({ conceptId, name, csrfToken, setFollowButtonStateToSelected, cacheablePersonalisedUrl, setInstantAlertsOn, flags }) {
+export default function FollowPlusInstantAlerts({ conceptId, name, csrfToken, setFollowButtonStateToSelected, cacheablePersonalisedUrl, setInstantAlertsOn, flags, variant }) {
 	if (!flags.myFtApiWrite) {
 		return null;
 	}
@@ -77,7 +79,11 @@ export default function FollowPlusInstantAlerts({ conceptId, name, csrfToken, se
 			/>
 			<button
 				{...dynamicButtonAttributes}
-				className={`n-myft-follow-button n-myft-follow-button--instant-alerts ${setInstantAlertsOn ? 'n-myft-follow-button--instant-alerts--on' : ''}`}
+				className={
+					`n-myft-follow-button n-myft-follow-button--instant-alerts
+						${setInstantAlertsOn ? 'n-myft-follow-button--instant-alerts--on' : ''}
+						${variant ? `n-myft-follow-button--${variant}` : ''}`
+				}
 				data-concept-id={conceptId}
 				data-trackable="follow"
 				type="submit"

--- a/components/jsx/follow-plus-instant-alerts/main.scss
+++ b/components/jsx/follow-plus-instant-alerts/main.scss
@@ -48,7 +48,7 @@
 		}
 
 		&.n-myft-follow-button--instant-alerts[aria-pressed=true]::after {
-			@include arrowIcon('arrow-down', getThemeColor(text))
+			@include arrowIcon('arrow-down', getThemeColor(text));
 		}
 
 		&.n-myft-follow-button--instant-alerts--open[aria-pressed=true]::after {

--- a/components/jsx/follow-plus-instant-alerts/main.scss
+++ b/components/jsx/follow-plus-instant-alerts/main.scss
@@ -3,29 +3,33 @@
 @import "@financial-times/o-icons/main";
 @import "@financial-times/o-colors/main";
 
-.n-myft-follow-button--instant-alerts[aria-pressed=true]::before {
+@mixin bellOffIcon($color, $background) {
 	@include oIconsContent(
 		$icon-name: 'mute-notifications',
-		$color: oColorsMix($color: 'white', $background: 'claret', $percentage: 60),
+		$color: oColorsMix(
+			$color: $color,
+			$background: $background,
+			$percentage: 60,
+		),
 		$size: 10
 	);
 	background-size: 21px;
 }
 
-.n-myft-follow-button--instant-alerts--on[aria-pressed=true]::before {
+@mixin bellOnIcon($color) {
 	@include oIconsContent(
 		$icon-name: 'notifications',
-		$color: oColorsByName('white'),
+		$color: $color,
 		$size: 10
 	);
 	background-size: 21px;
 }
 
-.n-myft-follow-button--instant-alerts[aria-pressed=true]::after {
+@mixin arrowIcon($icon-name, $color) {
 	content: "";
 	@include oIconsContent(
-		$icon-name: 'arrow-down',
-		$color: oColorsByName('white'),
+		$icon-name: $icon-name,
+		$color: $color,
 		$size: 10
 	);
 	background-size: 21px;
@@ -33,14 +37,28 @@
 	margin-left: 12px;
 }
 
-.n-myft-follow-button--instant-alerts--open[aria-pressed=true]::after {
-	content: "";
-	@include oIconsContent(
-		$icon-name: 'arrow-up',
-		$color: oColorsByName('white'),
-		$size: 10
-	);
-	background-size: 21px;
-	background-position: 50% 41%;
-	margin-left: 12px;
+@mixin myftFollowButtonPlusToggleIcons($theme: standard) {
+	@include withTheme($theme) {
+		&.n-myft-follow-button--instant-alerts[aria-pressed=true]::before {
+			@include bellOffIcon(getThemeColor(text), getThemeColor(background));
+		}
+
+		&.n-myft-follow-button--instant-alerts--on[aria-pressed=true]::before {
+			@include bellOnIcon(getThemeColor(text));
+		}
+
+		&.n-myft-follow-button--instant-alerts[aria-pressed=true]::after {
+			@include arrowIcon('arrow-down', getThemeColor(text))
+		}
+
+		&.n-myft-follow-button--instant-alerts--open[aria-pressed=true]::after {
+			@include arrowIcon('arrow-up', getThemeColor(text));
+		}
+	}
+}
+
+@each $theme in map-keys($myft-lozenge-themes) {
+	.n-myft-follow-button#{getThemeModifier($theme)} {
+		@include myftFollowButtonPlusToggleIcons($theme);
+	}
 }

--- a/components/jsx/preferences-modal/main.scss
+++ b/components/jsx/preferences-modal/main.scss
@@ -6,6 +6,7 @@
 	display: none;
 	visibility: hidden;
 	position: absolute;
+	color: oColorsByName('black');
 	background-color: oColorsByName('white-80');
 	border-radius: 10px;
 	border: 2px solid oColorsByName('black-5');


### PR DESCRIPTION
**Reminder: Please pull the latest version of branch `addNewMyFTButton` in `next-article` so the follow button can received the variant property.**

## Description

This PR is to allow for variant styling of the new follow button. It reuses the styling rules for the original follow button, and the colors of the bell and arrow within the new follow button follows the styling rules as well. In addition, the color of the text within the preference modal is set to be black so it is not affected by the variant styling.

## Changes

1. add class for the variant styling `n-myft-follow-button--{{variant}}` to the new follow button
2. add styling rules for the bell on/muted and arrow up/down within the new follow button for all variants
3. set the color of the text within the preference modal to be black

## Screen Recording

- Alphaville (variant: alphaville)

Instant alert on:

https://github.com/Financial-Times/n-myft-ui/assets/28527037/eadb67ab-661e-4319-b14b-0c496d4b1b53

Instant alert off:

https://github.com/Financial-Times/n-myft-ui/assets/28527037/b6d215f2-af16-4801-b156-9cb76b9cdc81

- HTSI (variant: monochrome)

Instant alert on:

https://github.com/Financial-Times/n-myft-ui/assets/28527037/91f42dbb-355c-4340-8324-b4933f2e839c

Instant alert off:


https://github.com/Financial-Times/n-myft-ui/assets/28527037/1d5a6138-a222-455f-bf6d-437a9679f4b6

