### PR TITLE
Remove browser alert preference

### DIFF
--- a/components/jsx/preferences-modal/index.js
+++ b/components/jsx/preferences-modal/index.js
@@ -144,20 +144,6 @@ const getAlertsPreferences = async ({ event, preferencesModal }) => {
 	});
 
 	preferencesList.innerHTML = getAlertsPreferenceText(addedTextBuffer);
-
-	try {
-		// We need the service worker registration to check for a subscription
-		const serviceWorkerRegistration = await navigator.serviceWorker.ready;
-		const subscription = await serviceWorkerRegistration.pushManager.getSubscription();
-		if (subscription) {
-			addedTextBuffer.push('browser');
-		}
-	} catch (error) {
-		// eslint-disable-next-line no-console
-		console.warn('There was an error fetching the browser notification preferences', error);
-	}
-
-	preferencesList.innerHTML = getAlertsPreferenceText(addedTextBuffer);
 };
 
 const setCheckboxForAlertConcept = ({ event, preferencesModal }) => {


### PR DESCRIPTION
This PR is a part of [decommission myFT desktop push notifications and n-service-worker](https://financialtimes.atlassian.net/browse/CON-3128)

We have removed the browser push notification from myft page ([The PR](https://github.com/Financial-Times/next-myft-page/pull/2731)) and have decommissioned n-service-worker. Therefore this preference is not available for users anymore.

[[The PR for adding this browser alert preference](https://github.com/Financial-Times/n-myft-ui/pull/599)]