### PR TITLE
PT-286 Fix return early statements

### DIFF
--- a/components/jsx/follow-plus-instant-alerts/index.js
+++ b/components/jsx/follow-plus-instant-alerts/index.js
@@ -8,7 +8,7 @@ const toggleInstantAlertsClass = ({ instantAlertsOn,followPlusInstantAlerts }) =
 };
 
 const instantAlertsIconLoad = ({ event, followPlusInstantAlerts }) => {
-	const modalConceptId = followPlusInstantAlerts.dataset && followPlusInstantAlerts.dataset.conceptId;
+	const modalConceptId = followPlusInstantAlerts.dataset.conceptId;
 
 	if (!event || !modalConceptId) {
 		return;
@@ -27,7 +27,7 @@ const instantAlertsIconLoad = ({ event, followPlusInstantAlerts }) => {
 };
 
 const instantAlertsIconUpdate = ({ event, followPlusInstantAlerts }) => {
-	const modalConceptId = followPlusInstantAlerts.dataset && followPlusInstantAlerts.dataset.conceptId;
+	const modalConceptId = followPlusInstantAlerts.dataset.conceptId;
 
 	if (!event || !modalConceptId) {
 		return;
@@ -71,5 +71,6 @@ export default () => {
 	followPlusInstantAlerts.addEventListener('click', () => sendModalToggleEvent({followPlusInstantAlerts}));
 
 	document.body.addEventListener('myft.user.followed.concept.load', (event) => instantAlertsIconLoad({event, followPlusInstantAlerts}));
+
 	document.body.addEventListener('myft.user.followed.concept.update', (event) => instantAlertsIconUpdate({event, followPlusInstantAlerts}));
 };

--- a/components/jsx/follow-plus-instant-alerts/index.js
+++ b/components/jsx/follow-plus-instant-alerts/index.js
@@ -8,7 +8,7 @@ const toggleInstantAlertsClass = ({ instantAlertsOn,followPlusInstantAlerts }) =
 };
 
 const instantAlertsIconLoad = ({ event, followPlusInstantAlerts }) => {
-	const modalConceptId = followPlusInstantAlerts.dataset.conceptId;
+	const modalConceptId = followPlusInstantAlerts.dataset && followPlusInstantAlerts.dataset.conceptId;
 
 	if (!event || !modalConceptId) {
 		return;
@@ -27,7 +27,7 @@ const instantAlertsIconLoad = ({ event, followPlusInstantAlerts }) => {
 };
 
 const instantAlertsIconUpdate = ({ event, followPlusInstantAlerts }) => {
-	const modalConceptId = followPlusInstantAlerts.dataset.conceptId;
+	const modalConceptId = followPlusInstantAlerts.dataset && followPlusInstantAlerts.dataset.conceptId;
 
 	if (!event || !modalConceptId) {
 		return;
@@ -39,7 +39,6 @@ const instantAlertsIconUpdate = ({ event, followPlusInstantAlerts }) => {
 	if (!currentConcept) {
 		return;
 	}
-
 
 	const instantAlertsOn = Boolean(currentConcept && currentConcept.rel && currentConcept.rel.properties && currentConcept.rel.properties.instant);
 	toggleInstantAlertsClass({instantAlertsOn, followPlusInstantAlerts });

--- a/components/jsx/preferences-modal/index.js
+++ b/components/jsx/preferences-modal/index.js
@@ -162,9 +162,13 @@ export default () => {
 	 * If this was to be used in other locations it would need some additional work to avoid being singleton
 	 */
 	const preferencesModal = document.querySelector('[data-component-id="myft-preferences-modal"]');
-	const conceptId = preferencesModal.dataset.conceptId;
 
-	if (!preferencesModal || !conceptId) {
+	if (!preferencesModal) {
+		return;
+	}
+	const conceptId = preferencesModal.dataset && preferencesModal.dataset.conceptId;
+
+	if (!conceptId) {
 		return;
 	}
 

--- a/components/jsx/preferences-modal/index.js
+++ b/components/jsx/preferences-modal/index.js
@@ -166,7 +166,7 @@ export default () => {
 	if (!preferencesModal) {
 		return;
 	}
-	const conceptId = preferencesModal.dataset && preferencesModal.dataset.conceptId;
+	const conceptId = preferencesModal.dataset.conceptId;
 
 	if (!conceptId) {
 		return;
@@ -175,7 +175,12 @@ export default () => {
 	const removeTopicButton = preferencesModal.querySelector('[data-component-id="myft-preference-modal-remove"]');
 	const instantAlertsCheckbox = preferencesModal.querySelector('[data-component-id="myft-preferences-modal-checkbox"]');
 
+	if (!removeTopicButton || !instantAlertsCheckbox) {
+		return;
+	}
+
 	removeTopicButton.addEventListener('click', event => removeTopic({ event, conceptId, preferencesModal }));
+
 	instantAlertsCheckbox.addEventListener('change', event => toggleInstantAlertsPreference({ event, conceptId, preferencesModal }));
 
 	document.addEventListener('myft.preference-modal.show-hide.toggle', event => preferenceModalShowAndHide({ event, preferencesModal }));


### PR DESCRIPTION
### Description

Following up on this incident: https://financialtimes.slack.com/archives/C05T4CC8MTK
We merged this [PR](https://github.com/Financial-Times/next-article/pull/5208) which caused the following error:  Uncaught (in promise) TypeError: Cannot read properties of null (reading 'dataset')

What happened:
The clientside JS was [always running in next-article](https://github.com/Financial-Times/next-article/pull/5208/files#diff-24d413c6815f76e41fc78f7656ef33cb2d524937ec0abbb1e4a55090b258e3d2R247). This didn't require the [myFTInstantAlertsOnboarding](https://toggler.ft.com/#myFTInstantAlertsOnboarding) flag to be on. Which caused that error to trigger when the JS was ran and the preferencesModal was not rendered

[JIRA](https://financialtimes.atlassian.net/browse/PT-286)