### PR TITLE
PT-292 Hide modal when document is clicked (and it's not the preferences modal)

### DIFF
--- a/components/jsx/follow-plus-instant-alerts/index.js
+++ b/components/jsx/follow-plus-instant-alerts/index.js
@@ -61,14 +61,18 @@ const instantAlertsIconOff = ({ event, followPlusInstantAlerts }) => {
 	});
 };
 
-
 const sendModalToggleEvent = ({ followPlusInstantAlerts }) => {
 	const preferenceModalToggleEvent = new CustomEvent('myft.preference-modal.show-hide.toggle', { bubbles: true });
 	followPlusInstantAlerts.dispatchEvent(preferenceModalToggleEvent);
 	followPlusInstantAlerts.classList.toggle('n-myft-follow-button--instant-alerts--open');
-
 };
 
+const sendModalHideEvent = ({ event, followPlusInstantAlerts }) => {
+	if (event.target !== followPlusInstantAlerts) {
+		const preferenceModalHideEvent = new CustomEvent('myft.preference-modal.hide', { detail: {targetElement: event.target}, bubbles: true });
+		followPlusInstantAlerts.dispatchEvent(preferenceModalHideEvent);
+	}
+};
 
 export default () => {
 	/**
@@ -88,5 +92,8 @@ export default () => {
 	document.body.addEventListener('myft.user.followed.concept.load', (event) => instantAlertsIconLoad({event, followPlusInstantAlerts}));
 
 	document.body.addEventListener('myft.user.followed.concept.update', (event) => instantAlertsIconUpdate({event, followPlusInstantAlerts}));
+
 	document.body.addEventListener('myft.user.followed.concept.remove', (event) => instantAlertsIconOff({ event, followPlusInstantAlerts }));
+
+	document.addEventListener('click', (event) => sendModalHideEvent({event, followPlusInstantAlerts}));
 };

--- a/components/jsx/preferences-modal/index.js
+++ b/components/jsx/preferences-modal/index.js
@@ -75,6 +75,12 @@ const tracking = (conceptId) => {
 	document.body.dispatchEvent(trackingEvent);
 };
 
+const preferenceModalHide = ({ event, preferencesModal }) => {
+	if (!preferencesModal.contains(event.detail.targetElement)) {
+		preferencesModal.classList.remove('n-myft-ui__preferences-modal--show');
+	}
+};
+
 const preferenceModalShowAndHide = ({ event, preferencesModal, conceptId }) => {
 	preferencesModal.classList.toggle('n-myft-ui__preferences-modal--show');
 
@@ -244,6 +250,8 @@ export default () => {
 	instantAlertsCheckbox.addEventListener('change', event => toggleInstantAlertsPreference({ event, conceptId, preferencesModal }));
 
 	document.addEventListener('myft.preference-modal.show-hide.toggle', event => preferenceModalShowAndHide({ event, preferencesModal, conceptId }));
+
+	document.addEventListener('myft.preference-modal.hide', event => preferenceModalHide({ event, preferencesModal }));
 
 	document.addEventListener('myft.user.preferred.preference.load', (event) => getAlertsPreferences({ event, preferencesModal }));
 


### PR DESCRIPTION
### Description
Up until now, the only to close the preference modal was to click on the addToMyFT button. This PR makes changes so that the modal is also closed when the user clicks elsewhere on the screen (but not on the preference modal itself)

[JIRA](https://financialtimes.atlassian.net/jira/software/c/projects/PT/boards/1655?modal=detail&selectedIssue=PT-292)

before:
https://github.com/Financial-Times/n-myft-ui/assets/10453619/a84209f1-b111-49aa-8499-d26be4da1219

after:
https://github.com/Financial-Times/n-myft-ui/assets/10453619/0d7b5a15-b85e-4cc5-8046-7b6736bb1010

