### PR TITLE
add .npmignore to allow dist folder to be included in package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,12 @@
+*.env*
+/.sass-cache/
+/node_modules/
+/npm-debug.log*
+.DS_Store
+.editorconfig
+.eslintrc.js
+.stylelintrc
+public/
+pa11y_screenCapture/
+.idea/
+.vscode/


### PR DESCRIPTION
### Description
Continues on https://github.com/Financial-Times/n-myft-ui/pull/605
The dist file is not included in the package. Adding an npmignore to include this. 
Files included in gitignore but not npmignore will be included in the package.

https://docs.npmjs.com/cli/v8/commands/npm-publish#files-included-in-package