### PR TITLE
CON-3317: fix aria label for alert icons

### DIFF
--- a/components/instant-alert/index.js
+++ b/components/instant-alert/index.js
@@ -27,7 +27,14 @@ function toggleButton (buttonEl, state) {
 
 	if (state !== isPressed) {
 		nextButtons.toggleState(buttonEl);
+		const name = buttonEl.getAttribute('data-name');
+		if (isPressed) {
+			buttonEl.setAttribute('aria-label', 'Instant alerts disabled for ' + name);
+		} else {
+			buttonEl.setAttribute('aria-label', 'Instant alerts enabled for ' + name);
+		}
 	}
+
 	buttonEl.removeAttribute('disabled');
 	buttonEl.setAttribute('value', !state);
 }

--- a/components/instant-alert/instant-alert.html
+++ b/components/instant-alert/instant-alert.html
@@ -13,10 +13,11 @@
 	<input type="hidden" value="http://www.ft.com/ontology/concept/Concept" name="directType">
 	{{/if}}
 	<button
-			aria-label="Get instant alerts for {{name}}"
 			{{#ifAll hasInstantAlert @root.cacheablePersonalisedUrl}}
+			aria-label="Instant alerts enabled for {{name}}"
 			aria-pressed="true"
 			{{else}}
+			aria-label="Instant alerts disabled for {{name}}"
 			aria-pressed="false"
 			{{/ifAll}}
 	class="n-myft-ui__button
@@ -24,7 +25,7 @@
 	{{#size}} n-myft-ui__button--{{this}}{{/size}}
 	n-myft-ui__button--instant
 	n-myft-ui__button--instant-light"
-	data-alternate-label="Stop instant alerts for {{name}}"
+	data-name="{{name}}"
 	{{#if alternateText}}
 	data-alternate-text="{{alternateText}}"
 	{{else}}


### PR DESCRIPTION
Issue: The state of the alert components was not clear for users of screen reading assistive
technologies
![image](https://github.com/Financial-Times/n-myft-ui/assets/98393608/67b21283-d10a-4aab-ac1f-3bc377eb50b9)

Solution:
change the aria-label text to fit with the current status of the instant alert of the topic