### PR TITLE
Add alias to the dist folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "commit": "commit-wizard",
     "prepare": "npx snyk protect || npx snyk protect -d || true"
   },
+  "exports": {
+    "./jsx-components/*": "./dist/*"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Financial-Times/n-myft-ui.git"


### PR DESCRIPTION
## Description

This PR is to add an export path alias pointing `/dist` to `/jsx-components`, so the consuming apps can have a more descriptive path when importing the transpiled jsx component from n-myft-ui.