### PR TITLE
Upgrade next-myft-client from v10 to v12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "form-serialize": "^0.7.2",
         "ftdomdelegate": "^4.0.6",
         "js-cookie": "^2.2.1",
-        "next-myft-client": "^10.3.0",
+        "next-myft-client": "^12.0.1",
         "next-session-client": "^4.0.0",
         "ready-state": "^2.0.5",
         "superstore-sync": "^2.1.1"
@@ -16538,18 +16538,17 @@
       }
     },
     "node_modules/next-myft-client": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/next-myft-client/-/next-myft-client-10.5.0.tgz",
-      "integrity": "sha512-IQqMJpc3wSzdkk2YOqPl6sJApcWzmOWBliNMZJLcSzgSqKEKVt0YCuQrpuRqKFGkqpduvZ47BL1g7lwXlUjD6g==",
-      "hasInstallScript": true,
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/next-myft-client/-/next-myft-client-12.1.0.tgz",
+      "integrity": "sha512-JDnM23YJa3VrVREmnxxMQM01zaTazP+YQl0zFk+Q5rD3VnRpph7hhi/RSQZk7j7MzVvCFBWmQ4pBOMWNM7BfwA==",
       "dependencies": {
         "black-hole-stream": "0.0.1",
         "fetchres": "^1.7.2",
         "next-session-client": "^4.0.0"
       },
       "engines": {
-        "node": "14.x || 16.x",
-        "npm": "7.x || 8.x"
+        "node": "16.x || 18.x",
+        "npm": "7.x || 8.x || 9.x"
       }
     },
     "node_modules/next-session-client": {

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "form-serialize": "^0.7.2",
     "ftdomdelegate": "^4.0.6",
     "js-cookie": "^2.2.1",
-    "next-myft-client": "^10.3.0",
+    "next-myft-client": "^12.0.1",
     "next-session-client": "^4.0.0",
     "ready-state": "^2.0.5",
     "superstore-sync": "^2.1.1"


### PR DESCRIPTION
This is causing problems with saved articles in production because FT Core are switching off the insecure sessions.

This will need bumping and then upgrading in next-myft-page I guess?

https://github.com/Financial-Times/next-myft-client/pull/201