### PR TITLE
PT-285 Render alerts preferences available before waiting for browser alerts

### DIFF
--- a/components/jsx/preferences-modal/index.js
+++ b/components/jsx/preferences-modal/index.js
@@ -74,6 +74,12 @@ const removeTopic = async ({ event, conceptId, preferencesModal }) => {
 	event.target.removeAttribute('disabled');
 };
 
+const getAlertsPreferenceText = (addedTextBuffer) => {
+	const alertsEnabledText = `Your delivery channels: ${addedTextBuffer.join(', ')}.`;
+	const alertsDisabledText = 'You have previously disabled all delivery channels';
+	return Array.isArray(addedTextBuffer) && addedTextBuffer.length > 0 ? alertsEnabledText : alertsDisabledText;
+};
+
 const getAlertsPreferences = async ({ event, preferencesModal }) => {
 	const preferencesList = preferencesModal.querySelector('[data-component-id="myft-preferences-modal-list"]');
 
@@ -91,6 +97,8 @@ const getAlertsPreferences = async ({ event, preferencesModal }) => {
 		}
 	});
 
+	preferencesList.innerHTML = getAlertsPreferenceText(addedTextBuffer);
+
 	try {
 		// We need the service worker registration to check for a subscription
 		const serviceWorkerRegistration = await navigator.serviceWorker.ready;
@@ -98,14 +106,12 @@ const getAlertsPreferences = async ({ event, preferencesModal }) => {
 		if (subscription) {
 			addedTextBuffer.push('browser');
 		}
-
 	} catch (error) {
 		// eslint-disable-next-line no-console
 		console.warn('There was an error fetching the browser notification preferences', error);
 	}
-	const alertsEnabledText = `Your delivery channels: ${addedTextBuffer.join(', ')}.`;
-	const alertsDisabledText = 'You have previously disabled all delivery channels';
-	preferencesList.innerHTML = addedTextBuffer.length > 0 ? alertsEnabledText : alertsDisabledText;
+
+	preferencesList.innerHTML = getAlertsPreferenceText(addedTextBuffer);
 };
 
 const setCheckboxForAlertConcept = ({ event, preferencesModal }) => {


### PR DESCRIPTION
### Description
See this piece of documentation: https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerContainer/ready
As you can see `.ready` for the ServiceWorkerContainer "waits indefinitely until the [ServiceWorkerRegistration](https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerRegistration) associated with the current page has an [active](https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerRegistration/active) worker"

This meant that when no active worker was found, nothing was being rendered in the preferences modal to show the user's alert preferences.

[JIRA](https://financialtimes.atlassian.net/browse/PT-285)

Before:
![Screenshot 2023-09-18 at 13 09 50](https://github.com/Financial-Times/n-myft-ui/assets/10453619/e5bbb010-0df3-4cd0-9417-f412771ef3ae)

After:
![Screenshot 2023-09-18 at 10 17 44](https://github.com/Financial-Times/n-myft-ui/assets/10453619/065c5b6d-71f2-4aba-8da0-0e8ea9f45095)
