### PR TITLE
Instant alert error message styling

### DIFF
--- a/components/jsx/preferences-modal/index.js
+++ b/components/jsx/preferences-modal/index.js
@@ -9,6 +9,13 @@ const renderError = ({ message, preferencesModal }) => {
 	errorElement.innerHTML = message;
 };
 
+const removeError = ({ preferencesModal }) => {
+	renderError({
+		message: "",
+		preferencesModal,
+	});
+}
+
 /**
  * This preference modal is part of a test
  * Therefore we have built the positioning function to work within the known parameters of that test
@@ -78,6 +85,7 @@ const tracking = (conceptId) => {
 const preferenceModalHide = ({ event, preferencesModal }) => {
 	if (!preferencesModal.contains(event.detail.targetElement)) {
 		preferencesModal.classList.remove('n-myft-ui__preferences-modal--show');
+		removeError({ preferencesModal });
 	}
 };
 
@@ -91,23 +99,25 @@ const preferenceModalShowAndHide = ({ event, preferencesModal, conceptId }) => {
 
 	} else {
 		// Remove existing errors when hiding the modal
-		renderError({
-			message: '',
-			preferencesModal,
-		});
+		removeError({ preferencesModal });
 	}
 };
 
 const removeTopic = async ({ event, conceptId, preferencesModal }) => {
 	event.target.setAttribute('disabled', true);
 
+	// remove error message before attempt to remove topic
+	removeError({ preferencesModal });
+
 	try {
 		await myFtClient.remove('user', null, 'followed', 'concept', conceptId, { token: csrfToken });
 		preferenceModalShowAndHide({ preferencesModal });
 	} catch (error) {
-		renderError({ message: 'Sorry, we are unable to remove this topic. Please try again later or try from <a href="/myft">myFT</a>', preferencesModal });
+		renderError({
+			message: 'Sorry, we are unable to remove this topic. Please try again later or try from <a href="/myft">myFT</a>',
+			preferencesModal,
+		});
 	}
-
 	event.target.removeAttribute('disabled');
 };
 
@@ -175,6 +185,9 @@ const toggleInstantAlertsPreference = async ({ event, conceptId, preferencesModa
 
 	instantAlertsCheckbox.setAttribute('disabled', true);
 
+	// remove error message before attempt to toggle instant alert
+	removeError({ preferencesModal });
+
 	const data = {
 		token: csrfToken
 	};
@@ -194,7 +207,7 @@ const toggleInstantAlertsPreference = async ({ event, conceptId, preferencesModa
 	} catch (error) {
 		renderError({
 			message: 'Sorry, we are unable to change your instant alert preference. Please try again later or try from <a href="/myft">myFT</a>',
-			preferencesModal
+			preferencesModal,
 		});
 
 		instantAlertsCheckbox.checked = instantAlertsCheckbox.checked

--- a/components/jsx/preferences-modal/main.scss
+++ b/components/jsx/preferences-modal/main.scss
@@ -47,14 +47,39 @@
 	color: oColorsByName('claret-60');
 }
 
+.n-myft-ui__preferences-modal__remove-button:disabled {
+	opacity: 0.5;
+}
+
 .n-myft-ui__preferences-modal--show {
 	display: block;
 	visibility: visible;
 }
 
+// reference to the color/BG color of the error message
+// components/o-message/src/scss/_brand.scss#L21 in origami
 .n-myft-ui__preferences-modal-error {
 	display: block;
 	@include oTypographySans($scale: -1, $weight: 'regular', $style: 'normal');
-	color: oColorsByName('claret');
-	text-align: center;
+	color: oColorsMix('black', 'crimson', $percentage: 12.5);
+	background-color: oColorsMix('crimson', $percentage: 10);
+	text-align: left;
+	padding: 8px 12px;
+	margin-top: 16px;
+
+	// use opacity to enforce CSS transition
+	opacity: 1;
+	transition: opacity 0.5s;
+
+	a {
+		@include oTypographySans($scale: -1, $weight: 'semibold', $style: 'normal');
+		color: oColorsMix('black', 'crimson', $percentage: 12.5);
+		text-decoration-color: oColorsMix('black', 'crimson', $percentage: 12.5);
+	}
+}
+
+.n-myft-ui__preferences-modal-error:empty {
+	opacity: 0;
+	padding: 0;
+	margin-top: 0;
 }


### PR DESCRIPTION
## Description

This PR is to add styling to the error message box within the preference modal of the instant alert. It adds the following styling changes:

- Error message box
  - top margin: 16px
  - padding: 8px for top/bottom, 12px for left/right
  - text color: #b30000 (color from oMessage)
  - background color: #fad9ce (color from oMessage)
  - text align: left

- Remove from myFT button when disabled:
  - opacity: 0.5

In addition, when the text inside the error message box changes, there is a CSS transition to emphasise the change.

## Screen capture

https://github.com/Financial-Times/n-myft-ui/assets/28527037/ad575f55-c050-44bc-84cb-d9b33b6a49f1

## Ticket:

[JIRA](https://financialtimes.atlassian.net/browse/ACC-2587)
