### PR TITLE
UG-1414: Remove notification for users referred from podcast links

### DIFF
--- a/myft/ui/myft-buttons/init.js
+++ b/myft/ui/myft-buttons/init.js
@@ -26,19 +26,13 @@ function getInteractionHandler (relationshipName) {
 	};
 }
 
-function anonEventListeners (flags = {}) {
+function anonEventListeners () {
 	const currentPath = window.location.pathname;
 	const subscribeUrl = '/products?segID=400863&segmentID=190b4443-dc03-bd53-e79b-b4b6fbd04e64';
 	const signInLink = `/login${currentPath.length ? `?location=${currentPath}` : ''}`;
 	const messages = {
 		followed: `Please <a href="${subscribeUrl}" class="myft-ui-subscribe" data-trackable="Subscribe">subscribe</a> or <a href="${signInLink}" data-trackable="Sign In">sign in</a> to add this topic to myFT.`,
 		saved: `Please <a href="${subscribeUrl}" class="myft-ui-subscribe" data-trackable="Subscribe">subscribe</a> or <a href="${signInLink}" data-trackable="Sign In">sign in</a> to save this article.`
-	};
-
-	// 11/5/23 - US Growth test for Free Article Demand, see https://financialtimes.atlassian.net/browse/UG-1191
-	// This will be cleaned up after the test as part of https://financialtimes.atlassian.net/browse/UG-1221
-	if (flags.get && flags.get('podcastReferral')) {
-		messages.saved = `<a href="/register/access?multistepRegForm=multistep?segmentID=ce23dd51-4421-32fc-23df-30099f38f1a4" data-trackable="Register">Register</a> for free or  <a href="${signInLink}" data-trackable="Sign In">sign in</a> to save this article`;
 	};
 
 	['followed', 'saved'].forEach(action => {
@@ -105,7 +99,7 @@ export default function (opts) {
 		enhanceActionUrls();
 
 		if (opts && opts.anonymous) {
-			anonEventListeners(opts.flags);
+			anonEventListeners();
 		} else {
 			signedInEventListeners();
 			personaliseLinks();

--- a/secrets.js
+++ b/secrets.js
@@ -4,7 +4,6 @@ module.exports = {
 		'38d9c080-3301-11ea-9616-d1b31132c269', // components/unread-articles-indicator/README.md:3
 		'11df4800-391a-11ea-973b-4a52933561ab', // components/unread-articles-indicator/README.md:67
 		'190b4443-dc03-bd53-e79b-b4b6fbd04e64', // segment ID for subscribe URL
-		'ce23dd51-4421-32fc-23df-30099f38f1a4', // segment ID for USG test https://financialtimes.atlassian.net/browse/UG-1191
 		'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx', // regex for uuid generator
 		'a5676e20-5c92-47f3-a76c-11f9761121f5', // test/navigationAlphaTest.spec.js
 		'72de123e-5082-11ee-be56-0242ac120002' // components/jsx/preferences-modal/index.js


### PR DESCRIPTION
Removes the notification shown to anonymous users when they try to save an article. Users will be shown the standard "subscribe or login" message instead.

## How to test
1. Checkout this PR
2. Run `npm install link`
3. Clone `next-article` and run `npm install` if you don't already have the project installed
4. In the `next-article` directory, run `npm link @financial-times/n-myft-ui`, then `npm start`
5. In an incognito/private window, turn the [podcastReferral](https://toggler.ft.com/#podcastReferral) flag on and navigate to https://local.ft.com:5050/content/ce0fa1d4-9883-4252-a79e-96548c3cecef
6. Click the save button in the social button group, and ensure the message says "Please subscribe or sign in to save this article"