### PR TITLE
Instant alerts on off

### DIFF
--- a/components/jsx/follow-plus-instant-alerts/index.js
+++ b/components/jsx/follow-plus-instant-alerts/index.js
@@ -1,39 +1,52 @@
-const setBellForAlertConcept = ({ event, followPlusInstantAlerts }) => {
-
-	if (!event) {
-		return;
-	}
-
-	/**
-	 * There are two types of event we receive
-	 * update - happens when the user changes their follows/instant alert
-	 * load - happens when the page loads and contains all follow data
-	 * The payload of those events are different so we need to handle them differently
-	 */
-	const isUpdateEvent = event.type === 'myft.user.followed.concept.update';
-	const modalConceptId = followPlusInstantAlerts.dataset.conceptId;
-
-	// Search through the event payload to see if any data relates to this modal
-	const currentConcept = isUpdateEvent
-		? event.detail.results.find(item => item && item.subject && item.subject.properties.uuid === modalConceptId)
-		: event.detail.items.find(item => item && item.uuid === modalConceptId);
-
-	if (!currentConcept) {
-		return;
-	}
-
-	// Does the event indicate that instant alerts are turned on
-	const isTurningAlertsOn = isUpdateEvent
-		? currentConcept.rel && currentConcept.rel.properties && currentConcept.rel.properties.instant
-		: currentConcept._rel && currentConcept._rel.instant;
-
+const toggleInstantAlertsClass = ({ instantAlertsOn,followPlusInstantAlerts }) => {
 	// Update the button icon to reflect the instant alert preference
-	if (isTurningAlertsOn) {
+	if (instantAlertsOn) {
 		followPlusInstantAlerts.classList.add('n-myft-follow-button--instant-alerts--on');
 	} else {
 		followPlusInstantAlerts.classList.remove('n-myft-follow-button--instant-alerts--on');
 	}
 };
+
+const instantAlertsIconLoad = ({ event, followPlusInstantAlerts }) => {
+	const modalConceptId = followPlusInstantAlerts.dataset.conceptId;
+
+	if (!event || !modalConceptId) {
+		return;
+	}
+
+	const currentConcept = event.detail.items
+		.find(item => item && item.uuid === modalConceptId);
+
+	if (!currentConcept) {
+		return;
+	}
+
+
+	const instantAlertsOn = Boolean(currentConcept && currentConcept._rel && currentConcept._rel.instant);
+	toggleInstantAlertsClass({instantAlertsOn, followPlusInstantAlerts });
+};
+
+const instantAlertsIconUpdate = ({ event, followPlusInstantAlerts }) => {
+	const modalConceptId = followPlusInstantAlerts.dataset.conceptId;
+
+	if (!event || !modalConceptId) {
+		return;
+	}
+
+	const currentConcept = event.detail.results
+		.find(item => item && item.subject && item.subject.properties && item.subject.properties.uuid === modalConceptId);
+
+	if (!currentConcept) {
+		return;
+	}
+
+
+	const instantAlertsOn = Boolean(currentConcept && currentConcept.rel && currentConcept.rel.properties && currentConcept.rel.properties.instant);
+	toggleInstantAlertsClass({instantAlertsOn, followPlusInstantAlerts });
+};
+
+
+
 
 const sendModalToggleEvent = ({ followPlusInstantAlerts }) => {
 	const preferenceModalToggleEvent = new CustomEvent('myft.preference-modal.show-hide.toggle', { bubbles: true });
@@ -58,6 +71,6 @@ export default () => {
 
 	followPlusInstantAlerts.addEventListener('click', () => sendModalToggleEvent({followPlusInstantAlerts}));
 
-	document.body.addEventListener('myft.user.followed.concept.load', (event) => setBellForAlertConcept({event, followPlusInstantAlerts}));
-	document.body.addEventListener('myft.user.followed.concept.update', (event) => setBellForAlertConcept({event, followPlusInstantAlerts}));
+	document.body.addEventListener('myft.user.followed.concept.load', (event) => instantAlertsIconLoad({event, followPlusInstantAlerts}));
+	document.body.addEventListener('myft.user.followed.concept.update', (event) => instantAlertsIconUpdate({event, followPlusInstantAlerts}));
 };

--- a/components/jsx/preferences-modal/index.js
+++ b/components/jsx/preferences-modal/index.js
@@ -106,7 +106,6 @@ const getAlertsPreferences = async ({ event, preferencesModal }) => {
 	const alertsEnabledText = `Your delivery channels: ${addedTextBuffer.join(', ')}.`;
 	const alertsDisabledText = 'You have previously disabled all delivery channels';
 	preferencesList.innerHTML = addedTextBuffer.length > 0 ? alertsEnabledText : alertsDisabledText;
-
 };
 
 const setCheckboxForAlertConcept = ({ event, preferencesModal }) => {
@@ -146,6 +145,10 @@ const toggleInstantAlertsPreference = async ({ event, conceptId, preferencesModa
 			message: 'Sorry, we are unable to change your instant alert preference. Please try again later or try from <a href="/myft">myFT</a>',
 			preferencesModal
 		});
+
+		instantAlertsToggle.checked = instantAlertsToggle.checked
+			? false
+			: true;
 	}
 
 	instantAlertsToggle.removeAttribute('disabled');

--- a/components/jsx/preferences-modal/index.js
+++ b/components/jsx/preferences-modal/index.js
@@ -124,6 +124,25 @@ const setCheckboxForAlertConcept = ({ event, preferencesModal }) => {
 	}
 };
 
+const toggleInstantAlertsPreference = async ({ event, conceptId }) => {
+	const instantAlertsToggle = event.target;
+
+	const data = {
+		token: csrfToken
+	};
+
+	if (instantAlertsToggle.checked) {
+		data._rel = {instant: 'true'};
+	} else {
+		data._rel = {instant: 'false'};
+	}
+
+	try {
+		await myFtClient.updateRelationship('user', null, 'followed', 'concept', conceptId, data);
+	} catch (error) {
+	}
+};
+
 export default () => {
 	/**
 	 * This feature is part of a test
@@ -139,8 +158,10 @@ export default () => {
 	}
 
 	const removeTopicButton = preferencesModal.querySelector('[data-component-id="myft-preference-modal-remove"]');
+	const instantAlertsCheckbox = preferencesModal.querySelector('[data-component-id="myft-preferences-modal-checkbox"]');
 
 	removeTopicButton.addEventListener('click', event => removeTopic({ event, conceptId, preferencesModal }));
+	instantAlertsCheckbox.addEventListener('change', event => toggleInstantAlertsPreference({ event, conceptId }));
 
 	document.addEventListener('myft.preference-modal.show-hide.toggle', event => preferenceModalShowAndHide({ event, preferencesModal }));
 

--- a/components/jsx/preferences-modal/index.js
+++ b/components/jsx/preferences-modal/index.js
@@ -127,6 +127,8 @@ const setCheckboxForAlertConcept = ({ event, preferencesModal }) => {
 const toggleInstantAlertsPreference = async ({ event, conceptId, preferencesModal }) => {
 	const instantAlertsToggle = event.target;
 
+	instantAlertsToggle.setAttribute('disabled', true);
+
 	const data = {
 		token: csrfToken
 	};
@@ -145,6 +147,8 @@ const toggleInstantAlertsPreference = async ({ event, conceptId, preferencesModa
 			preferencesModal
 		});
 	}
+
+	instantAlertsToggle.removeAttribute('disabled');
 };
 
 export default () => {

--- a/components/jsx/preferences-modal/index.js
+++ b/components/jsx/preferences-modal/index.js
@@ -124,7 +124,7 @@ const setCheckboxForAlertConcept = ({ event, preferencesModal }) => {
 	}
 };
 
-const toggleInstantAlertsPreference = async ({ event, conceptId }) => {
+const toggleInstantAlertsPreference = async ({ event, conceptId, preferencesModal }) => {
 	const instantAlertsToggle = event.target;
 
 	const data = {
@@ -140,6 +140,10 @@ const toggleInstantAlertsPreference = async ({ event, conceptId }) => {
 	try {
 		await myFtClient.updateRelationship('user', null, 'followed', 'concept', conceptId, data);
 	} catch (error) {
+		renderError({
+			message: 'Sorry, we are unable to change your instant alert preference. Please try again later or try from <a href="/myft">myFT</a>',
+			preferencesModal
+		});
 	}
 };
 
@@ -161,7 +165,7 @@ export default () => {
 	const instantAlertsCheckbox = preferencesModal.querySelector('[data-component-id="myft-preferences-modal-checkbox"]');
 
 	removeTopicButton.addEventListener('click', event => removeTopic({ event, conceptId, preferencesModal }));
-	instantAlertsCheckbox.addEventListener('change', event => toggleInstantAlertsPreference({ event, conceptId }));
+	instantAlertsCheckbox.addEventListener('change', event => toggleInstantAlertsPreference({ event, conceptId, preferencesModal }));
 
 	document.addEventListener('myft.preference-modal.show-hide.toggle', event => preferenceModalShowAndHide({ event, preferencesModal }));
 


### PR DESCRIPTION
Allow users to turn instant alerts on/off from within the preference modal component

### Whats included

1. Make the request to turn on/off instant alerts
2. Error handling for the request
3. Switching the state back when erroring
4. Switching the visual status of the alert icon in the follow button


### Jira

https://financialtimes.atlassian.net/browse/PT-236