### PR TITLE
CON-3316: change icon for disabled notification alerts

### DIFF
--- a/components/instant-alert/main.scss
+++ b/components/instant-alert/main.scss
@@ -27,7 +27,7 @@
 		color: oColorsByName('black-80');
 	}
 	&::before {
-		@include oIconsContent('notifications', oColorsByName('black-60'), $icon-width, $iconset-version: 1);
+		@include oIconsContent('mute-notifications', oColorsByName('black-60'), $icon-width, $iconset-version: 1);
 		left: auto;
 		right: 1px;
 		margin-top: -18px;


### PR DESCRIPTION
As recomendation for DAC:
The bells indicating the alert status for the topics, must use additional indicators to convey which ones are currently set to on and off. Consider using a strikethrough the icon.

![image](https://github.com/Financial-Times/n-myft-ui/assets/98393608/ca8891c9-83b4-40ee-8455-1d9f27e4bc3a)

Ticket:
https://financialtimes.atlassian.net/browse/CON-3316

ScreenShots of demo:
Before:

<img width="181" alt="Captura de pantalla 2024-04-26 a las 12 17 11" src="https://github.com/Financial-Times/n-myft-ui/assets/98393608/9e2edc79-3725-4070-9bbb-4d7857be8d62">

After:

<img width="137" alt="Captura de pantalla 2024-04-26 a las 12 16 41" src="https://github.com/Financial-Times/n-myft-ui/assets/98393608/1e01f20e-eb2b-45c3-ac4f-17f530848907">
