### PR TITLE
Enforce text transform = none in preference modal

### DIFF
--- a/components/jsx/preferences-modal/main.scss
+++ b/components/jsx/preferences-modal/main.scss
@@ -11,6 +11,7 @@
 	border-radius: 10px;
 	border: 2px solid oColorsByName('black-5');
 	width: 275px;
+	text-transform: none;
 	z-index: 9999999;
 }
 


### PR DESCRIPTION
## Description

This PR is to enforce text transform: none in preferences modal so the text within is not affected by the styling from other components. (e.g. columnist topper)

## Screen Captures

Before:

<img width="350" alt="Screenshot 2023-09-14 at 16 25 05" src="https://github.com/Financial-Times/n-myft-ui/assets/28527037/03f92cd8-9f4c-4497-9a08-9e0987e5c98a">

After:

<img width="350" alt="Screenshot 2023-09-14 at 16 25 12" src="https://github.com/Financial-Times/n-myft-ui/assets/28527037/a3e4a3dc-bdb2-41ea-9cf1-df79498e2d54">

