### PR TITLE
Support n-ui-foundations v10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -105,7 +105,7 @@
         "@financial-times/o-overlay": "^4.0.0",
         "@financial-times/o-spacing": "^3.0.0",
         "@financial-times/o-tooltip": "^5.2.4",
-        "n-ui-foundations": "^9.0.0",
+        "n-ui-foundations": "^9.0.0 || ^10.0.0",
         "react": "^17.0.2"
       }
     },

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "@financial-times/o-overlay": "^4.0.0",
     "@financial-times/o-spacing": "^3.0.0",
     "@financial-times/o-tooltip": "^5.2.4",
-    "n-ui-foundations": "^9.0.0",
+    "n-ui-foundations": "^9.0.0 || ^10.0.0",
     "react": "^17.0.2"
   },
   "dependencies": {


### PR DESCRIPTION
A small PR to update to n-ui-foundations-v10.

This allows this module to be used with either v9 or v10 of this library.