### PR TITLE
Handle missing preferencesModal

### DIFF
--- a/components/jsx/preferences-modal/index.js
+++ b/components/jsx/preferences-modal/index.js
@@ -162,9 +162,9 @@ export default () => {
 	 * If this was to be used in other locations it would need some additional work to avoid being singleton
 	 */
 	const preferencesModal = document.querySelector('[data-component-id="myft-preferences-modal"]');
-	const conceptId = preferencesModal.dataset.conceptId;
+	const conceptId = preferencesModal?.dataset?.conceptId;
 
-	if (!preferencesModal || !conceptId) {
+	if (!conceptId) {
 		return;
 	}
 

--- a/components/jsx/preferences-modal/index.js
+++ b/components/jsx/preferences-modal/index.js
@@ -162,7 +162,12 @@ export default () => {
 	 * If this was to be used in other locations it would need some additional work to avoid being singleton
 	 */
 	const preferencesModal = document.querySelector('[data-component-id="myft-preferences-modal"]');
-	const conceptId = preferencesModal?.dataset?.conceptId;
+
+	if (!preferencesModal) {
+		return;
+	}
+
+	const conceptId = preferencesModal.dataset.conceptId;
 
 	if (!conceptId) {
 		return;


### PR DESCRIPTION
## Description
This PR checks for the existence of `preferencesModal` in the DOM to ensure that trying to access its `conceptId` data attribute  doesn't throw

Addresses [#inc-2318](https://financialtimes.slack.com/archives/C05T4CC8MTK)